### PR TITLE
Note required PyPy version; add OS X instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python site-packages
 all:	build
 
 $(BIN)/pip: $(BIN)/pypy
-	wget https://bootstrap.pypa.io/get-pip.py
+	curl -O https://bootstrap.pypa.io/get-pip.py
 	$(PYTHON) get-pip.py
 	rm get-pip.py
 

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,26 @@ You will first need to get pypy as appropriate for your system and put it's
 uncompressed folder in the autopush directory as ``pypy``.
 
 PyPy downloads can be found here: http://pypy.org/download.html#default-with-a-jit-compiler
+autopush requires PyPy >= 2.5.1.
 
 Once you have downloaded, decompressed, and renamed this to ``pypy``, you can
 run the Makefile with ``make``, which will setup the application.
+
+OS X
+~~~~
+
+autopush depends on the Python `cryptography <https://cryptography.io/en/latest/installation>`_
+library, which requires OpenSSL. If you're installing autopush on OS X
+with a custom version of OpenSSL, you'll need to set the ``ARCHFLAGS``
+environment variable, and add your OpenSSL library path to ``LDFLAGS`` and
+``CFLAGS`` before running ``make``:
+
+.. code-block:: bash
+
+    export ARCHFLAGS="-arch x86_64"
+    # Homebrew installs OpenSSL to `/usr/local/opt/openssl` instead of
+    # `/usr/local`.
+    export LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include"
 
 Running
 =======


### PR DESCRIPTION
Mostly for selfish reasons, since @jrconlin and @bbangert both use Linux...

* `cffi@0.9.2` requires PyPy >= 2.5.1.
* OS X doesn't ship with `wget` by default, but `curl -O` is equivalent for our purposes. :crying_cat_face:
* `ARCHFLAGS`, `LDFLAGS`, and `CFLAGS` should be set, to avoid linking against the ancient system-bundled OpenSSL.