### PR TITLE
Integrate smoke-tests, also fixes bugs found as a result

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,19 @@
 Autopush Changelog
 ==================
 
-1.4.0 (**dev**)
+1.3.2 (**dev**)
 ===============
+
+Bug Fixes
+---------
+
+* Fix deferToLater to not call the function if it was cancelled using a
+  canceller function.
+* Fix finish_webpush_notifications to not immediately call
+  process_notifications as that will be called as needed after ack's have been
+  completed.
+* Fix process_ack to not call process_notifications when using webpush if there
+  are still remaining notifications to ack.
 
 Features
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Autopush Changelog
 ==================
 
+1.4.0 (**dev**)
+===============
+
+Features
+--------
+
+* Integrate simplepush_test smoke-test client with the main autopush test-suite
+  into the test-runner. Issue #119.
+
 1.3.1 (2015-08-04)
 ==================
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -123,7 +123,7 @@ class EndpointTestCase(unittest.TestCase):
             assert(frouter.route_notification.called)
             args, kwargs = frouter.route_notification.call_args
             notif = args[0]
-            assert(notif.ttl, 0)
+            assert(notif.ttl == 0)
 
         self.finish_deferred.addCallback(handle_finish)
         return self.finish_deferred

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -160,6 +160,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
         log.debug("%s body: %s", method, body)
         http.request(method, url.path, body, headers)
         resp = http.getresponse()
+        http.close()
         log.debug("%s Response: %s", method, resp.read())
         eq_(resp.status, status)
         if self.use_webpush and ttl != 0:

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -94,7 +94,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
         self.ws.send(msg)
         result = json.loads(self.ws.recv())
         log.debug("Recv: %s", result)
-        if self.uaid and self.uaid != result["uaid"]:  # pragme: nocover
+        if self.uaid and self.uaid != result["uaid"]:  # pragma: nocover
             log.debug("Mismatch on re-using uaid. Old: %s, New: %s",
                       self.uaid, result["uaid"])
             self.channels = {}
@@ -130,7 +130,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
         endpoint = self.channels[channel]
         url = urlparse.urlparse(endpoint)
         http = None
-        if url.scheme == "https":
+        if url.scheme == "https":  # pragma: nocover
             http = httplib.HTTPSConnection(url.netloc)
         else:
             http = httplib.HTTPConnection(url.netloc)

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -1,26 +1,66 @@
 import os
+import signal
 import subprocess
 from unittest.case import SkipTest
 
+import boto
+import psutil
 from twisted.trial import unittest
+from twisted.internet import reactor
 
-
+here_dir = os.path.abspath(os.path.dirname(__file__))
+root_dir = os.path.dirname(os.path.dirname(here_dir))
 moto_process = None
 
 
 def setUp():
-    if "SKIP_INTEGRATION" in os.environ:
+    boto_path = os.path.join(root_dir, "automock", "boto.cfg")
+    boto.config.load_from_path(boto_path)
+    if "SKIP_INTEGRATION" in os.environ:  # pragma: nocover
         raise SkipTest("Skipping integration tests")
     global moto_process
     cmd = "moto_server dynamodb2 -p 5000"
-    moto_process = subprocess.Popen(cmd)
+    moto_process = subprocess.Popen(cmd, shell=True, env=os.environ)
 
 
 def tearDown():
     global moto_process
-    moto_process.terminate()
+    # This kinda sucks, but its the only way to nuke the child procs
+    proc = psutil.Process(pid=moto_process.pid)
+    child_procs = proc.children(recursive=True)
+    for p in [proc] + child_procs:
+        os.kill(p.pid, signal.SIGTERM)
+    moto_process.wait()
+
+    # Clear out the boto config that was loaded so the rest of the tests run
+    # fine
+    for section in boto.config.sections():
+        boto.config.remove_section(section)
 
 
 class TestIntegration(unittest.TestCase):
+    def setUp(self):
+        from autobahn.twisted.websocket import WebSocketServerFactory
+        from autopush.settings import AutopushSettings
+        from autopush.websocket import SimplePushServerProtocol
+        settings = AutopushSettings(
+            hostname="localhost",
+            statsd_host=None,
+        )
+        factory = WebSocketServerFactory("ws://localhost:9010/")
+        factory.protocol = SimplePushServerProtocol
+        factory.protocol.ap_settings = settings
+        factory.setProtocolOptions(
+            webStatus=False,
+            maxFramePayloadSize=2048,
+            maxMessagePayloadSize=2048,
+            openHandshakeTimeout=5,
+        )
+        settings.factory = factory
+        self.websocket = reactor.listenTCP(9010, factory)
+
+    def tearDown(self):
+        self.websocket.stopListening()
+
     def test_basic(self):
         pass

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+from unittest.case import SkipTest
+
+from twisted.trial import unittest
+
+
+moto_process = None
+
+
+def setUp():
+    if "SKIP_INTEGRATION" in os.environ:
+        raise SkipTest("Skipping integration tests")
+    global moto_process
+    cmd = "moto_server dynamodb2 -p 5000"
+    moto_process = subprocess.Popen(cmd)
+
+
+def tearDown():
+    global moto_process
+    moto_process.terminate()
+
+
+class TestIntegration(unittest.TestCase):
+    def test_basic(self):
+        pass

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -195,9 +195,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
         self.ws.send(msg)
 
     def disconnect(self):
-        self.ws.send_close()
         self.ws.close()
