### PR TITLE
Feature/log core protocol errors

### DIFF
--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -80,6 +80,20 @@ class WebsocketTestCase(unittest.TestCase):
         self._wait_for_message(d)
         return d
 
+    def test_exc_catcher(self):
+        self.proto.log_err = Mock()
+        req = Mock()
+
+        def raise_error(*args, **kwargs):
+            raise Exception("Oops")
+
+        req.headers.get.side_effect = raise_error
+
+        with self.assertRaises(Exception):
+            self.proto.onConnect(req)
+
+        req.headers.get.assert_called_with("user-agent")
+
     def test_producer_interface(self):
         self._connect()
         self.proto.pauseProducing()


### PR DESCRIPTION
The Websocket Protocol only chooses to log exceptions in the methods it calls if debug is enabled. However, debug enables a *ton* of logging we don't want. This add's exception catching to the main methods the Protocol calls (the rest are deferreds that we already log errors on).