### PR TITLE
Add unified and Moto server binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
+.tox
 .DS_Store
 .svn
 *.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ lib-python/*
 bin/*
 include/*
 lib_pypy/*
+pypy

--- a/Dockerfile.automock
+++ b/Dockerfile.automock
@@ -38,4 +38,6 @@ EXPOSE 8080
 # HTTP update port.
 EXPOSE 8082
 
+ENV RESOLVE_HOSTNAMES 1
+
 CMD ["./automock/automock"]

--- a/Dockerfile.automock
+++ b/Dockerfile.automock
@@ -38,6 +38,4 @@ EXPOSE 8080
 # HTTP update port.
 EXPOSE 8082
 
-ENV RESOLVE_HOSTNAMES 1
-
-CMD ["./automock/automock"]
+CMD ["./automock/automock.sh"]

--- a/Dockerfile.automock
+++ b/Dockerfile.automock
@@ -1,0 +1,41 @@
+# This Dockerfile runs the AutoPush connection and endpoint nodes in the same
+# container, using Moto to simulate DynamoDB calls.
+
+FROM stackbrew/debian:wheezy
+
+MAINTAINER Ben Bangert <bbangert@mozilla.com>
+
+# It's nice to have some newer packages
+RUN echo "deb http://ftp.debian.org/debian sid main" >> /etc/apt/sources.list
+
+ADD automock/boto.cfg /etc/boto.cfg
+
+RUN mkdir -p /home/autopush
+ADD . /home/autopush/
+
+ENV WORKDIR /home/autopush
+ENV PATH ${WORKDIR}/pypy/bin:$PATH
+
+WORKDIR ${WORKDIR}
+
+RUN \
+    apt-get update; \
+    apt-get install -y -qq make curl bzip2 libexpat1-dev gcc libssl-dev libffi-dev; \
+    curl -sSL https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux64.tar.bz2 | tar xj; \
+    mv pypy-2.5.1-linux64 pypy; \
+    make clean && \
+    make && \
+    pip install moto && \
+    apt-get remove -y -qq make curl bzip2 libexpat1-dev gcc libssl-dev libffi-dev && \
+    apt-get install -y -qq libexpat1 libssl1.0.0 libffi6 && \
+    apt-get autoremove -y -qq && \
+    apt-get clean -y
+# End run
+
+# WebSocket connection port.
+EXPOSE 8080
+
+# HTTP update port.
+EXPOSE 8082
+
+CMD ["./automock/automock"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ DEPS =
 HERE = $(shell pwd)
 BIN = $(HERE)/pypy/bin
 VIRTUALENV = virtualenv
-NOSE = $(BIN)/nosetests
 TESTS = $(APPNAME)/tests
 PYTHON = $(BIN)/pypy
 INSTALL = $(BIN)/pip install
@@ -13,7 +12,7 @@ PATH := $(BIN):$(PATH)
 BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python site-packages
 
 
-.PHONY: all build test lint clean clean-env
+.PHONY: all build test coverage lint clean clean-env
 
 all:	build
 
@@ -22,8 +21,8 @@ $(BIN)/pip: $(BIN)/pypy
 	$(PYTHON) get-pip.py
 	rm get-pip.py
 
-$(BIN)/nosetests: $(BIN)/pip
-	$(INSTALL) -r test-requirements.txt
+$(BIN)/tox: $(BIN)/pip
+	$(INSTALL) tox
 
 $(BIN)/flake8: $(BIN)/pip
 	$(INSTALL) flake8
@@ -41,8 +40,11 @@ build: $(BIN)/pip
 	$(INSTALL) -r requirements.txt
 	$(PYTHON) setup.py develop
 
-test: $(BIN)/nosetests
-	$(NOSE)
+test: $(BIN)/tox
+	$(BIN)/tox
+
+coverage: $(BIN)/tox
+	$(BIN)/tox -- --with-coverage --cover-package=autopush
 
 lint: $(BIN)/flake8
 	$(BIN)/flake8 autopush

--- a/automock/automock.sh
+++ b/automock/automock.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+PATH="`pwd`/pypy/bin:$PATH"
+
+moto_server dynamodb2 -p 5000 &
+autonode

--- a/automock/boto.cfg
+++ b/automock/boto.cfg
@@ -1,0 +1,9 @@
+[Credentials]
+aws_access_key_id =
+aws_secret_access_key =
+
+[Boto]
+is_secure = False
+https_validate_certificates = False
+proxy_port = 5000
+proxy = 127.0.0.1

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -49,6 +49,8 @@ def add_shared_args(parser):
                         default=10, env_var="DATADOG_FLUSH_INTERVAL")
     parser.add_argument('--hostname', help="Hostname to announce under",
                         type=str, default=None, env_var="HOSTNAME")
+    parser.add_argument('--resolve_hostnames', help='Resolve all hostnames',
+                        type=bool, default=False, env_var="RESOLVE_HOSTNAMES")
     parser.add_argument('--statsd_host', help="Statsd Host", type=str,
                         default="localhost", env_var="STATSD_HOST")
     parser.add_argument('--statsd_port', help="Statsd Port", type=int,
@@ -223,6 +225,7 @@ def make_settings(args, **kwargs):
         storage_write_throughput=args.storage_write_throughput,
         router_read_throughput=args.router_read_throughput,
         router_write_throughput=args.router_write_throughput,
+        resolve_hostnames=args.resolve_hostnames,
         **kwargs
     )
 

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -11,6 +11,7 @@ from autopush.endpoint import (EndpointHandler, RegistrationHandler)
 from autopush.health import StatusHandler
 from autopush.logging import setup_logging
 from autopush.settings import AutopushSettings
+from autopush.utils import str2bool
 from autopush.websocket import (
     SimplePushServerProtocol,
     RouterHandler,
@@ -34,7 +35,7 @@ def add_ssl_args(parser):
 
 
 def add_shared_args(parser):
-    parser.add_argument('--debug', help='Debug Info.', action='store_true',
+    parser.add_argument('--debug', help='Debug Info.', type=bool,
                         default=False, env_var="DEBUG")
     parser.add_argument('--crypto_key', help="Crypto key for tokens", type=str,
                         default="i_CYcNKa2YXrF_7V1Y-2MFfoEl7b6KX55y_9uvOKfJQ=",
@@ -98,15 +99,13 @@ def add_connection_args(parser):
 
 def add_endpoint_args(parser):
     parser.add_argument('--cors', help='Allow CORS PUTs for update.',
-                        action='store_true', default=False,
-                        env_var='ALLOW_CORS')
+                        type=bool, default=False, env_var='ALLOW_CORS')
 
 
 def add_pinger_args(parser):
     # GCM
     parser.add_argument('--pinger', help='enable Proprietary Ping',
-                        action='store_true',
-                        default=False, env_var='PINGER')
+                        type=bool, default=False, env_var='PINGER')
     label = "Proprietary Ping: Google Cloud Messaging:"
     parser.add_argument('--gcm_ttl',
                         help="%s Time to Live" % label,
@@ -146,6 +145,7 @@ def _parse_connection(sysargs=None):
     parser = configargparse.ArgumentParser(
         description='Runs a Connection Node.',
         default_config_files=shared_config_files + config_files)
+    parser.register('type', bool, str2bool)
     parser.add_argument('--config-shared',
                         help="Common configuration file path",
                         dest='config_file', is_config_file=True)
@@ -174,6 +174,7 @@ def _parse_endpoint(sysargs=None):
     parser = configargparse.ArgumentParser(
         description='Runs an Endpoint Node.',
         default_config_files=shared_config_files + config_files)
+    parser.register('type', bool, str2bool)
     parser.add_argument('--config-shared',
                         help="Common configuration file path",
                         dest='config_file', is_config_file=True)
@@ -388,6 +389,7 @@ def unified_main(sysargs=None):
             '~/.autopush.ini',
             '.autopush.ini'
         ])
+    parser.register('type', bool, str2bool)
     parser.add_argument('-c', '--connection_port', help="Websocket Port",
                         type=int, default=8080, env_var="CONNECTION_PORT")
     parser.add_argument('--connection_ssl_key',

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -96,7 +96,7 @@ class AutopushSettings(object):
         self.connection_port = connection_port
         self.endpoint_hostname = endpoint_hostname or default_hostname
         self.endpoint_port = endpoint_port
-        self.router_hostname = router_hostname or self.connection_hostname
+        self.router_hostname = router_hostname or default_hostname
         self.router_port = router_port
 
         self.router_url = canonical_url(

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -1,6 +1,7 @@
 import socket
 
 from cryptography.fernet import Fernet
+from itertools import imap
 from twisted.internet import reactor
 from twisted.web.client import Agent, HTTPConnectionPool
 
@@ -49,6 +50,7 @@ class AutopushSettings(object):
                  statsd_host="localhost",
                  statsd_port=8125,
                  pingConf=None,
+                 resolve_hostnames=False,
                  enable_cors=False):
 
         # Use a persistent connection pool for HTTP requests.
@@ -79,11 +81,16 @@ class AutopushSettings(object):
 
         # Setup hosts/ports/urls
         default_hostname = socket.gethostname()
-        self.connection_hostname = connection_hostname or default_hostname
+        hostnames = (x or default_hostname for x in (connection_hostname,
+                     endpoint_hostname, router_hostname))
+        if resolve_hostnames:
+            hostnames = imap(resolve_hostname, hostnames)
+
+        self.connection_hostname, self.endpoint_hostname,\
+            self.router_hostname = hostnames
+
         self.connection_port = connection_port
-        self.endpoint_hostname = endpoint_hostname or default_hostname
         self.endpoint_port = endpoint_port
-        self.router_hostname = router_hostname or default_hostname
         self.router_port = router_port
 
         self.router_url = canonical_url(

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -44,8 +44,9 @@ class AutopushSettings(object):
                  datadog_api_key=None,
                  datadog_app_key=None,
                  datadog_flush_interval=None,
-                 hostname=None,
                  port=None,
+                 connection_hostname=None,
+                 connection_port=None,
                  router_scheme=None,
                  router_hostname=None,
                  router_port=None,
@@ -91,21 +92,23 @@ class AutopushSettings(object):
 
         # Setup hosts/ports/urls
         default_hostname = socket.gethostname()
-        self.hostname = hostname or default_hostname
-        self.port = port
-        self.endpoint_hostname = endpoint_hostname or self.hostname
-        self.router_hostname = router_hostname or self.hostname
+        self.connection_hostname = connection_hostname or default_hostname
+        self.connection_port = connection_port
+        self.endpoint_hostname = endpoint_hostname or default_hostname
+        self.endpoint_port = endpoint_port
+        self.router_hostname = router_hostname or self.connection_hostname
+        self.router_port = router_port
 
         self.router_url = canonical_url(
             router_scheme or 'http',
             self.router_hostname,
-            router_port
+            self.router_port
         )
 
         self.endpoint_url = canonical_url(
             endpoint_scheme or 'http',
             self.endpoint_hostname,
-            endpoint_port
+            self.endpoint_port
         )
 
         # Database objects

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -11,22 +11,9 @@ from autopush.db import (
     Router
 )
 from autopush.metrics import DatadogMetrics, TwistedMetrics
+from autopush.utils import canonical_url, resolve_hostname
 
 from autopush.pinger.pinger import Pinger
-
-
-default_ports = {
-    "ws": 80,
-    "http": 80,
-    "wss": 443,
-    "https": 443,
-}
-
-
-def canonical_url(scheme, hostname, port=None):
-    if port is None or port == default_ports.get(scheme):
-        return "%s://%s" % (scheme, hostname)
-    return "%s://%s:%s" % (scheme, hostname, port)
 
 
 class MetricSink(object):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -60,7 +60,7 @@ class EndpointTestCase(unittest.TestCase):
         twisted.internet.base.DelayedCall.debug = True
 
         settings = endpoint.EndpointHandler.ap_settings = AutopushSettings(
-            hostname="localhost",
+            endpoint_hostname="localhost",
             statsd_host=None,
         )
         self.fernet_mock = settings.fernet = Mock(spec=Fernet)
@@ -662,7 +662,7 @@ class RegistrationTestCase(unittest.TestCase):
         twisted.internet.base.DelayedCall.debug = True
         settings = endpoint.RegistrationHandler.ap_settings =\
             AutopushSettings(
-                hostname="localhost",
+                endpoint_hostname="localhost",
                 statsd_host=None,
             )
         self.fernet_mock = settings.fernet = Mock(spec=Fernet)

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -19,7 +19,8 @@ class HealthTestCase(unittest.TestCase):
         self.mock_dynamodb2.start()
 
         self.settings = StatusHandler.ap_settings = AutopushSettings(
-            hostname="localhost",
+            connection_hostname="localhost",
+            endpoint_hostname="localhost",
             statsd_host=None,
         )
         self.request_mock = Mock()

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -131,6 +131,7 @@ class EndpointMainTestCase(unittest.TestCase):
             storage_write_throughput = 0
             router_read_throughput = 0
             router_write_throughput = 0
+            resolve_hostnames = False
 
         ap = make_settings(arg)
         eq_(ap.pinger.gcm.gcm.api_key, arg.gcm_apikey)

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -7,7 +7,14 @@ from nose.tools import eq_
 from autopush.main import (
     connection_main,
     endpoint_main,
+    unified_main,
     make_settings
+)
+from autopush.endpoint import (EndpointHandler, RegistrationHandler)
+from autopush.websocket import (
+    SimplePushServerProtocol,
+    RouterHandler,
+    NotificationHandler,
 )
 
 mock_dynamodb2 = mock_dynamodb2()
@@ -19,6 +26,41 @@ def setUp():
 
 def tearDown():
     mock_dynamodb2.stop()
+
+
+class UnifiedMainTestCase(unittest.TestCase):
+    def setUp(self):
+        patchers = [
+            "autopush.main.log",
+            "autopush.main.task",
+            "autopush.main.reactor",
+            "autopush.settings.TwistedMetrics",
+        ]
+        self.mocks = {}
+        for name in patchers:
+            patcher = patch(name)
+            self.mocks[name] = patcher.start()
+
+    def tearDown(self):
+        for mock in self.mocks.values():
+            mock.stop()
+
+    def test_basic(self):
+        unified_main([
+            "--hostname",
+            "localhost",
+        ])
+        eq_(len(self.mocks["autopush.main.reactor"].run.mock_calls), 1)
+        # Should use a unified settings object for all handlers.
+        settings = EndpointHandler.ap_settings
+        eq_(settings, RegistrationHandler.ap_settings)
+        eq_(settings, SimplePushServerProtocol.ap_settings)
+        eq_(settings, RouterHandler.ap_settings)
+        eq_(settings, NotificationHandler.ap_settings)
+        eq_(settings.connection_hostname, "localhost")
+        eq_(settings.connection_port, 8080)
+        eq_(settings.endpoint_url, "http://localhost:8082")
+        eq_(settings.router_url, "http://localhost:8081")
 
 
 class ConnectionMainTestCase(unittest.TestCase):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -39,7 +39,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto = SimplePushServerProtocol()
 
         settings = AutopushSettings(
-            hostname="localhost",
+            connection_hostname="localhost",
             statsd_host=None,
         )
         self.proto.ap_settings = settings
@@ -111,7 +111,7 @@ class WebsocketTestCase(unittest.TestCase):
         eq_(args, ("update.client.connections", 0))
 
     def test_handeshake_sub(self):
-        self.proto.ap_settings.port = 8080
+        self.proto.ap_settings.connection_port = 8080
         self.proto.factory = Mock(externalPort=80)
 
         def check_subbed(s):
@@ -124,7 +124,7 @@ class WebsocketTestCase(unittest.TestCase):
         eq_(self.proto.factory.externalPort, 80)
 
     def test_handshake_nosub(self):
-        self.proto.ap_settings.port = 80
+        self.proto.ap_settings.connection_port = 80
         self.proto.factory = Mock(externalPort=80)
 
         def check_subbed(s):
@@ -1036,7 +1036,7 @@ class RouterHandlerTestCase(unittest.TestCase):
         twisted.internet.base.DelayedCall.debug = True
 
         self.ap_settings = AutopushSettings(
-            hostname="localhost",
+            connection_hostname="localhost",
             statsd_host=None,
         )
         self.ap_settings.metrics = Mock(spec=Metrics)
@@ -1080,7 +1080,7 @@ class NotificationHandlerTestCase(unittest.TestCase):
         twisted.internet.base.DelayedCall.debug = True
 
         self.ap_settings = AutopushSettings(
-            hostname="localhost",
+            connection_hostname="localhost",
             statsd_host=None,
         )
         self.ap_settings.metrics = Mock(spec=Metrics)

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -1,0 +1,28 @@
+import socket
+
+default_ports = {
+    "ws": 80,
+    "http": 80,
+    "wss": 443,
+    "https": 443,
+}
+
+
+def str2bool(v):
+    return v in ("1", "t", "T", "true", "TRUE", "True")
+
+
+def canonical_url(scheme, hostname, port=None):
+    if port is None or port == default_ports.get(scheme):
+        return "%s://%s" % (scheme, hostname)
+    return "%s://%s:%s" % (scheme, hostname, port)
+
+
+def resolve_hostname(hostname):
+    interfaces = socket.getaddrinfo(hostname, 0, socket.AF_INET,
+                                    socket.SOCK_STREAM,
+                                    socket.IPPROTO_TCP)
+    if len(interfaces) == 0:
+        return hostname
+    addr = interfaces[0][-1]
+    return addr[0]

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -94,7 +94,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def processHandshake(self):
         """Disable host port checking on nonstandard ports since some
         clients are buggy and don't provide it"""
-        port = self.ap_settings.port
+        port = self.ap_settings.connection_port
         hide = port != 80 and port != 443
         if not hide:
             return self.parent_class.processHandshake(self)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name="AutoPush",
       [console_scripts]
       autopush = autopush.main:connection_main
       autoendpoint = autopush.main:endpoint_main
+      autonode = autopush.main:unified_main
       autokey = autokey:main
       """,
       **extra_options

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = pypy,flake8
 deps = -rtest-requirements.txt
 usedevelop = True
 commands =
-    nosetests --with-coverage --cover-package=autopush autopush {posargs}
+    nosetests {posargs} autopush
 install_command = pip install --pre {opts} {packages}
 
 [testenv:flake8]


### PR DESCRIPTION
Closes #33.

* `autonode` starts connection and endpoint nodes on the same machine. It's identical to running `autopush` and `autoendpoint` side-by-side, but uses `--{connection, endpoint}_port` and `--{connection, endpoint}_ssl_{key, cert}` options to avoid environment variable collisions.
* `automock` starts a unified server that proxies all AWS calls to a Moto server. Using the `@mock_dynamodb2` decorator with Twisted didn't work; see gabrielfalcao/HTTPretty#239.
* Add a `RESOLVE_HOSTNAMES` option for Docker. I found this helpful testing locally.
* Allow setting Boolean flags via environment variables and config files. Setting the flag via `RESOLVE_HOSTNAMES=1` (or `RESOLVE_HOSTNAMES=`) resulted in the error, `RESOLVE_HOSTNAMES is a flag but is being set to 1`.