### PR TITLE
Support for limiting maximum concurrent connections

### DIFF
--- a/autopush/main.py
+++ b/autopush/main.py
@@ -151,6 +151,9 @@ def _parse_connection(sysargs):
     parser.add_argument('--auto_ping_timeout',
                         help="Timeout in seconds for Websocket ping replys",
                         default=4, type=float, env_var="AUTO_PING_TIMEOUT")
+    parser.add_argument('--max_connections',
+                        help="The maximum number of concurrent connections.",
+                        default=0, type=int, env_var="MAX_CONNECTIONS")
 
     add_external_router_args(parser)
     add_shared_args(parser)
@@ -281,6 +284,7 @@ def connection_main(sysargs=None):
         openHandshakeTimeout=5,
         autoPingInterval=args.auto_ping_interval,
         autoPingTimeout=args.auto_ping_timeout,
+        maxConnections=args.max_connections
     )
     settings.factory = factory
 


### PR DESCRIPTION
Add max connections as a config argument to avoid server load over a
safe value. In case of a DOS attack, this would avoid a failure of
existing connections.

This PR doesn't include tests, since I couldn't figure a way to test it. I 
understand that a test for this would become a test for Autobahn, 
which would be the library's responsibility?

When I set the limit to 1, this results in a `503` with the message:
`maximum number of connections reached` on a second connection.

When the old connection is closed, a connection spot is open again. The
default  `0`, removes any soft limits on the number of connections.

Ref #104