-        self.ws = None
 
 
 class IntegrationBase(unittest.TestCase):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -557,6 +557,27 @@ class WebsocketTestCase(unittest.TestCase):
         d.addErrback(fail2)
         ok_(d is not None)
 
+    def test_deferToLater_cancel(self):
+        self._connect()
+
+        f = Deferred()
+
+        def dont_run():  # pragma: nocover
+            self.fail("This shouldn't run")
+
+        def trap_cancel(fail):
+            fail.trap(twisted.internet.defer.CancelledError)
+
+        def dont_run_callback(result):  # pragma: nocover
+            self.fail("Callback shouldn't run")
+
+        d = self.proto.deferToLater(0.2, dont_run)
+        d.addCallback(dont_run_callback)
+        d.addErrback(trap_cancel)
+        d.cancel()
+        reactor.callLater(0.2, lambda: f.callback(True))
+        return f
+
     def test_force_retry(self):
         self._connect()
 

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1208,7 +1208,6 @@ class WebsocketTestCase(unittest.TestCase):
             dict(chidmessageid="asdf:fdsa", headers={}, data="bleh", ttl=ttl)
         ])
         assert self.send_mock.called
-        assert self.proto.process_notifications.called
 
     def test_notif_finished_with_webpush_with_old_notifications(self):
         self._connect()
@@ -1224,7 +1223,6 @@ class WebsocketTestCase(unittest.TestCase):
         ])
         assert self.proto.force_retry.called
         assert not self.send_mock.called
-        assert self.proto.process_notifications.called
 
     def test_notification_results(self):
         # Populate the database for ourself

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -125,7 +125,6 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
             # Don't run if the deferred was cancelled already
             if d._cancelled:
-                d.errback(CancelledError)
                 return
             try:
                 result = func(*args, **kwargs)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -841,8 +841,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             # Resume consuming ack's
             self.transport.resumeProducing()
 
-        # When using webpush, we don't check again unless we have no
-        # outstanding notifications
+        # When using webpush, we don't check again if we have outstanding
+        # notifications
         if self.use_webpush and any(self.updates_sent.values()):
                 return
 

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -101,10 +101,6 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def deferToThread(self, func, *args, **kwargs):
         """deferToThread helper that tracks defers outstanding"""
         d = deferToThread(func, *args, **kwargs)
-
-        def trapCancel(fail):
-            fail.trap(CancelledError)
-
         self._callbacks.append(d)
 
         def f(result):
@@ -112,17 +108,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
                 self._callbacks.remove(d)
             return result
         d.addBoth(f)
-        d.addErrback(trapCancel)
         return d
 
     def deferToLater(self, when, func, *args, **kwargs):
         """deferToLater helper that tracks defers outstanding"""
         d = Deferred()
-
-        def trapCancel(fail):
-            fail.trap(CancelledError)
-
-        d.addErrback(trapCancel)
         self._callbacks.append(d)
 
         def f():
@@ -135,6 +125,9 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
                 d.errback(failure.Failure())
         reactor.callLater(when, f)
         return d
+
+    def trap_cancel(self, fail):
+        fail.trap(CancelledError)
 
     def force_retry(self, func, *args, **kwargs):
         """Forcefully retry a function in a thread until it doesn't error
@@ -556,15 +549,15 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         self._check_notifications = False
         self._more_notifications = True
 
-        # Prevent repeat calls
         if self.use_webpush:
             d = self.deferToThread(self.ap_settings.message.fetch_messages,
                                    self.uaid)
         else:
             d = self.deferToThread(
                 self.ap_settings.storage.fetch_notifications, self.uaid)
-        d.addErrback(self.error_notifications)
         d.addCallback(self.finish_notifications)
+        d.addErrback(self.trap_cancel)
+        d.addErrback(self.error_notifications)
         self._notification_fetch = d
 
     def error_notifications(self, fail):
@@ -580,6 +573,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         # Are we paused, try again later
         if self.paused:
             self.deferToLater(1, self.process_notifications)
+            return
 
         # Process notifications differently based on webpush style or not
         if self.use_webpush:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -32,6 +32,7 @@ itsdangerous==0.24
 mccabe==0.3.1
 pbr==1.3.0
 pluggy==0.3.0
+psutil==3.1.1
 pyOpenSSL==0.15.1
 pyasn1==0.1.8
 pyasn1-modules==0.0.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -48,7 +48,7 @@ translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 txaio==1.0.0
 virtualenv==13.1.0
-websocket-client==0.10.0
+websocket-client==0.32.0
 wsaccel==0.6.2
 wsgiref==0.1.2
 xmltodict==0.9.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -48,6 +48,7 @@ translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 txaio==1.0.0
 virtualenv==13.1.0
+websocket-client==0.10.0
 wsaccel==0.6.2
 wsgiref==0.1.2
 xmltodict==0.9.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = pypy,flake8
 [testenv]
 deps = -rtest-requirements.txt
 usedevelop = True
+passenv = SKIP_INTEGRATION
 commands =
     nosetests {posargs} autopush
 install_command = pip install --pre {opts} {packages}


### PR DESCRIPTION
Bug Fixes
---------

* Fix deferToLater to not call the function if it was cancelled using a
  canceller function.
* Fix finish_webpush_notifications to not immediately call
  process_notifications as that will be called as needed after ack's have been
  completed.
* Fix process_ack to not call process_notifications when using webpush if there
  are still remaining notifications to ack.

Features
--------

* Integrate simplepush_test smoke-test client with the main autopush test-suite
  into the test-runner. Issue #119.

Closes #119.