### PR TITLE
s/router/router_type in endpoint

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -215,7 +215,7 @@ class EndpointHandler(AutoendpointHandler):
     def _uaid_lookup_results(self, result, notification):
         """Process the result of the AWS UAID lookup"""
         # Save the whole record
-        router_key = result.get("router", "simplepush")
+        router_key = result.get("router_type", "simplepush")
         router = self.ap_settings.routers[router_key]
         d = Deferred()
         d.addCallback(router.route_notification, result)

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -508,8 +508,8 @@ class RegistrationHandler(AutoendpointHandler):
     #############################################################
     def _return_router_data(self, user_item):
         msg = dict(
-            type=user_item["type"],
-            data=user_item["data"],
+            type=user_item["router_type"],
+            data=user_item["router_data"],
         )
         self.write(json.dumps(msg))
         self.finish()

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -482,8 +482,8 @@ class RegistrationTestCase(unittest.TestCase):
             'encrypt.return_value': 'abcd123',
         })
         user_item = dict(
-            type="simplepush",
-            data={},
+            router_type="simplepush",
+            router_data={},
         )
         self.reg.ap_settings.endpoint_url = "http://localhost"
         self.reg.request.headers["Authorization"] = "something else"
@@ -493,7 +493,10 @@ class RegistrationTestCase(unittest.TestCase):
             call_args = self.reg.write.call_args
             ok_(call_args is not None)
             args = call_args[0]
-            eq_(json.loads(args[0]), user_item)
+            retval = dict(
+                type=user_item["router_type"],
+                data=user_item["router_data"])
+            eq_(json.loads(args[0]), retval)
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.get(dummy_uaid)

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -88,6 +88,21 @@ class EndpointTestCase(unittest.TestCase):
         d = self.finish_deferred = Deferred()
         self.endpoint.finish = lambda: d.callback(True)
 
+    def test_uaid_lookup_results(self):
+        fresult = dict(router_type="test")
+        notification = {}
+        frouter = Mock(spec=Router)
+        frouter.route_notification = Mock()
+        frouter.route_notification.return_value = RouterResponse()
+        self.endpoint.ap_settings.routers["test"] = frouter
+        self.endpoint._uaid_lookup_results(fresult, notification)
+
+        def handle_finish(value):
+            frouter.route_notification.assert_called()
+
+        self.finish_deferred.addCallback(handle_finish)
+        return self.finish_deferred
+
     def test_client_info(self):
         h = self.request_mock.headers
         h["user-agent"] = "myself"


### PR DESCRIPTION
correct bug where endpoint was not getting the correct router from the stored routing data.

@bbangert r?