### PR TITLE
Add WebPush TTL's

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,11 +8,12 @@ Autopush Changelog
 Features
 --------
 
+* Add WebPush TTL scheme per spec (as of July 28th 2015). Issue #56.
 * Add WebPush style data delivery with crypto headers to connected clients.
   Each message is stored independently in a new message table, with the version
   and channel id still required to ack a message. The version is a UUID4 hex
   which is also echo'd back to the AppServer as a Location URL per the current
-  WebPush spec (as of July 28th 2015).
+  WebPush spec (as of July 28th 2015). Issue #57.
 * Add Sphinx docs with ReadTheDocs publishing. Issue #98.
   This change also includes a slight Metrics refactoring with a IMetrics
   interface, and renames MetricSink -> SinkMetrics for naming consistency.

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -1,4 +1,5 @@
 """Database Interaction"""
+import time
 import uuid
 from functools import wraps
 
@@ -263,7 +264,7 @@ class Message(object):
             return set([])
 
     @track_provisioned
-    def store_message(self, uaid, channel_id, data, headers, message_id):
+    def store_message(self, uaid, channel_id, data, headers, message_id, ttl):
         """Stores a message in the message table for the given uaid/channel with
         the message id"""
         self.table.put_item(data=dict(
@@ -271,6 +272,7 @@ class Message(object):
             chidmessageid="%s:%s" % (channel_id, message_id),
             data=data,
             headers=headers,
+            ttl=ttl+int(time.time()),
         ))
         return True
 

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -1,5 +1,4 @@
 """Database Interaction"""
-import time
 import uuid
 from functools import wraps
 
@@ -272,7 +271,7 @@ class Message(object):
             chidmessageid="%s:%s" % (channel_id, message_id),
             data=data,
             headers=headers,
-            ttl=ttl+int(time.time()),
+            ttl=ttl,
         ))
         return True
 

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -336,7 +336,7 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
         """errBack for router failures"""
         fail.trap(RouterException)
         exc = fail.value
-        if not str(exc.status_code).startswith('2'):
+        if exc.status_code < 200 or exc.status_code >= 300:
             # Only log non-2XX responses, we sometimes have to throw one to
             # stop processing even though its a 2XX response
             log.err(fail, **self._client_info())

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -408,7 +408,10 @@ class EndpointHandler(AutoendpointHandler):
             version = uuid.uuid4().hex
             data = self.request.body
 
-        ttl = self.request.headers.get("TTL", 0)
+        try:
+            ttl = int(self.request.headers.get("ttl", "0"))
+        except ValueError:
+            ttl = 0
         if data and len(data) > self.ap_settings.max_data:
             self.set_status(401)
             log.msg("Data too large", **self._client_info())

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -8,10 +8,11 @@ class RouterException(AutopushException):
 
     """
     def __init__(self, message, status_code=500, response_body="",
-                 router_data=None):
+                 router_data=None, headers={}):
         """Create a new RouterException"""
         super(AutopushException, self).__init__(message)
         self.status_code = status_code
+        self.headers = headers
         self.response_body = response_body or message
 
 

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -91,5 +91,5 @@ class WebPushRouter(SimpleRouter):
             data=notification.data,
             headers=self._crypto_headers(notification),
             message_id=notification.version,
-            ttl=notification.ttl,
+            ttl=notification.ttl+int(time.time()),
         )

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -6,6 +6,7 @@ table for retrieval by the client.
 
 """
 import json
+import time
 from StringIO import StringIO
 
 from twisted.internet.threads import deferToThread
@@ -62,6 +63,7 @@ class WebPushRouter(SimpleRouter):
                               "version": notification.version,
                               "data": notification.data,
                               "headers": self._crypto_headers(notification),
