### PR TITLE
[WIP] Support for using custom dynamodb host and port

### DIFF
--- a/autopush/main.py
+++ b/autopush/main.py
@@ -49,6 +49,15 @@ def add_shared_args(parser):
     parser.add_argument('--resolve_hostname',
                         help="Resolve the announced hostname",
                         type=bool, default=False, env_var="RESOLVE_HOSTNAME")
+    parser.add_argument('--db_host',
+                        help="DynamoDB server post", type=str,
+                        default=None, env_var="DB_HOST")
+    parser.add_argument('--db_port',
+                        help="DynamoDB server port", type=int,
+                        default=None, env_var="DB_PORT")
+    parser.add_argument('--db_no_secure',
+                        help="DynamoDB server is insecure", dest='db_secure',
+                        action='store_false', default=True, env_var="DB_SECURE")
     parser.add_argument('--statsd_host', help="Statsd Host", type=str,
                         default="localhost", env_var="STATSD_HOST")
     parser.add_argument('--statsd_port', help="Statsd Port", type=int,
@@ -225,11 +234,13 @@ def make_settings(args, **kwargs):
         datadog_app_key=args.datadog_app_key,
         datadog_flush_interval=args.datadog_flush_interval,
         hostname=args.hostname,
+        db_host=args.db_host,
+        db_port=args.db_port,
+        db_secure=args.db_secure,
         statsd_host=args.statsd_host,
         statsd_port=args.statsd_port,
         pingConf=pingConf,
         router_tablename=args.router_tablename,
-        storage_tablename=args.storage_tablename,
         storage_read_throughput=args.storage_read_throughput,
         storage_write_throughput=args.storage_write_throughput,
         router_read_throughput=args.router_read_throughput,

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -241,6 +241,7 @@ def make_settings(args, **kwargs):
         statsd_port=args.statsd_port,
         pingConf=pingConf,
         router_tablename=args.router_tablename,
+        storage_tablename=args.storage_tablename,
         storage_read_throughput=args.storage_read_throughput,
         storage_write_throughput=args.storage_write_throughput,
         router_read_throughput=args.router_read_throughput,

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -34,6 +34,9 @@ class AutopushSettings(object):
                  datadog_flush_interval=None,
                  hostname=None,
                  port=None,
+                 db_host=None,
+                 db_port=None,
+                 db_secure=None,
                  router_scheme=None,
                  router_hostname=None,
                  router_port=None,
@@ -100,10 +103,12 @@ class AutopushSettings(object):
         # Database objects
         self.router_table = get_router_table(router_tablename,
                                              router_read_throughput,
-                                             router_write_throughput)
+                                             router_write_throughput,
+                                             db_host, db_port, db_secure)
         self.storage_table = get_storage_table(storage_tablename,
                                                storage_read_throughput,
-                                               storage_write_throughput)
+                                               storage_write_throughput,
+                                               db_host, db_port, db_secure)
         self.storage = Storage(self.storage_table, self.metrics)
         self.router = Router(self.router_table, self.metrics)
 


### PR DESCRIPTION
The aim of this is to be able to develop autopush without using the
actual AWS credentials. This is still not functional, I have noticed
that there is a issue with `condition_expression` and
`expression_attribute_values`. I am looking more on this. Sending
out this request to make sure that I am not going into a completely
wrong direction.

My objective here is to not have to use actual AWS credentials and
avoid latency while developing.

Ref: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html