### PR TITLE
Freeze mock to version `1.0.1`

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 nose
 coverage
-mock>=1.0.1
+mock==1.0.1
 -e git+https://github.com/habnabit/txstatsd.git@master#egg=txStatsD
 -e git+https://github.com/bbangert/moto.git@master#egg=moto
 flake8


### PR DESCRIPTION
In their recent upgrade, mock `assert_called` has started to fail, which
is being used in [various places](https://gist.github.com/crodjer/7646fb56f49efd363793) by our tests.

For now, this ensures that the test suite passes. Gradually, we can
upgrade to the latest `mock` by updating the `assert_called` calls. We
should upgrade because `assert_called` is something undocumented anyway:
<http://www.voidspace.org.uk/python/mock/mock.html>.