### PR TITLE
* Increase test coverage of utils for 100% test coverage.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Autopush Changelog
 1.3.0 (**dev**)
 ===============
 
+Bug Fixes
+---------
+
+* Increase test coverage of utils for 100% test coverage.
+
 Internal
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ You will first need to get pypy as appropriate for your system and put it's
 uncompressed folder in the autopush directory as ``pypy``.
 
 PyPy downloads can be found here: http://pypy.org/download.html#default-with-a-jit-compiler
-autopush requires PyPy >= 2.5.1.
+autopush requires PyPy >= 2.6.
 
 Once you have downloaded, decompressed, and renamed this to ``pypy``, you can
 run the Makefile with ``make``, which will setup the application.

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 
 from mock import Mock, patch
 from moto import mock_dynamodb2
@@ -10,7 +11,12 @@ from autopush.main import (
     make_settings,
     skip_request_logging,
 )
-from autopush.utils import str2bool, resolve_ip
+from autopush.utils import (
+    str2bool,
+    resolve_ip,
+    generate_hash,
+    validate_hash,
+)
 from autopush.settings import AutopushSettings
 
 
@@ -30,6 +36,16 @@ class UtilsTestCase(unittest.TestCase):
         eq_(True, str2bool("t"))
         eq_(False, str2bool("false"))
         eq_(True, str2bool("True"))
+
+    def test_validate_hash(self):
+        key = str(uuid.uuid4())
+        payload = str(uuid.uuid4())
+        hashed = generate_hash(key, payload)
+        print hashed
+
+        eq_(validate_hash(key, payload, hashed), True)
+        eq_(validate_hash(key, payload, str(uuid.uuid4())), False)
+        eq_(validate_hash(key, payload, ""), False)
 
 
 class SettingsTestCase(unittest.TestCase):

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -46,11 +46,8 @@ def validate_uaid(uaid):
 def validate_hash(key, payload, hashed):
     """Validates that a UAID matches the HMAC value using the supplied
     secret"""
-    try:
-        h = hmac.new(key=key, msg=payload, digestmod=hashlib.sha256)
-        return hmac.compare_digest(hashed, h.hexdigest())
-    except:
-        return False
+    h = hmac.new(key=key, msg=payload, digestmod=hashlib.sha256)
+    return hmac.compare_digest(hashed, h.hexdigest())
 
 
 def generate_hash(key, payload):


### PR DESCRIPTION
I previously didn't see the two lines missing since a blanket except statement caught the import error. Python 2.7.7 and above have compare_digest, the rest don't. I've also bumped the pypy dependency to ensure it requires a Python appropriate, and removed the try/except that wasn't needed.