### PR TITLE
Omit headers and data for empty messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Features
 
 * Add /status HTTP endpoint for autopush. Issue #136.
 * Log all disconnects, whether they were clean, the code, and the reason.
+* Allow encryption headers to be omitted for blank messages. Issue #132.
 
 1.3.3 (2015-08-18)
 ==================

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -263,16 +263,21 @@ class Message(object):
             return set([])
 
     @track_provisioned
-    def store_message(self, uaid, channel_id, data, headers, message_id, ttl):
+    def store_message(self, uaid, channel_id, message_id, ttl, data=None,
+                      headers=None):
         """Stores a message in the message table for the given uaid/channel with
         the message id"""
-        self.table.put_item(data=dict(
+        item = dict(
             uaid=uaid,
             chidmessageid="%s:%s" % (channel_id, message_id),
             data=data,
             headers=headers,
             ttl=ttl,
-        ))
+        )
+        if data:
+            item["headers"] = headers
+            item["data"] = data
+        self.table.put_item(data=item)
         return True
 
     @track_provisioned

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -396,17 +396,18 @@ class EndpointHandler(AutoendpointHandler):
         if router_key == "simplepush":
             version, data = parse_request_params(self.request)
         else:
+            data = self.request.body
             if router_key == "webpush":
-                # We need crypto headers
+                # We need crypto headers for messages with payloads.
                 req_fields = ["content-encoding", "encryption"]
-                if not all([x in self.request.headers for x in req_fields]):
+                if data and not all([x in self.request.headers
+                                     for x in req_fields]):
                     self.set_status(401)
                     log.msg("Missing Crypto headers", **self._client_info())
                     self.write("Missing crypto headers.")
                     return self.finish()
 
             version = uuid.uuid4().hex
-            data = self.request.body
 
         try:
             ttl = int(self.request.headers.get("ttl", "0"))

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -208,9 +208,9 @@ class MessageTestCase(unittest.TestCase):
         data2 = str(uuid.uuid4())
         ttl = int(time.time())+100
         time1, time2, time3 = self._nstime(), self._nstime(), self._nstime()+1
-        message.store_message(self.uaid, chid, data1, {}, time1, ttl)
-        message.store_message(self.uaid, chid2, data2, {}, time2, ttl)
-        message.store_message(self.uaid, chid2, data1, {}, time3, ttl)
+        message.store_message(self.uaid, chid, time1, ttl, data1, {})
+        message.store_message(self.uaid, chid2, time2, ttl, data2, {})
+        message.store_message(self.uaid, chid2, time3, ttl, data1, {})
 
         all_messages = list(message.fetch_messages(self.uaid))
         eq_(len(all_messages), 3)
@@ -230,7 +230,7 @@ class MessageTestCase(unittest.TestCase):
             ttl = int(time.time())+200
             for i in range(count):
                 m.append(
-                    (self.uaid, channel_id, str(uuid.uuid4()), {}, t+i, ttl)
+                    (self.uaid, channel_id, str(uuid.uuid4()), ttl, {}, t+i)
                 )
             return m
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -129,11 +129,12 @@ class EndpointTestCase(unittest.TestCase):
         return self.finish_deferred
 
     # Crypto headers should be required for Web Push...
-    def test_webpush_uaid_lookup_no_crypto_headers(self):
+    def test_webpush_uaid_lookup_no_crypto_headers_with_data(self):
         fresult = dict(router_type="webpush")
         frouter = self.settings.routers["webpush"]
         frouter.route_notification.return_value = RouterResponse()
         self.endpoint.chid = "fred"
+        self.request_mock.body = b"stuff"
         self.endpoint._uaid_lookup_results(fresult)
 
         def handle_finish(value):
@@ -142,7 +143,21 @@ class EndpointTestCase(unittest.TestCase):
         self.finish_deferred.addCallback(handle_finish)
         return self.finish_deferred
 
-    # ...But can be omitted for other router types.
+    # ...But can be omitted for blank messages...
+    def test_webpush_uaid_lookup_no_crypto_headers_without_data(self):
+        fresult = dict(router_type="webpush")
+        frouter = self.settings.routers["webpush"]
+        frouter.route_notification.return_value = RouterResponse()
+        self.endpoint.chid = "fred"
+        self.endpoint._uaid_lookup_results(fresult)
+
+        def handle_finish(value):
+            assert(frouter.route_notification.called)
+
+        self.finish_deferred.addCallback(handle_finish)
+        return self.finish_deferred
+
+    # ...And for other router types.
     def test_other_uaid_lookup_no_crypto_headers(self):
         fresult = dict(router_type="test")
         frouter = Mock(spec=Router)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -657,16 +657,18 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
                     self.ap_settings.message.delete_message, self.uaid, chid,
                     version)
                 continue
+            data = notif.get("data")
             msg = dict(
                 messageType="notification",
                 channelID=chid,
                 version=version,
-                data=notif["data"],
-                headers=notif["headers"],
             )
+            if data:
+                msg["data"] = data
+                msg["headers"] = notif["headers"]
             self.updates_sent[chid].append(
                 Notification(channel_id=chid, version=version,
-                             data=notif["data"], headers=notif["headers"],
+                             data=notif["data"], headers=notif.get("headers"),
                              ttl=notif["ttl"])
             )
             self.sendJSON(msg)


### PR DESCRIPTION
This lets folks use Web Push as if it were Simple Push. For that case, I don't think there's much point to sending an encrypted empty string.

Closes #132.