### PR TITLE
Add a `pong_delay` option for excessive pings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ PYTHON = $(BIN)/pypy
 INSTALL = $(BIN)/pip install
 PATH := $(BIN):$(PATH)
 
-BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python site-packages
+BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python\
+	src site-packages .tox .eggs .coverage
 
 
 .PHONY: all build test coverage lint clean clean-env
@@ -32,6 +33,7 @@ $(BIN)/paster: lib $(BIN)/pip
 	$(PYTHON) setup.py develop
 
 clean-env:
+	rm -rf *.egg-info
 	rm -rf $(BUILD_DIRS)
 
 clean:	clean-env

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -163,6 +163,9 @@ def _parse_connection(sysargs=None):
         default=20,
         type=int,
         env_var="MIN_PING_INTERVAL")
+    parser.add_argument('--pong_delay', help=("Time to wait after receiving a "
+                        "pong for clients that ping too frequently"),
+                        default=0, type=int, env_var="PONG_DELAY")
 
     add_bridge_args(parser)
     add_shared_args(parser)

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -51,6 +51,7 @@ class AutopushSettings(object):
                  pingConf=None,
                  resolve_hostname=False,
                  min_ping_interval=20,
+                 pong_delay=0,
                  max_data=4096,
                  enable_cors=False):
 
@@ -73,6 +74,7 @@ class AutopushSettings(object):
         key = crypto_key or Fernet.generate_key()
         self.fernet = Fernet(key)
 
+        self.pong_delay = pong_delay
         self.min_ping_interval = min_ping_interval
         self.max_data = max_data
         self.clients = {}

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -395,7 +395,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def _send_ping(self):
         self.last_ping = time.time()
-        self.metrics.increment("updates.client.ping")
+        self.metrics.increment("updates.client.ping", tags=self.base_tags)
         return self.sendMessage("{}", False)
 
     def process_ping(self):

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -45,8 +45,6 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     # Testing purposes
     parent_class = WebSocketServerProtocol
 
-    too_many_pings = False
-
     @property
     def base_tags(self):
         return self._base_tags if self._base_tags else None

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -7,6 +7,7 @@ import cyclone.web
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from twisted.internet import reactor
 from twisted.internet.defer import (
+    Deferred,
     DeferredList,
     CancelledError
 )
@@ -43,6 +44,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     # Testing purposes
     parent_class = WebSocketServerProtocol
+
+    too_many_pings = False
 
     @property
     def base_tags(self):
@@ -392,15 +395,24 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             self._check_notifications = False
             reactor.callLater(1, self.process_notifications)
 
+    def _send_ping(self):
+        self.last_ping = time.time()
+        self.metrics.increment("updates.client.ping")
+        return self.sendMessage("{}", False)
+
     def process_ping(self):
         now = time.time()
         if now - self.last_ping < self.ap_settings.min_ping_interval:
+            if self.ap_settings.pong_delay > 0:
+                d = Deferred()
+                d.addCallback(lambda x: self._send_ping())
+                reactor.callLater(self.ap_settings.pong_delay, d.callback,
+                                  True)
+                return d
             self.metrics.increment("updates.client.too_many_pings",
                                    tags=self.base_tags)
             return self.sendClose()
-        self.last_ping = now
-        self.metrics.increment("updates.client.ping")
-        return self.sendMessage("{}", False)
+        self._send_ping()
 
     def process_register(self, data):
         if "channelID" not in data:

--- a/configs/autopush_endpoint.ini
+++ b/configs/autopush_endpoint.ini
@@ -8,3 +8,12 @@ port = 8082
 
 ; Uncomment to enable CORS for incoming notifications.
 ; cors
+
+; The minimum client ping interval, in seconds. Clients that send more
+; frequently will have their connections closed.
+min_ping_interval = 20
+
+; The time to wait after receiving a client ping before responding with a
+; pong. Used to avoid excessive network and battery usage on clients that
+; ping too frequently.
+pong_delay = 0


### PR DESCRIPTION
`pong_delay` waits to respond to client pings, to work around clients that enter a ping loop.