### PR TITLE
Remove excessive exception logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Autopush Changelog
 ==================
 
+1.3.1 (**dev**)
+===============
+
+Bug Fixes
+---------
+
+* Fix RouterException to allow for non-logged responses. Change
+  RouterException's to only log actual exceptions that should be address in
+  bug-fixes. Issue #125.
+
 1.3.0 (2015-07-29)
 ==================
 

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -336,9 +336,7 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
         """errBack for router failures"""
         fail.trap(RouterException)
         exc = fail.value
-        if exc.status_code < 200 or exc.status_code >= 300:
-            # Only log non-2XX responses, we sometimes have to throw one to
-            # stop processing even though its a 2XX response
+        if exc.log_exception:
             log.err(fail, **self._client_info())
         self.set_status(exc.status_code)
         self.write(exc.response_body)

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -8,11 +8,12 @@ class RouterException(AutopushException):
 
     """
     def __init__(self, message, status_code=500, response_body="",
-                 router_data=None, headers={}):
+                 router_data=None, headers={}, log_exception=True):
         """Create a new RouterException"""
         super(AutopushException, self).__init__(message)
         self.status_code = status_code
         self.headers = headers
+        self.log_exception = log_exception
         self.response_body = response_body or message
 
 

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -88,7 +88,8 @@ class SimpleRouter(object):
                 yield deferToThread(router.clear_node,
                                     uaid_data).addErrback(self._eat_db_err)
                 raise RouterException("Node was invalid", status_code=503,
-                                      response_body="Retry Request")
+                                      response_body="Retry Request",
+                                      log_exception=False)
             if result.code == 200:
                 self.metrics.increment("router.broadcast.hit")
                 returnValue(self.delivered_response(notification))

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -44,7 +44,8 @@ class WebPushRouter(SimpleRouter):
 
     def _verify_channel(self, result, channel_id):
         if channel_id not in result:
-            raise RouterException("No such subscription", status_code=404)
+            raise RouterException("No such subscription", status_code=404,
+                                  log_exception=False)
 
     def preflight_check(self, uaid, channel_id):
         """Verifies this routing call can be done successfully"""
@@ -83,7 +84,8 @@ class WebPushRouter(SimpleRouter):
 
         """
         if notification.ttl == 0:
-            raise RouterException("Finished Routing", status_code=201)
+            raise RouterException("Finished Routing", status_code=201,
+                                  log_exception=False)
         return deferToThread(
             self.ap_settings.message.store_message,
             uaid=uaid,


### PR DESCRIPTION
Use log_exception on RouterException to determine if it should be logged (and flagged in Sentry).
Don't log common exception use, where the exception is not actually an actionable bug.

Closes Issue #125.