### PR TITLE
[WIP] Provide the service enviornment information

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Features
   Some devices which use SimplePush routing offer a feature to wake on
   a carrier provided UDP ping. See issue #106 for details.
 
+* Provide service environment information
+  To help clients identify the service environment, server provides
+  it along with the hello message. See issue #50 for details.
+
 Bug Fixes
 ---------
 

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -98,6 +98,9 @@ def add_shared_args(parser):
                         env_var="LOG_LEVEL")
     parser.add_argument('--max_data', help="Max data segment length in bytes",
                         default=4096, env_var='MAX_DATA')
+    parser.add_argument('--env',
+                        help="The environment autopush is running under",
+                        default='development', env_var='AUTOPUSH_ENV')
 
 
 def add_external_router_args(parser):
@@ -296,6 +299,7 @@ def connection_main(sysargs=None):
         router_scheme="https" if args.router_ssl_key else "http",
         router_hostname=args.router_hostname,
         router_port=args.router_port,
+        env=args.env
     )
     setup_logging("Autopush")
 

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -62,6 +62,7 @@ class AutopushSettings(object):
                  max_data=4096,
                  # Reflected up from UDP Router
                  wake_timeout=0,
+                 env='development',
                  enable_cors=False):
         """Initialize the Settings object
 
@@ -150,6 +151,9 @@ class AutopushSettings(object):
             self.routers["apns"] = APNSRouter(self, router_conf["apns"])
         if 'gcm' in router_conf:
             self.routers["gcm"] = GCMRouter(self, router_conf["gcm"])
+
+        # Env
+        self.env = env
 
     def update(self, **kwargs):
         """Update the arguments, if a ``crypto_key`` is in kwargs then the

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -48,6 +48,7 @@ class WebsocketTestCase(unittest.TestCase):
         settings = AutopushSettings(
             hostname="localhost",
             statsd_host=None,
+            env="test",
         )
         self.proto.ap_settings = settings
         self.proto.sendMessage = self.send_mock = Mock()
@@ -556,6 +557,14 @@ class WebsocketTestCase(unittest.TestCase):
         d.addCallback(check_result)
         self._wait_for_close(d)
         return d
+
+    def test_hello_env(self):
+        self._connect()
+        self._send_message(dict(messageType="hello", channelIDs=[]))
+
+        def check_result(msg):
+            eq_(msg["env"], "test")
+        return self._check_response(check_result)
 
     def test_ping(self):
         self._connect()

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -502,7 +502,6 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         """Send a Python dict as a JSON string in a websocket message"""
 
         body['env'] = self.ap_settings.env
-
         self.sendMessage(json.dumps(body).encode('utf8'), False)
 
     #############################################################

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -500,6 +500,9 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
 
     def sendJSON(self, body):
         """Send a Python dict as a JSON string in a websocket message"""
+
+        body['env'] = self.ap_settings.env
+
         self.sendMessage(json.dumps(body).encode('utf8'), False)
 
     #############################################################

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -501,7 +501,9 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
     def sendJSON(self, body):
         """Send a Python dict as a JSON string in a websocket message"""
 
-        body['env'] = self.ap_settings.env
+        if body.get('messageType') == 'hello':
+            body['env'] = self.ap_settings.env
+
         self.sendMessage(json.dumps(body).encode('utf8'), False)
 
     #############################################################


### PR DESCRIPTION
In order for the clients to identify which service they are dealing with, provide the running environment in json responses. Being aware of the environment will help in debugging issues with applications.

This patch may need more tests. I tested it out with simplepush_test locally and added a basic test case.

Ref: #50 