### PR TITLE
Add an `automock` script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 .DS_Store
+.git
 .svn
 *.pyc
 *.egg-info
 *.egg
+.tox
 bin
 build
 dist
@@ -17,3 +19,4 @@ lib-python/*
 bin/*
 include/*
 lib_pypy/*
+pypy

--- a/Dockerfile.automock
+++ b/Dockerfile.automock
@@ -1,0 +1,43 @@
+# This Dockerfile runs the AutoPush connection and endpoint nodes in the same
+# container, using Moto to simulate DynamoDB calls.
+
+FROM stackbrew/debian:wheezy
+
+MAINTAINER Kit Cambridge <kcambridge@mozilla.com>
+
+# It's nice to have some newer packages
+RUN echo "deb http://ftp.debian.org/debian sid main" >> /etc/apt/sources.list
+
+ADD automock/boto.cfg /etc/boto.cfg
+ADD automock/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN mkdir -p /home/autopush
+ADD . /home/autopush/
+
+ENV WORKDIR /home/autopush
+ENV PATH ${WORKDIR}/pypy/bin:$PATH
+
+WORKDIR ${WORKDIR}
+
+RUN \
+    apt-get update; \
+    apt-get install -y -qq make curl bzip2 libexpat1-dev gcc libssl-dev libffi-dev supervisor; \
+    mkdir -p /var/log/supervisor; \
+    curl -sSL https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux64.tar.bz2 | tar xj; \
+    mv pypy-2.5.1-linux64 pypy; \
+    make clean && \
+    make && \
+    pip install moto && \
+    apt-get remove -y -qq make curl bzip2 libexpat1-dev gcc libssl-dev libffi-dev && \
+    apt-get install -y -qq libexpat1 libssl1.0.0 libffi6 && \
+    apt-get autoremove -y -qq && \
+    apt-get clean -y
+# End run
+
+# WebSocket connection port.
+EXPOSE 8080
+
+# HTTP update port.
+EXPOSE 8082
+
+CMD ["/usr/bin/supervisord"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ DEPS =
 HERE = $(shell pwd)
 BIN = $(HERE)/pypy/bin
 VIRTUALENV = virtualenv
-NOSE = $(BIN)/nosetests
 TESTS = $(APPNAME)/tests
 PYTHON = $(BIN)/pypy
 INSTALL = $(BIN)/pip install
@@ -13,7 +12,7 @@ PATH := $(BIN):$(PATH)
 BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python site-packages
 
 
-.PHONY: all build test lint clean clean-env
+.PHONY: all build test coverage lint clean clean-env
 
 all:	build
 
@@ -22,8 +21,8 @@ $(BIN)/pip: $(BIN)/pypy
 	$(PYTHON) get-pip.py
 	rm get-pip.py
 
-$(BIN)/nosetests: $(BIN)/pip
-	$(INSTALL) -r test-requirements.txt
+$(BIN)/tox: $(BIN)/pip
+	$(INSTALL) tox
 
 $(BIN)/flake8: $(BIN)/pip
 	$(INSTALL) flake8
@@ -41,8 +40,11 @@ build: $(BIN)/pip
 	$(INSTALL) -r requirements.txt
 	$(PYTHON) setup.py develop
 
-test: $(BIN)/nosetests
-	$(NOSE)
+test: $(BIN)/tox
+	$(BIN)/tox
+
+coverage: $(BIN)/tox
+	$(BIN)/tox -- --with-coverage --cover-package=autopush
 
 lint: $(BIN)/flake8
 	$(BIN)/flake8 autopush

--- a/automock/boto.cfg
+++ b/automock/boto.cfg
@@ -1,0 +1,9 @@
+[Credentials]
+aws_access_key_id =
+aws_secret_access_key =
+
+[Boto]
+is_secure = False
+https_validate_certificates = False
+proxy_port = 5000
+proxy = 127.0.0.1

--- a/automock/supervisord.conf
+++ b/automock/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:moto]
+command=/home/autopush/pypy/bin/moto_server dynamodb2 -p 5000
+stdout_logfile=/var/log/moto_server.log
+
+[program:autopush]
+command=/home/autopush/pypy/bin/autopush
+redirect_stderr=true
+stdout_logfile=/var/log/autopush.log
+
+[program:autoendpoint]
+command=/home/autopush/pypy/bin/autoendpoint
+redirect_stderr=true
+stdout_logfile=/var/log/autoendpoint.log

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -11,6 +11,7 @@ from autopush.endpoint import (EndpointHandler, RegistrationHandler)
 from autopush.health import StatusHandler
 from autopush.logging import setup_logging
 from autopush.settings import AutopushSettings
+from autopush.utils import str2bool
 from autopush.websocket import (
     SimplePushServerProtocol,
     RouterHandler,
@@ -30,7 +31,7 @@ def add_shared_args(parser):
     parser.add_argument('--config-shared',
                         help="Common configuration file path",
                         dest='config_file', is_config_file=True)
-    parser.add_argument('--debug', help='Debug Info.', action='store_true',
+    parser.add_argument('--debug', help='Debug Info.', type=bool,
                         default=False, env_var="DEBUG")
     parser.add_argument('--crypto_key', help="Crypto key for tokens", type=str,
                         default="i_CYcNKa2YXrF_7V1Y-2MFfoEl7b6KX55y_9uvOKfJQ=",
@@ -77,8 +78,7 @@ def add_shared_args(parser):
 def add_pinger_args(parser):
     # GCM
     parser.add_argument('--pinger', help='enable Proprietary Ping',
-                        action='store_true',
-                        default=False, env_var='PINGER')
+                        type=bool, default=False, env_var='PINGER')
     label = "Proprietary Ping: Google Cloud Messaging:"
     parser.add_argument('--gcm_ttl',
                         help="%s Time to Live" % label,
@@ -118,6 +118,7 @@ def _parse_connection(sysargs=None):
     parser = configargparse.ArgumentParser(
         description='Runs a Connection Node.',
         default_config_files=shared_config_files + config_files)
+    parser.register('type', bool, str2bool)
     parser.add_argument('--config-connection',
                         help="Connection node configuration file path",
                         dest='config_file', is_config_file=True)
@@ -161,14 +162,14 @@ def _parse_endpoint(sysargs=None):
     parser = configargparse.ArgumentParser(
         description='Runs an Endpoint Node.',
         default_config_files=shared_config_files + config_files)
+    parser.register('type', bool, str2bool)
     parser.add_argument('--config-endpoint',
                         help="Endpoint node configuration file path",
                         dest='config_file', is_config_file=True)
     parser.add_argument('-p', '--port', help='Public HTTP Endpoint Port',
                         type=int, default=8082, env_var="PORT")
     parser.add_argument('--cors', help='Allow CORS PUTs for update.',
-                        action='store_true', default=False,
-                        env_var='ALLOW_CORS')
+                        type=bool, default=False, env_var='ALLOW_CORS')
     add_shared_args(parser)
     add_pinger_args(parser)
     args = parser.parse_args(sysargs)

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -45,6 +45,9 @@ def add_shared_args(parser):
                         default=10, env_var="DATADOG_FLUSH_INTERVAL")
     parser.add_argument('--hostname', help="Hostname to announce under",
                         type=str, default=None, env_var="HOSTNAME")
+    parser.add_argument('--resolve_hostname',
+                        help="Resolve the announced hostname",
+                        type=bool, default=False, env_var="RESOLVE_HOSTNAME")
     parser.add_argument('--statsd_host', help="Statsd Host", type=str,
                         default="localhost", env_var="STATSD_HOST")
     parser.add_argument('--statsd_port', help="Statsd Port", type=int,
@@ -209,6 +212,7 @@ def make_settings(args, **kwargs):
         storage_write_throughput=args.storage_write_throughput,
         router_read_throughput=args.router_read_throughput,
         router_write_throughput=args.router_write_throughput,
+        resolve_hostname=args.resolve_hostname,
         **kwargs
     )
 

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -11,22 +11,9 @@ from autopush.db import (
     Router
 )
 from autopush.metrics import DatadogMetrics, TwistedMetrics
+from autopush.utils import canonical_url
 
 from autopush.pinger.pinger import Pinger
-
-
-default_ports = {
-    "ws": 80,
-    "http": 80,
-    "wss": 443,
-    "https": 443,
-}
-
-
-def canonical_url(scheme, hostname, port=None):
-    if port is None or port == default_ports.get(scheme):
-        return "%s://%s" % (scheme, hostname)
-    return "%s://%s:%s" % (scheme, hostname, port)
 
 
 class MetricSink(object):

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -11,7 +11,7 @@ from autopush.db import (
     Router
 )
 from autopush.metrics import DatadogMetrics, TwistedMetrics
-from autopush.utils import canonical_url
+from autopush.utils import canonical_url, resolve_ip
 
 from autopush.pinger.pinger import Pinger
 
@@ -48,6 +48,7 @@ class AutopushSettings(object):
                  statsd_host="localhost",
                  statsd_port=8125,
                  pingConf=None,
+                 resolve_hostname=False,
                  enable_cors=False):
 
         # Use a persistent connection pool for HTTP requests.
@@ -79,6 +80,9 @@ class AutopushSettings(object):
         # Setup hosts/ports/urls
         default_hostname = socket.gethostname()
         self.hostname = hostname or default_hostname
+        if resolve_hostname:
+            self.hostname = resolve_ip(self.hostname)
+
         self.port = port
         self.endpoint_hostname = endpoint_hostname or self.hostname
         self.router_hostname = router_hostname or self.hostname

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -89,6 +89,7 @@ class EndpointMainTestCase(unittest.TestCase):
             storage_write_throughput = 0
             router_read_throughput = 0
             router_write_throughput = 0
+            resolve_hostname = False
 
         ap = make_settings(arg)
         eq_(ap.pinger.gcm.gcm.api_key, arg.gcm_apikey)

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -1,0 +1,16 @@
+default_ports = {
+    "ws": 80,
+    "http": 80,
+    "wss": 443,
+    "https": 443,
+}
+
+
+def str2bool(v):
+    return v in ("1", "t", "T", "true", "TRUE", "True")
+
+
+def canonical_url(scheme, hostname, port=None):
+    if port is None or port == default_ports.get(scheme):
+        return "%s://%s" % (scheme, hostname)
+    return "%s://%s:%s" % (scheme, hostname, port)

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -1,3 +1,5 @@
+import socket
+
 default_ports = {
     "ws": 80,
     "http": 80,
@@ -14,3 +16,13 @@ def canonical_url(scheme, hostname, port=None):
     if port is None or port == default_ports.get(scheme):
         return "%s://%s" % (scheme, hostname)
     return "%s://%s:%s" % (scheme, hostname, port)
+
+
+def resolve_ip(hostname):
+    interfaces = socket.getaddrinfo(hostname, 0, socket.AF_INET,
+                                    socket.SOCK_STREAM,
+                                    socket.IPPROTO_TCP)
+    if len(interfaces) == 0:
+        return hostname
+    addr = interfaces[0][-1]
+    return addr[0]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = pypy,flake8
 deps = -rtest-requirements.txt
 usedevelop = True
 commands =
-    nosetests --with-coverage --cover-package=autopush autopush {posargs}
+    nosetests {posargs} autopush
 install_command = pip install --pre {opts} {packages}
 
 [testenv:flake8]


### PR DESCRIPTION
Alternative implementation of #40, using Supervisor instead of a unified `autonode`. This requires mounting a config file into the container, since `autopush` and `autoendpoint` rely on shared environment variables (e.g., `port`, `ssl_key`, `ssl_cert`).