### PR TITLE
Message deletion endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Autopush Changelog
 ==================
 
+1.6.0 (**dev**)
+===============
+
+Features
+--------
+
+* Add an endpoint for deleting undelivered messages. PR #131.
+
 1.5.1 (2015-09-02)
 ==================
 

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -6,7 +6,11 @@ from autobahn.twisted.resource import WebSocketResource
 from twisted.internet import reactor, task
 from twisted.web.server import Site
 
-from autopush.endpoint import (EndpointHandler, RegistrationHandler)
+from autopush.endpoint import (
+    EndpointHandler,
+    MessageHandler,
+    RegistrationHandler,
+)
 from autopush.health import (HealthHandler, StatusHandler)
 from autopush.logging import setup_logging
 from autopush.settings import AutopushSettings
@@ -368,6 +372,7 @@ def endpoint_main(sysargs=None):
     # Endpoint HTTP router
     site = cyclone.web.Application([
         (r"/push/([^\/]+)", EndpointHandler, dict(ap_settings=settings)),
+        (r"/m/([^\/]+)", MessageHandler, dict(ap_settings=settings)),
         # PUT /register/ => connect info
         # GET /register/uaid => chid + endpoint
         (r"/register(?:/(.+))?", RegistrationHandler,

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -156,3 +156,7 @@ class AutopushSettings(object):
         """ Create an endpoint from the identifiers"""
         return self.endpoint_url + '/push/' + \
             self.fernet.encrypt((uaid + ':' + chid).encode('utf8'))
+
+    def make_message_endpoint(self, uaid, chid, message_id):
+        return '%s/m/%s' % (self.endpoint_url, self.fernet.encrypt(':'.join([
+            uaid, chid, str(message_id)]).encode('utf8')))

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -286,7 +286,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 200)
         d.addBoth(verify_deliver)
         return d
@@ -314,7 +314,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 202)
         d.addBoth(verify_deliver)
         return d
@@ -344,7 +344,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 202)
         d.addBoth(verify_deliver)
         return d
@@ -373,7 +373,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 202)
         d.addBoth(verify_deliver)
         return d
@@ -388,7 +388,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 202)
             assert(self.router_mock.get_uaid.called)
         d.addBoth(verify_deliver)
@@ -407,7 +407,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 202)
             assert(self.router_mock.clear_node.called)
             nk = simple.node_key(router_data["node_id"])
@@ -431,7 +431,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 202)
             assert(self.router_mock.clear_node.called)
             nk = simple.node_key(router_data["node_id"])
@@ -451,7 +451,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 200)
             self.router.metrics.increment.assert_called_with(
                 "router.broadcast.save_hit"
@@ -499,7 +499,7 @@ class WebPushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(result):
-            ok_(result, RouterResponse)
+            ok_(isinstance(result, RouterResponse))
             eq_(result.status_code, 201)
             self.router.metrics.increment.assert_called_with(
                 "router.broadcast.save_hit"


### PR DESCRIPTION
Here's a sketch of a `DELETE` implementation for messages. Still needs tests, but I thought I'd extract what I have so far.

This only deletes messages from storage, not direct updates. I thought about having it handle those, too, but that'd mean an extra routing table read to look up the home node. That seems fine, since deleting a message sent to a connected client is inherently racy, and it's far more likely the message will be delivered before the connection node receives the "oops, don't send that" signal.

f? @bbangert @jrconlin