### PR TITLE
logging: move message_type out to Type field

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -68,6 +68,10 @@ def stdout(message):
     for key in ["Type", "Severity"]:
         if key in message:
             msg[key] = message.pop(key)
+
+    if "message_type" in message:
+        msg["Type"] = message.pop("message_type")
+
     msg["Timestamp"] = ts * 1000 * 1000 * 1000
     msg["Fields"] = message
     msg["EnvVersion"] = "2.0"


### PR DESCRIPTION
@bbangert r?

This was suggested by @whd to more closely meet our logging standard.