### PR TITLE
Add optional CORS support to Autopush

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -43,19 +43,11 @@ class EndpointHandler(cyclone.web.RequestHandler):
         self.version = version
         self.data = data
 
-    @cyclone.web.asynchronous
     def options(self, token):
         self._addCors()
-        self.set_status(200)
-        self.write("")
-        self.finish()
 
-    @cyclone.web.asynchronous
     def head(self, token):
         self._addCors()
-        self.set_status(200)
-        self.write("")
-        self.finish()
 
     @cyclone.web.asynchronous
     def put(self, token):
@@ -223,11 +215,8 @@ class EndpointHandler(cyclone.web.RequestHandler):
 
     def write_error(self, code, exception=None):
         """ Write the error (otherwise unhandled exception when dealing with
-        unknown protocol specifications.) """
-        reason = "No reason"
-        if exception is not None and exception.reason is not None:
-            reason = exception.reason
-        error = "%d: %s" % (code, reason)
+        unknown method specifications.) """
         self.set_status(code)
-        log.err("Endpoint write_error: %s" % error)
+        if exception is not None:
+            log.err(exception)
         self.finish()

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -174,7 +174,7 @@ def endpoint_main(sysargs=None):
 
     # Endpoint HTTP router
     endpoint = EndpointHandler
-    endpoint.settings = settings
+    endpoint.ap_settings = settings
     site = cyclone.web.Application([
         (r"/push/([^\/]+)", endpoint)
     ], default_host=settings.hostname, debug=args.debug

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -64,7 +64,9 @@ def _parse_endpoint(sysargs=None):
     parser = configargparse.ArgumentParser(description='Runs an Endpoint Node.')
     parser.add_argument('-p', '--port', help='Public HTTP Endpoint Port',
                         type=int, default=8082, env_var="PORT")
-
+    parser.add_argument('--cors', help='Allow CORS PUTs for update.',
+                        action='store_true', default=False,
+                        env_var='ALLOW_CORS')
     add_shared_args(parser)
     args = parser.parse_args(sysargs)
     return args, parser
@@ -76,6 +78,7 @@ def make_settings(args, **kwargs):
         hostname=args.hostname,
         statsd_host=args.statsd_host,
         statsd_port=args.statsd_port,
+        enable_cors=args.cors,
         **kwargs
     )
 

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -1,4 +1,5 @@
 """autopush daemon script"""
+import os
 import sys
 
 import configargparse
@@ -86,7 +87,6 @@ def make_settings(args, **kwargs):
         hostname=args.hostname,
         statsd_host=args.statsd_host,
         statsd_port=args.statsd_port,
-        enable_cors=args.cors,
         **kwargs
     )
 
@@ -166,7 +166,7 @@ def connection_main(sysargs=None):
 
 def endpoint_main(sysargs=None):
     args, parser = _parse_endpoint(sysargs)
-    settings = make_settings(args)
+    settings = make_settings(args, enable_cors=args.cors)
 
     log.startLogging(sys.stdout)
 

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -75,7 +75,7 @@ class AutopushSettings(object):
         self.storage = Storage(self.storage_table)
         self.router = Router(self.router_table)
 
-        #CORS
+        # CORS
         self.cors = enable_cors
 
     def update(self, **kwargs):

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -89,5 +89,4 @@ class AutopushSettings(object):
         """ cyclone/web.py is calling self.settings.get("debug") where
         self == EndpointHandler. this is causing an unhandled exception.
         """
-        import pdb; pdb.set_trace()
         return self.__dict__[key]

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -26,7 +26,8 @@ class AutopushSettings(object):
                  endpoint_hostname=None,
                  endpoint_port=None,
                  statsd_host="localhost",
-                 statsd_port=8125):
+                 statsd_port=8125,
+                 enable_cors=False):
 
         # Setup the requests lib session
         sess = requests.Session()
@@ -74,9 +75,19 @@ class AutopushSettings(object):
         self.storage = Storage(self.storage_table)
         self.router = Router(self.router_table)
 
+        #CORS
+        self.cors = enable_cors
+
     def update(self, **kwargs):
         for key, val in kwargs.items():
             if key == "crypto_key":
                 self.fernet = Fernet(val)
             else:
                 setattr(self, key, val)
+
+    def get(self, key):
+        """ cyclone/web.py is calling self.settings.get("debug") where
+        self == EndpointHandler. this is causing an unhandled exception.
+        """
+        import pdb; pdb.set_trace()
+        return self.__dict__[key]

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -84,9 +84,3 @@ class AutopushSettings(object):
                 self.fernet = Fernet(val)
             else:
                 setattr(self, key, val)
-
-    def get(self, key):
-        """ cyclone/web.py is calling self.settings.get("debug") where
-        self == EndpointHandler. this is causing an unhandled exception.
-        """
-        return self.__dict__[key]

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -38,7 +38,7 @@ def patch_logger(test):
 
 class EndpointTestCase(unittest.TestCase):
     def initialize(self):
-        self.metrics = self.settings.metrics
+        self.metrics = self.ap_settings.metrics
 
     def setUp(self):
         self.timeout = 0.5
@@ -47,7 +47,7 @@ class EndpointTestCase(unittest.TestCase):
         self.mock_dynamodb2.start()
         twisted.internet.base.DelayedCall.debug = True
 
-        settings = endpoint.EndpointHandler.settings = AutopushSettings(
+        settings = endpoint.EndpointHandler.ap_settings = AutopushSettings(
             hostname="localhost",
             statsd_host=None,
         )
@@ -126,7 +126,7 @@ class EndpointTestCase(unittest.TestCase):
         eq_(self.endpoint.data, 'bai')
 
     def test_put_data_too_large(self):
-        self.endpoint.settings.max_data = 3
+        self.endpoint.ap_settings.max_data = 3
         self.endpoint.request.body = b'version=1&data=1234'
 
         def handle_finish(result):
@@ -458,26 +458,26 @@ class EndpointTestCase(unittest.TestCase):
     def test_cors(self):
         acrm = "Access-Control-Request-Method"
         endpoint = self.endpoint
-        endpoint.settings.cors = False
+        endpoint.ap_settings.cors = False
         endpoint._addCors()
         assert endpoint._headers.get(acrm) != "*"
 
         endpoint.clear_header(acrm)
-        endpoint.settings.cors = True
+        endpoint.ap_settings.cors = True
         endpoint._addCors()
         eq_(endpoint._headers[acrm], "*")
 
     def test_cors_head(self):
         acrm = "Access-Control-Request-Method"
         endpoint = self.endpoint
-        endpoint.settings.cors = True
+        endpoint.ap_settings.cors = True
         endpoint.head(None)
         eq_(endpoint._headers[acrm], "*")
 
     def test_cors_options(self):
         acrm = "Access-Control-Request-Method"
         endpoint = self.endpoint
-        endpoint.settings.cors = True
+        endpoint.ap_settings.cors = True
         endpoint.options(None)
         eq_(endpoint._headers[acrm], "*")
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -481,6 +481,19 @@ class EndpointTestCase(unittest.TestCase):
         endpoint.options(None)
         eq_(endpoint._headers[acrm], "*")
 
+    @patch_logger
+    def test_write_error(self, log_mock):
+        """ Write error is triggered by sending the app a request
+        with an invalid method (e.g. "put" instead of "PUT").
+        This is not code that is triggered within normal flow, but
+        by the cyclone wrapper. """
+        class testX(Exception):
+            pass
+
+        self.endpoint.write_error(999, testX)
+        self.status_mock.assert_called_with(999)
+        self.assertTrue(log_mock.err.called)
+
     def _assert_jumped_client(self):
         def handle_finish(result):
             self.requests_mock.put.assert_called_with(

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -60,7 +60,7 @@ class ConnectionMainTestCase(unittest.TestCase):
             mock.stop()
 
     def test_basic(self):
-            connection_main([])
+        connection_main([])
 
 
 class EndpointMainTestCase(unittest.TestCase):
@@ -81,4 +81,4 @@ class EndpointMainTestCase(unittest.TestCase):
             mock.stop()
 
     def test_basic(self):
-            endpoint_main([])
+        endpoint_main([])


### PR DESCRIPTION
This is a late fix request from releng. CORS support is only required for DEV and STAGE environments (thus why it defaults to "off")

Operations:
Note that CORS is only enabled if you run `autoendpoint --cors` or with environment `ALLOW_CORS`