### PR TITLE
Remove adaptive ping, log connection losses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Autopush Changelog
 ==================
 
+1.4.0 (**dev**)
+===============
+
+Bug Fixes
+---------
+
+* Remove adaptive ping entirely. Send special close code and drop clients that
+  ping more frequently than 55 seconds (approx 1 min). This will result in
+  clients that ping too much being turned away for awhile, but will alleviate
+  data/battery issues in buggy mobile clients. Issue #103.
+
+Features
+--------
+
+* Log all disconnects, whether they were clean, the code, and the reason.
+
 1.3.2 (2015-08-11)
 ==================
 

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -549,6 +549,14 @@ class WebsocketTestCase(unittest.TestCase):
         f.addErrback(lambda x: d.errback(x))
         return d
 
+    def test_auto_ping(self):
+        self.proto.ping_time_out = False
+        self.proto.dropConnection = Mock()
+        self.proto.debugCodePaths = False
+        self.proto.onAutoPingTimeout()
+        ok_(self.proto.ping_time_out, True)
+        ok_(self.proto.dropConnection.called)
+
     def test_deferToLater(self):
         self._connect()
 

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -54,6 +54,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.sendClose = self.close_mock = Mock()
         self.proto.transport = self.transport_mock = Mock()
         self.proto.closeHandshakeTimeout = 0
+        self.proto.autoPingInterval = 300
         self.proto._force_retry = self.proto.force_retry
         settings.metrics = Mock(spec=Metrics)
 
@@ -530,15 +531,23 @@ class WebsocketTestCase(unittest.TestCase):
         f.addErrback(lambda x: d.errback(x))
         return d
 
-    def test_ping_pong_delay(self):
+    def test_ping_too_much(self):
         self._connect()
-        self.proto.last_ping = time.time() - 8
-        f = Deferred()
-        d = self.proto.process_ping()
-        # This should be a deferred
-        ok_(d is not None)
-        d.addBoth(lambda x: f.callback(x))
-        return f
+        self._send_message(dict(messageType="hello", channelIDs=[]))
+
+        d = Deferred()
+
+        def check_result(msg):
+            eq_(msg["status"], 200)
+            self.proto.last_ping = time.time() - 30
+            self.proto.sendClose = Mock()
+            self._send_message({})
+            ok_(self.proto.sendClose.called)
+            d.callback(True)
+
+        f = self._check_response(check_result)
+        f.addErrback(lambda x: d.errback(x))
+        return d
 
     def test_deferToLater(self):
         self._connect()


### PR DESCRIPTION
* Remove adaptive ping entirely. Send special close code and drop clients that
  ping more frequently than 55 seconds (approx 1 min). This will result in
  clients that ping too much being turned away for awhile, but will alleviate
  data/battery issues in buggy mobile clients. Issue #103.
* Log all disconnects, whether they were clean, the code, and the reason.

Closes #103.