### PR TITLE
Expose Web Push headers for CORS requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Autopush Changelog
 ==================
 
+1.4.1 (**dev**)
+===============
+
+Bug Fixes
+---------
+
+* Expose Web Push headers for CORS requests. PR #148.
+
 1.4.0 (2015-08-27)
 ==================
 

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -246,6 +246,8 @@ def parse_request_params(request):
 class AutoendpointHandler(cyclone.web.RequestHandler):
     """Common overrides for Autoendpoint handlers"""
     cors_methods = ""
+    cors_request_headers = []
+    cors_response_headers = []
 
     #############################################################
     #                    Cyclone API Methods
@@ -261,7 +263,12 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
         """Common request preparation"""
         if self.ap_settings.cors:
             self.set_header("Access-Control-Allow-Origin", "*")
-            self.set_header("Access-Control-Allow-Methods", self.cors_methods)
+            self.set_header("Access-Control-Allow-Methods",
+                            self.cors_methods)
+            self.set_header("Access-Control-Allow-Headers",
+                            ",".join(self.cors_request_headers))
+            self.set_header("Access-Control-Expose-Headers",
+                            ",".join(self.cors_response_headers))
 
     def write_error(self, code, **kwargs):
         """Write the error (otherwise unhandled exception when dealing with
@@ -353,7 +360,10 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
 
 
 class EndpointHandler(AutoendpointHandler):
-    cors_methods = "PUT"
+    cors_methods = "POST,PUT"
+    cors_request_headers = ["content-encoding", "encryption",
+                            "encryption-key", "content-type"]
+    cors_response_headers = ["location"]
 
     #############################################################
     #                    Cyclone HTTP Methods

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -435,37 +435,55 @@ class EndpointTestCase(unittest.TestCase):
     def test_cors(self):
         ch1 = "Access-Control-Allow-Origin"
         ch2 = "Access-Control-Allow-Methods"
+        ch3 = "Access-Control-Allow-Headers"
+        ch4 = "Access-Control-Expose-Headers"
         endpoint = self.endpoint
         endpoint.ap_settings.cors = False
         assert endpoint._headers.get(ch1) != "*"
-        assert endpoint._headers.get(ch2) != "PUT"
+        assert endpoint._headers.get(ch2) != "POST,PUT"
+        assert endpoint._headers.get(ch3) != ("content-encoding,encryption,"
+                                              "encryption-key,content-type")
+        assert endpoint._headers.get(ch4) != "location"
 
         endpoint.clear_header(ch1)
         endpoint.clear_header(ch2)
         endpoint.ap_settings.cors = True
         self.endpoint.prepare()
         eq_(endpoint._headers[ch1], "*")
-        eq_(endpoint._headers[ch2], "PUT")
+        eq_(endpoint._headers[ch2], "POST,PUT")
+        eq_(endpoint._headers[ch3], "content-encoding,encryption,"
+            "encryption-key,content-type")
+        eq_(endpoint._headers[ch4], "location")
 
     def test_cors_head(self):
         ch1 = "Access-Control-Allow-Origin"
         ch2 = "Access-Control-Allow-Methods"
+        ch3 = "Access-Control-Allow-Headers"
+        ch4 = "Access-Control-Expose-Headers"
         endpoint = self.endpoint
         endpoint.ap_settings.cors = True
         endpoint.prepare()
         endpoint.head(None)
         eq_(endpoint._headers[ch1], "*")
-        eq_(endpoint._headers[ch2], "PUT")
+        eq_(endpoint._headers[ch2], "POST,PUT")
+        eq_(endpoint._headers[ch3], "content-encoding,encryption,"
+            "encryption-key,content-type")
+        eq_(endpoint._headers[ch4], "location")
 
     def test_cors_options(self):
         ch1 = "Access-Control-Allow-Origin"
         ch2 = "Access-Control-Allow-Methods"
+        ch3 = "Access-Control-Allow-Headers"
+        ch4 = "Access-Control-Expose-Headers"
         endpoint = self.endpoint
         endpoint.ap_settings.cors = True
         endpoint.prepare()
         endpoint.options(None)
         eq_(endpoint._headers[ch1], "*")
-        eq_(endpoint._headers[ch2], "PUT")
+        eq_(endpoint._headers[ch2], "POST,PUT")
+        eq_(endpoint._headers[ch3], "content-encoding,encryption,"
+            "encryption-key,content-type")
+        eq_(endpoint._headers[ch4], "location")
 
     @patch_logger
     def test_write_error(self, log_mock):


### PR DESCRIPTION
This lets our tests make cross-origin requests directly.