### PR TITLE
Add check to avoid delivering to ourselves.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Autopush Changelog
 Bug Fixes
 ---------
 
+* Fix _notify_node to not attempt delivering to ourselves at the end of the
+  client connection.
 * Remove adaptive ping entirely. Send special close code and drop clients that
   ping more frequently than 55 seconds (approx 1 min). This will result in
   clients that ping too much being turned away for awhile, but will alleviate

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -437,6 +437,10 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if not node_id:
             return
 
+        # If it's ourselves, we can stop
+        if result.get("connected_at") == self.connected_at:
+            return
+
         # Send the notify to the node
         url = node_id + "/notif/" + self.uaid
         d = self.ap_settings.agent.request(


### PR DESCRIPTION
* Fix _notify_node to not attempt delivering to ourselves at the end of the
  client connection.