+                              "ttl": notification.ttl+int(time.time()),
                               })
         url = node_id + "/push/" + uaid
         d = self.ap_settings.agent.request(
@@ -80,6 +82,8 @@ class WebPushRouter(SimpleRouter):
         available.
 
         """
+        if notification.ttl == 0:
+            raise RouterException("Finished Routing", status_code=201)
         return deferToThread(
             self.ap_settings.message.store_message,
             uaid=uaid,
@@ -87,4 +91,5 @@ class WebPushRouter(SimpleRouter):
             data=notification.data,
             headers=self._crypto_headers(notification),
             message_id=notification.version,
+            ttl=notification.ttl,
         )

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -206,10 +206,11 @@ class MessageTestCase(unittest.TestCase):
 
         data1 = str(uuid.uuid4())
         data2 = str(uuid.uuid4())
+        ttl = int(time.time())+100
         time1, time2, time3 = self._nstime(), self._nstime(), self._nstime()+1
-        message.store_message(self.uaid, chid, data1, {}, time1)
-        message.store_message(self.uaid, chid2, data2, {}, time2)
-        message.store_message(self.uaid, chid2, data1, {}, time3)
+        message.store_message(self.uaid, chid, data1, {}, time1, ttl)
+        message.store_message(self.uaid, chid2, data2, {}, time2, ttl)
+        message.store_message(self.uaid, chid2, data1, {}, time3, ttl)
 
         all_messages = list(message.fetch_messages(self.uaid))
         eq_(len(all_messages), 3)
@@ -226,9 +227,10 @@ class MessageTestCase(unittest.TestCase):
         def make_messages(channel_id, count):
             m = []
             t = self._nstime()
+            ttl = int(time.time())+200
             for i in range(count):
                 m.append(
-                    (self.uaid, channel_id, str(uuid.uuid4()), {}, t+i)
+                    (self.uaid, channel_id, str(uuid.uuid4()), {}, t+i, ttl)
                 )
             return m
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -107,6 +107,27 @@ class EndpointTestCase(unittest.TestCase):
         self.finish_deferred.addCallback(handle_finish)
         return self.finish_deferred
 
+    def test_uaid_lookup_results_bad_ttl(self):
+        fresult = dict(router_type="test")
+        frouter = Mock(spec=Router)
+        frouter.route_notification = Mock()
+        frouter.route_notification.return_value = RouterResponse()
+        self.endpoint.chid = "fred"
+        self.request_mock.headers["ttl"] = "woops"
+        self.request_mock.headers["encryption"] = "stuff"
+        self.request_mock.headers["content-encoding"] = "aes128"
+        self.endpoint.ap_settings.routers["test"] = frouter
+        self.endpoint._uaid_lookup_results(fresult)
+
+        def handle_finish(value):
+            assert(frouter.route_notification.called)
+            args, kwargs = frouter.route_notification.call_args
+            notif = args[0]
+            assert(notif.ttl, 0)
+
+        self.finish_deferred.addCallback(handle_finish)
+        return self.finish_deferred
+
     def test_uaid_lookup_no_crypto_headers(self):
         fresult = dict(router_type="test")
         frouter = Mock(spec=Router)

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -81,7 +81,7 @@ class APNSRouterTestCase(unittest.TestCase):
         self.mock_apns = Mock(spec=apns.APNs)
         self.router = APNSRouter(settings, apns_config)
         self.router.apns = self.mock_apns
-        self.notif = Notification(10, "data", dummy_chid, None)
+        self.notif = Notification(10, "data", dummy_chid, None, 200)
         self.router_data = dict(router_data=dict(token="connect_data"))
 
     def test_register(self):
@@ -148,7 +148,7 @@ class GCMRouterTestCase(unittest.TestCase):
 
         gcm_config = {'apikey': '12345678abcdefg'}
         self.router = GCMRouter(settings, gcm_config)
-        self.notif = Notification(10, "data", dummy_chid, None)
+        self.notif = Notification(10, "data", dummy_chid, None, 200)
         self.router_data = dict(router_data=dict(token="connect_data"))
         mock_result = Mock(spec=gcmclient.gcm.Result)
         mock_result.canonical = dict()
@@ -254,7 +254,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         )
 
         self.router = SimpleRouter(settings, {})
-        self.notif = Notification(10, "data", dummy_chid, None)
+        self.notif = Notification(10, "data", dummy_chid, None, 200)
         mock_result = Mock(spec=gcmclient.gcm.Result)
         mock_result.canonical = dict()
         mock_result.failed = dict()
@@ -473,7 +473,7 @@ class WebPushRouterTestCase(unittest.TestCase):
             "encryption-key": "niftykey"
         }
         self.router = WebPushRouter(settings, {})
-        self.notif = Notification(10, "data", dummy_chid, headers)
+        self.notif = Notification(10, "data", dummy_chid, headers, 20)
         mock_result = Mock(spec=gcmclient.gcm.Result)
         mock_result.canonical = dict()
         mock_result.failed = dict()

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -317,7 +317,7 @@ class WebsocketTestCase(unittest.TestCase):
         # Stick an un-acked direct notification in
         self.proto.direct_updates[chid] = [
             Notification(channel_id=chid, version=str(uuid.uuid4()),
-                         headers={}, data="blah")
+                         headers={}, data="blah", ttl=200)
         ]
 
         # Apply some mocks
@@ -891,7 +891,7 @@ class WebsocketTestCase(unittest.TestCase):
 
         # Send ourself a notification
         payload = {"channelID": chid, "version": 10, "data": "bleh",
-                   "headers": {}}
+                   "headers": {}, "ttl": 20}
         self.proto.send_notifications(payload)
 
         # Check the call result
@@ -977,7 +977,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.use_webpush = True
         self.proto.direct_updates[chid] = [
             Notification(version="bleh", headers={}, data="meh",
-                         channel_id=chid)
+                         channel_id=chid, ttl=200)
         ]
 
         self.proto.ack_update(dict(
@@ -992,7 +992,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.direct_updates[chid] = []
         self.proto.updates_sent[chid] = [
             Notification(version="bleh", headers={}, data="meh",
-                         channel_id=chid)
+                         channel_id=chid, ttl=200)
         ]
 
         mock_defer = Mock()
@@ -1008,7 +1008,7 @@ class WebsocketTestCase(unittest.TestCase):
         self._connect()
         chid = str(uuid.uuid4())
         notif = Notification(version="bleh", headers={}, data="meh",
-                             channel_id=chid)
+                             channel_id=chid, ttl=200)
         self.proto.updates_sent[chid] = [notif]
         self.proto._handle_webpush_update_remove(None, chid, notif)
         eq_(self.proto.updates_sent[chid], [])
@@ -1017,7 +1017,7 @@ class WebsocketTestCase(unittest.TestCase):
         self._connect()
         chid = str(uuid.uuid4())
         notif = Notification(version="bleh", headers={}, data="meh",
-                             channel_id=chid)
+                             channel_id=chid, ttl=200)
         self.proto.updates_sent[chid] = None
         self.proto._handle_webpush_update_remove(None, chid, notif)
 
@@ -1168,7 +1168,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.use_webpush = True
         self.proto.updates_sent["chid"] = [
             Notification(channel_id="chid", data="bleh", headers={},
-                         version="now")
+                         version="now", ttl=200)
         ]
         self.proto.deferToLater = Mock()
         self.proto.process_notifications()
@@ -1216,7 +1216,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.updates_sent["asdf"] = []
 
         self.proto.finish_webpush_notifications([
-            dict(chidmessageid="asdf:fdsa", headers={}, data="bleh")
+            dict(chidmessageid="asdf:fdsa", headers={}, data="bleh", ttl=20)
         ])
         assert self.proto.process_notifications.called
 

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -86,7 +86,7 @@ def log_exception(func):
 
 
 class Notification(namedtuple("Notification",
-                              "channel_id data headers version")):
+                              "channel_id data headers version ttl")):
     """Parsed notification from the request"""
 
 
@@ -385,6 +385,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             data=notif.data,
             headers=notif.headers,
             message_id=notif.version,
+            ttl=notif.ttl,
         ).addErrback(self.log_err)
 
     def _save_simple_notif(self, channel_id, version):
@@ -631,7 +632,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             )
             self.updates_sent[chid].append(
                 Notification(channel_id=chid, version=version,
-                             data=notif["data"], headers=notif["headers"])
+                             data=notif["data"], headers=notif["headers"],
+                             ttl=notif["ttl"])
             )
             self.sendJSON(msg)
 
@@ -860,7 +862,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if self.use_webpush:
             self.direct_updates[chid].append(
                 Notification(channel_id=chid, version=version,
-                             data=update["data"], headers=update["headers"])
+                             data=update["data"], headers=update["headers"],
+                             ttl=update["ttl"])
             )
             self.sendJSON(dict(
                 messageType="notification",


### PR DESCRIPTION
Add WebPush TTL scheme per spec (as of July 28th 2015).

This is a relatively minor change to store the TTL value, and avoid storage of it if the TTL is set to 0. The spec is slightly ambiguous on whether a Location should still be returned if a TTL is 0 and it couldn't be delivered (such that no such resource exists, and its not clear if a NACK exists). So for now, no Location is returned if the message couldn't be delivered, the spec says POST always returns a 201 though, so, its still a 201.

To break off router execution if the TTL is 0, I threw a RouterException in the webpush router, and added a headers field for the possibility that in the future, a Location should still be returned in this case.

Closes #56.