### PR TITLE
Fix for #151 allow for larger cyclone messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,13 @@ Bug Fixes
 ---------
 
 * Expose Web Push headers for CORS requests. PR #148.
+* Expose argument for larger websocket message sizes (to fix issue #151)
+  Clients with a large number of channelIDs (50+) can cause the initial
+  connection to fail. A proper solution is to modify the client to not send
+  ChannelIDs as part of the "hello" message, but being able to increase the
+  message size on the server should keep the server from dying up front.
+  This fix should only impact clients with large numbers of registered channels,
+  notably, devs.
 
 1.4.0 (2015-08-27)
 ==================

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -168,6 +168,10 @@ def _parse_connection(sysargs):
     parser.add_argument('--max_connections',
                         help="The maximum number of concurrent connections.",
                         default=0, type=int, env_var="MAX_CONNECTIONS")
+    parser.add_argument('--max_message_size',
+                        help="The maximum size that messages from client " +
+                        "can be (e.g. header, data, json formatting, etc.)",
+                        default=2048, type=int, env_var="MAX_MESSAGE_SIZE")
 
     add_external_router_args(parser)
     add_shared_args(parser)
@@ -296,8 +300,8 @@ def connection_main(sysargs=None):
     factory.protocol.ap_settings = settings
     factory.setProtocolOptions(
         webStatus=False,
-        maxFramePayloadSize=2048,
-        maxMessagePayloadSize=2048,
+        maxFramePayloadSize=args.max_message_size,
+        maxMessagePayloadSize=args.max_message_size,
         openHandshakeTimeout=5,
         autoPingInterval=args.auto_ping_interval,
         autoPingTimeout=args.auto_ping_timeout,


### PR DESCRIPTION
Allow for servers to specify larger default message buffer sizes
(Current recommendation is to raise them to 3072 or larger until the
client lands which turns off client send of ChannelIDs as part of the
"hello")

r? @bbangert @kitcambridge