### PR TITLE
Add a health handler with DynamoDB connection status

### DIFF
--- a/autopush/health.py
+++ b/autopush/health.py
@@ -1,6 +1,66 @@
 import cyclone.web
 
+from boto.dynamodb2.exceptions import (
+    InternalServerError,
+)
+from twisted.internet.defer import DeferredList
+from twisted.internet.threads import deferToThread
+from twisted.python import log
+
 from autopush import __version__
+
+
+class MissingTableException(Exception):
+    pass
+
+
+class HealthHandler(cyclone.web.RequestHandler):
+    @cyclone.web.asynchronous
+    def get(self):
+        self._healthy = True
+        self._health_checks = {
+            "version": __version__,
+            "clients": len(self.ap_settings.clients)
+        }
+
+        dl = DeferredList([
+            self._check_table(self.ap_settings.router.table),
+            self._check_table(self.ap_settings.storage.table)
+        ])
+        dl.addBoth(self._finish_response)
+
+    def _check_table(self, table):
+        d = deferToThread(table.connection.list_tables)
+        d.addCallback(self._check_success, table.table_name)
+        d.addErrback(self._check_error, table.table_name)
+        return d
+
+    def _check_success(self, result, name):
+        if name not in result.get("TableNames", {}):
+            raise MissingTableException("Nonexistent table")
+        self._health_checks[name] = {"status": "OK"}
+
+    def _check_error(self, failure, name):
+        self._healthy = False
+        log.err(failure, name)
+
+        cause = self._health_checks[name] = {"status": "NOT OK"}
+        if failure.check(InternalServerError):
+            cause["error"] = "Server error"
+        elif failure.check(MissingTableException):
+            cause["error"] = failure.getErrorMessage()
+        else:
+            cause["error"] = "Internal error"
+
+    def _finish_response(self, results):
+        if self._healthy:
+            self._health_checks["status"] = "OK"
+        else:
+            self.set_status(503)
+            self._health_checks["status"] = "NOT OK"
+
+        self.write(self._health_checks)
+        self.finish()
 
 
 class StatusHandler(cyclone.web.RequestHandler):

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -8,7 +8,7 @@ from twisted.internet import reactor, task
 from twisted.python import log
 
 from autopush.endpoint import (EndpointHandler, RegistrationHandler)
-from autopush.health import StatusHandler
+from autopush.health import (HealthHandler, StatusHandler)
 from autopush.logging import setup_logging
 from autopush.settings import AutopushSettings
 from autopush.ssl import AutopushSSLContextFactory
@@ -226,6 +226,17 @@ def skip_request_logging(handler):
     pass
 
 
