### PR TITLE
Datadog features

### DIFF
--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -27,22 +27,30 @@ class TwistedMetrics(object):
 
 
 class DatadogMetrics(object):
-    def __init__(self, api_key, app_key, flush_interval=10):
+    def __init__(self, api_key, app_key, flush_interval=10,
+                 namespace="autopush"):
+
         datadog.initialize(api_key=api_key, app_key=app_key)
         self._client = ThreadStats()
         self._flush_interval = flush_interval
-
         self._host = get_hostname()
+        self._namespace = namespace
+
+    def _prefix_name(self, name):
+        return "%s.%s" % (self._namespace, name)
 
     def start(self):
         self._client.start(flush_interval=self._flush_interval,
                            roll_up_interval=self._flush_interval)
 
     def increment(self, name, count=1, **kwargs):
-        self._client.increment(name, count, host=self._host, **kwargs)
+        self._client.increment(self._prefix_name(name), count, host=self._host,
+                               **kwargs)
 
     def gauge(self, name, count, **kwargs):
-        self._client.gauge(name, count, host=self._host, **kwargs)
+        self._client.gauge(self._prefix_name(name), count, host=self._host,
+                           **kwargs)
 
     def timing(self, name, duration, **kwargs):
-        self._client.timing(name, value=duration, host=self._host, **kwargs)
+        self._client.timing(self._prefix_name(name), value=duration,
+                            host=self._host, **kwargs)

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -4,6 +4,7 @@ from txstatsd.metrics.metrics import Metrics
 
 import datadog
 from datadog import ThreadStats
+from datadog.util.hostname import get_hostname
 
 
 class TwistedMetrics(object):
@@ -31,15 +32,17 @@ class DatadogMetrics(object):
         self._client = ThreadStats()
         self._flush_interval = flush_interval
 
+        self._host = get_hostname()
+
     def start(self):
         self._client.start(flush_interval=self._flush_interval,
                            roll_up_interval=self._flush_interval)
 
     def increment(self, name, count=1, **kwargs):
-        self._client.increment(name, count, **kwargs)
+        self._client.increment(name, count, host=self._host, **kwargs)
 
     def gauge(self, name, count, **kwargs):
-        self._client.gauge(name, count, **kwargs)
+        self._client.gauge(name, count, host=self._host, **kwargs)
 
     def timing(self, name, duration, **kwargs):
-        self._client.timing(name, value=duration, **kwargs)
+        self._client.timing(name, value=duration, host=self._host, **kwargs)

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -27,15 +27,15 @@ class TwistedMetricsTestCase(unittest.TestCase):
 class DatadogMetricsTestCase(unittest.TestCase):
     @patch("autopush.metrics.datadog")
     def test_basic(self, mock_dog):
-        m = DatadogMetrics("someapikey", "someappkey")
+        m = DatadogMetrics("someapikey", "someappkey", namespace="testpush")
         ok_(len(mock_dog.mock_calls) > 0)
         m._client = Mock()
         m.start()
         m._client.start.assert_called_with(flush_interval=10,
                                            roll_up_interval=10)
         m.increment("test", 5)
-        m._client.increment.assert_called_with("test", 5)
+        m._client.increment.assert_called_with("testpush.test", 5)
         m.gauge("connection_count", 200)
-        m._client.gauge.assert_called_with("connection_count", 200)
+        m._client.gauge.assert_called_with("testpush.connection_count", 200)
         m.timing("lifespan", 113)
-        m._client.timing.assert_called_with("lifespan", value=113)
+        m._client.timing.assert_called_with("testpush.lifespan", value=113)

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -5,6 +5,8 @@ import twisted.internet.base
 from nose.tools import ok_
 from mock import Mock, patch
 
+from datadog.util.hostname import get_hostname
+
 from autopush.metrics import DatadogMetrics, TwistedMetrics
 
 
@@ -27,6 +29,8 @@ class TwistedMetricsTestCase(unittest.TestCase):
 class DatadogMetricsTestCase(unittest.TestCase):
     @patch("autopush.metrics.datadog")
     def test_basic(self, mock_dog):
+        hostname = get_hostname()
+
         m = DatadogMetrics("someapikey", "someappkey", namespace="testpush")
         ok_(len(mock_dog.mock_calls) > 0)
         m._client = Mock()
@@ -34,8 +38,11 @@ class DatadogMetricsTestCase(unittest.TestCase):
         m._client.start.assert_called_with(flush_interval=10,
                                            roll_up_interval=10)
         m.increment("test", 5)
-        m._client.increment.assert_called_with("testpush.test", 5)
+        m._client.increment.assert_called_with("testpush.test", 5,
+                                               host=hostname)
         m.gauge("connection_count", 200)
-        m._client.gauge.assert_called_with("testpush.connection_count", 200)
+        m._client.gauge.assert_called_with("testpush.connection_count", 200,
+                                           host=hostname)
         m.timing("lifespan", 113)
-        m._client.timing.assert_called_with("testpush.lifespan", value=113)
+        m._client.timing.assert_called_with("testpush.lifespan", value=113,
+                                            host=hostname)


### PR DESCRIPTION
Adding the `host` argument to each metric allows it to aggregate the metric with everything else it knows about that host.