+def mount_health_handlers(site, settings):
+    status = StatusHandler
+    status.ap_settings = settings
+    health = HealthHandler
+    health.ap_settings = settings
+    site.add_handlers(".*$", [
+        (r"^/status", status),
+        (r"^/health", health),
+    ])
+
+
 def connection_main(sysargs=None):
     args, parser = _parse_connection(sysargs)
     settings = make_settings(
@@ -244,18 +255,16 @@ def connection_main(sysargs=None):
     r.ap_settings = settings
     n = NotificationHandler
     n.ap_settings = settings
-    s = StatusHandler
-    s.ap_settings = settings
 
     # Internal HTTP notification router
     site = cyclone.web.Application([
         (r"/push/([^\/]+)", r),
         (r"/notif/([^\/]+)", n),
-        (r"^/status/", s),
     ],
         default_host=settings.router_hostname, debug=args.debug,
         log_function=skip_request_logging
     )
+    mount_health_handlers(site, settings)
 
     # Public websocket server
     proto = "wss" if args.ssl_key else "ws"
@@ -323,18 +332,16 @@ def endpoint_main(sysargs=None):
     endpoint.ap_settings = settings
     register = RegistrationHandler
     register.ap_settings = settings
-    status = StatusHandler
-    status.ap_settings = settings
     site = cyclone.web.Application([
         (r"/push/([^\/]+)", endpoint),
         # PUT /register/ => connect info
         # GET /register/uaid => chid + endpoint
         (r"/register/([^\/]+)?", register),
-        (r"^/status", status),
     ],
         default_host=settings.hostname, debug=args.debug,
         log_function=skip_request_logging
     )
+    mount_health_handlers(site, settings)
 
     # No reason that the endpoint couldn't handle both...
     endpoint.pinger = settings.pinger

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -1,16 +1,130 @@
 import twisted.internet.base
 
+from boto.dynamodb2.exceptions import (
+    InternalServerError,
+)
 from cyclone.web import Application
-from mock import Mock
+from mock import (Mock, patch)
 from moto import mock_dynamodb2
+from twisted.internet.defer import Deferred
 from twisted.trial import unittest
 
 from autopush import __version__
-from autopush.health import StatusHandler
+from autopush.health import (
+    HealthHandler,
+    MissingTableException,
+    StatusHandler,
+)
 from autopush.settings import AutopushSettings
 
 
 class HealthTestCase(unittest.TestCase):
+    def setUp(self):
+        self.timeout = 0.5
+        twisted.internet.base.DelayedCall.debug = True
+
+        self.log_mock = patch("autopush.health.log").start()
+        self.mock_dynamodb2 = mock_dynamodb2()
+        self.mock_dynamodb2.start()
+
+        HealthHandler.ap_settings = self.settings = AutopushSettings(
+            hostname="localhost",
+            statsd_host=None,
+        )
+        self.router_table = self.settings.router.table
+        self.storage_table = self.settings.storage.table
+
+        self.request_mock = Mock()
+        self.health = HealthHandler(Application(), self.request_mock)
+        self.status_mock = self.health.set_status = Mock()
+        self.write_mock = self.health.write = Mock()
+
+        d = self.finish_deferred = Deferred()
+        self.health.finish = lambda: d.callback(True)
+
+    def tearDown(self):
+        self.mock_dynamodb2.stop()
+        self.log_mock.stop()
+
+    def test_healthy(self):
+        return self._assert_reply({
+            "status": "OK",
+            "version": __version__,
+            "clients": 0,
+            "storage": {"status": "OK"},
+            "router": {"status": "OK"}
+        })
+
+    def test_aws_error(self):
+        def raise_error(*args, **kwargs):
+            raise InternalServerError(None, None)
+        self.router_table.connection.list_tables = Mock(
+            side_effect=raise_error)
+        self.storage_table.connection.list_tables = Mock(
+            return_value={"TableNames": ["storage"]})
+
+        return self._assert_reply({
+            "status": "NOT OK",
+            "version": __version__,
+            "clients": 0,
+            "storage": {"status": "OK"},
+            "router": {
+                "status": "NOT OK",
+                "error": "Server error"
+            }
+        }, InternalServerError)
+
+    def test_nonexistent_table(self):
+        no_tables = Mock(return_value={"TableNames": []})
+        self.storage_table.connection.list_tables = no_tables
+        self.router_table.connection.list_tables = no_tables
+
+        return self._assert_reply({
+            "status": "NOT OK",
+            "version": __version__,
+            "clients": 0,
+            "storage": {
+                "status": "NOT OK",
+                "error": "Nonexistent table"
+            },
+            "router": {
+                "status": "NOT OK",
+                "error": "Nonexistent table"
+            }
+        }, MissingTableException)
+
+    def test_internal_error(self):
+        def raise_error(*args, **kwargs):
+            raise Exception("synergies not aligned")
+        self.router_table.connection.list_tables = Mock(
+            return_value={"TableNames": ["router"]})
+        self.storage_table.connection.list_tables = Mock(
+            side_effect=raise_error)
+
+        return self._assert_reply({
+            "status": "NOT OK",
+            "version": __version__,
+            "clients": 0,
+            "storage": {
+                "status": "NOT OK",
+                "error": "Internal error"
+            },
+            "router": {"status": "OK"}
+        }, Exception)
+
+    def _assert_reply(self, reply, exception=None):
+        def handle_finish(result):
+            if exception:
+                self.status_mock.assert_called_with(503)
+                self.flushLoggedErrors(exception)
+            self.write_mock.assert_called_with(reply)
+        self.finish_deferred.addCallback(handle_finish)
+
+        self.health.get()
+        return self.finish_deferred
+
+
+class StatusTestCase(unittest.TestCase):
     def setUp(self):
         self.timeout = 0.5
         twisted.internet.base.DelayedCall.debug = True


### PR DESCRIPTION
Closes #34.

I thought about reusing `preflight_check` for this...but it would be really inconvenient if folks could use up our provisioned throughput with a simple `while true; do curl https://autopush.server/health; done`.