### PR TITLE
Feature/avoid dict reallocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,9 @@ Features
 
 * Memory profile benchmarking on a connection, displays in test results. Issue
   #142.
-
+* Refactor of attribute assignment to the Websocket instance to avoid memory
+  increases due to Python reallocating the underlying dict datastructure. Issue
+  #149.
 
 1.4.1 (2015-08-31)
 ==================

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -35,6 +35,7 @@ twisted.internet.base.DelayedCall.debug = True
 
 
 def setUp():
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
     boto_path = os.path.join(root_dir, "automock", "boto.cfg")
     boto.config.load_from_path(boto_path)
     if "SKIP_INTEGRATION" in os.environ:  # pragma: nocover
@@ -239,7 +240,7 @@ class IntegrationBase(unittest.TestCase):
 
         # Websocket server
         self._ws_url = "ws://localhost:9010/"
-        factory = WebSocketServerFactory(self._ws_url)
+        factory = WebSocketServerFactory(self._ws_url, debug=False)
         factory.protocol = SimplePushServerProtocol
         factory.protocol.ap_settings = settings
         factory.setProtocolOptions(
@@ -264,7 +265,8 @@ class IntegrationBase(unittest.TestCase):
             (r"/notif/([^\/]+)(/([^\/]+))?", n),
         ],
             default_host=settings.router_hostname,
-            log_function=skip_request_logging
+            log_function=skip_request_logging,
+            debug=False,
         )
         self.ws_website = reactor.listenTCP(9030, ws_site)
 
@@ -277,7 +279,8 @@ class IntegrationBase(unittest.TestCase):
              dict(ap_settings=settings)),
         ],
             default_host=settings.hostname,
-            log_function=skip_request_logging
+            log_function=skip_request_logging,
+            debug=False,
         )
         self.website = reactor.listenTCP(9020, site)
         self._settings = settings

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -384,7 +384,9 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         outstanding deferreds related to this connection"""
         try:
             uaid = self.ps.uaid
-        except AttributeError:
+        except AttributeError:  # pragma: nocover
+            # Sometimes in odd production cases, onClose will be called without
+            # onConnect being called to set this up.
             uaid = None
         self._shutdown_ran = True
         self.ps._should_stop = True

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -93,9 +93,84 @@ class Notification(namedtuple("Notification",
     """Parsed notification from the request"""
 
 
+class PushState(object):
+    implements(IProducer)
+
+    __slots__ = [
+        '_callbacks',
+        '_user_agent',
+        '_base_tags',
+        '_should_stop',
+        '_paused',
+        'metrics',
+        'uaid',
+        'last_ping',
+        'check_storage',
+        'use_webpush',
+        'connected_at',
+        'ping_time_out',
+        '_check_notifications',
+        '_more_notifications',
+        '_notification_fetch',
+        '_register',
+        'updates_sent',
+        'direct_updates',
+        'pauseProducing',
+        'resumeProducing',
+        'stopProducing',
+    ]
+
+    def __init__(self, settings, request):
+        self._callbacks = []
+
+        if request:
+            self._user_agent = request.headers.get("user-agent")
+        else:
+            self._user_agent = None
+        self._base_tags = []
+        if self._user_agent:
+            self._base_tags.append("user-agent:%s" % self._user_agent)
+        self._should_stop = False
+        self._paused = False
+        self.metrics = settings.metrics
+        self.metrics.increment("client.socket.connect",
+                               tags=self._base_tags or None)
+        self.uaid = None
+        self.last_ping = 0
+        self.check_storage = False
+        self.use_webpush = False
+        self.connected_at = ms_time()
+        self.ping_time_out = False
+
+        self._check_notifications = False
+        self._more_notifications = False
+
+        # Hanger for common actions we defer
+        self._notification_fetch = None
+        self._register = None
+
+        # Reflects Notification's sent that haven't been ack'd
+        self.updates_sent = {}
+
+        # Track Notification's we don't need to delete separately
+        self.direct_updates = {}
+
+    def pauseProducing(self):
+        """IProducer implementation tracking if we should pause output"""
+        self._paused = True
+
+    def resumeProducing(self):
+        """IProducer implementation tracking when we should resume output"""
+        self._paused = False
+
+    def stopProducing(self):
+        """IProducer implementation tracking when we should stop"""
+        self._paused = True
+        self._should_stop = True
+
+
 class SimplePushServerProtocol(WebSocketServerProtocol):
     """Main Websocket Connection Protocol"""
-    implements(IProducer)
 
     # Testing purposes
     parent_class = WebSocketServerProtocol
@@ -104,11 +179,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def deferToThread(self, func, *args, **kwargs):
         """deferToThread helper that tracks defers outstanding"""
         d = deferToThread(func, *args, **kwargs)
-        self._callbacks.append(d)
+        self.ps._callbacks.append(d)
 
         def f(result):
-            if d in self._callbacks:
-                self._callbacks.remove(d)
+            if d in self.ps._callbacks:
+                self.ps._callbacks.remove(d)
             return result
         d.addBoth(f)
         return d
@@ -120,11 +195,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
         d = Deferred(canceller=cancel)
         d._cancelled = False
-        self._callbacks.append(d)
+        self.ps._callbacks.append(d)
 
         def f():
-            if d in self._callbacks:
-                self._callbacks.remove(d)
+            if d in self.ps._callbacks:
+                self.ps._callbacks.remove(d)
 
             # Don't run if the deferred was cancelled already
             if d._cancelled:
@@ -163,42 +238,29 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def base_tags(self):
         """Property that uses None if there's no tags due to a DataDog library
         bug"""
-        return self._base_tags if self._base_tags else None
+        return self.ps._base_tags if self.ps._base_tags else None
 
     def log_err(self, failure, **kwargs):
         """Log a twisted failure out through twisted's log.err"""
         log.err(failure, **kwargs)
 
-    def pauseProducing(self):
-        """IProducer implementation tracking if we should pause output"""
-        self._paused = True
-
-    def resumeProducing(self):
-        """IProducer implementation tracking when we should resume output"""
-        self._paused = False
-
-    def stopProducing(self):
-        """IProducer implementation tracking when we should stop"""
-        self._paused = True
-        self._should_stop = True
-
     @property
     def paused(self):
         """Indicates if we are paused for output production or not"""
-        return self._paused
+        return self.ps._paused
 
     @log_exception
     def _sendAutoPing(self):
         """Override for sanity checking during auto-ping interval"""
-        if not self.uaid:
+        if not self.ps.uaid:
             # No uaid yet, drop the connection
-            self.metrics.increment("client.autoping.no_uaid",
-                                   tags=self.base_tags)
+            self.ps.metrics.increment("client.autoping.no_uaid",
+                                      tags=self.base_tags)
             self.sendClose()
-        elif self.ap_settings.clients.get(self.uaid) != self:
+        elif self.ap_settings.clients.get(self.ps.uaid) != self:
             # UAID, but we're not in clients anymore for some reason
-            self.metrics.increment("client.autoping.invalid_client",
-                                   tags=self.base_tags)
+            self.ps.metrics.increment("client.autoping.invalid_client",
+                                      tags=self.base_tags)
             self.sendClose()
         return WebSocketServerProtocol._sendAutoPing(self)
 
@@ -218,8 +280,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return
 
         # Uh-oh, we have not been shut-down properly, report detailed data
-        self.metrics.increment("client.error.sendClose_failed",
-                               tags=self.base_tags)
+        self.ps.metrics.increment("client.error.sendClose_failed",
+                                  tags=self.base_tags)
         log.msg("sendClose failed to result in onClose", state=str(self.state))
 
         self.transport.abortConnection()
@@ -233,50 +295,19 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return
 
         # abortConnection still has failed to shut this down one minute later
-        self.metrics.increment("client.error.abortConnection_failed",
-                               tags=self.base_tags)
+        self.ps.metrics.increment("client.error.abortConnection_failed",
+                                  tags=self.base_tags)
 
     @log_exception
     def onConnect(self, request):
         """autobahn onConnect handler for when a connection has started"""
         track_object(self, msg="onConnect Start")
+        self.ps = PushState(settings=self.ap_settings, request=request)
 
         # Setup ourself to handle producing the data
         self.transport.bufferSize = 2 * 1024
-        self.transport.registerProducer(self, True)
+        self.transport.registerProducer(self.ps, True)
 
-        self._callbacks = []
-
-        if request:
-            self._user_agent = request.headers.get("user-agent")
-        else:
-            self._user_agent = None
-        self._base_tags = []
-        if self._user_agent:
-            self._base_tags.append("user-agent:%s" % self._user_agent)
-        self._should_stop = False
-        self._paused = False
-        self.metrics = self.ap_settings.metrics
-        self.metrics.increment("client.socket.connect", tags=self.base_tags)
-        self.uaid = None
-        self.last_ping = 0
-        self.check_storage = False
-        self.use_webpush = False
-        self.connected_at = ms_time()
-        self.ping_time_out = False
-
-        self._check_notifications = False
-        self._more_notifications = False
-
-        # Hanger for common actions we defer
-        self._notification_fetch = None
-        self._register = None
-
-        # Reflects Notification's sent that haven't been ack'd
-        self.updates_sent = {}
-
-        # Track Notification's we don't need to delete separately
-        self.direct_updates = {}
         track_object(self, msg="onConnect End")
 
     #############################################################
@@ -318,7 +349,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return
 
         # Without a UAID, hello must be next
-        if not self.uaid:
+        if not self.ps.uaid:
             return self.process_hello(data)
 
         # Ping's get a ping reply
@@ -344,17 +375,20 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def onAutoPingTimeout(self):
         """Override to track that this shut-down is from a ping timeout"""
-        self.ping_time_out = True
+        self.ps.ping_time_out = True
         WebSocketServerProtocol.onAutoPingTimeout(self)
 
     @log_exception
     def onClose(self, wasClean, code, reason):
         """autobahn onClose handler for shutting down the connection and any
         outstanding deferreds related to this connection"""
-        uaid = getattr(self, "uaid", None)
+        try:
+            uaid = self.ps.uaid
+        except AttributeError:
+            uaid = None
         self._shutdown_ran = True
-        self._should_stop = True
-        self._check_notifications = False
+        self.ps._should_stop = True
+        self.ps._check_notifications = False
 
         # Log out the disconnect reason
         if uaid:
@@ -363,32 +397,33 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def cleanUp(self, wasClean, code, reason):
         """Thorough clean-up method to cancel all remaining deferreds, and send
         connection metrics in"""
-        self.metrics.increment("client.socket.disconnect", tags=self.base_tags)
-        elapsed = (ms_time() - self.connected_at) / 1000.0
-        self.metrics.timing("client.socket.lifespan", duration=elapsed,
-                            tags=self.base_tags)
+        self.ps.metrics.increment("client.socket.disconnect",
+                                  tags=self.base_tags)
+        elapsed = (ms_time() - self.ps.connected_at) / 1000.0
+        self.ps.metrics.timing("client.socket.lifespan", duration=elapsed,
+                               tags=self.base_tags)
 
         # Log out the connection close and info
         log.msg("Connection Close", code=code, reason=reason,
                 was_clean=wasClean, lifespan=elapsed,
-                ping_time_out=self.ping_time_out)
+                ping_time_out=self.ps.ping_time_out)
 
         # Cleanup our client entry
-        if self.uaid and self.ap_settings.clients.get(self.uaid) == self:
-            del self.ap_settings.clients[self.uaid]
+        if self.ps.uaid and self.ap_settings.clients.get(self.ps.uaid) == self:
+            del self.ap_settings.clients[self.ps.uaid]
 
         # Cancel any outstanding deferreds
-        for d in self._callbacks:
+        for d in self.ps._callbacks:
             d.cancel()
 
         # Attempt to deliver any notifications not originating from storage
-        if self.direct_updates:
+        if self.ps.direct_updates:
             defers = []
-            if self.use_webpush:
-                for notifs in self.direct_updates.values():
+            if self.ps.use_webpush:
+                for notifs in self.ps.direct_updates.values():
                     defers.extend(map(self._save_webpush_notif, notifs))
             else:
-                for chid, version in self.direct_updates.items():
+                for chid, version in self.ps.direct_updates.items():
                     defers.append(self._save_simple_notif(chid, version))
 
             # Tag on the notifier once everything has been stored
@@ -396,14 +431,14 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             dl.addBoth(self._lookup_node)
 
         # Delete and remove remaining dicts and lists
-        del self.direct_updates
-        del self.updates_sent
+        del self.ps.direct_updates
+        del self.ps.updates_sent
 
     def _save_webpush_notif(self, notif):
         """Save a direct_update webpush style notification"""
         return deferToThread(
             self.ap_settings.message.store_message,
-            uaid=self.uaid,
+            uaid=self.ps.uaid,
             channel_id=notif.channel_id,
             data=notif.data,
             headers=notif.headers,
@@ -415,7 +450,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         """Save a simplepush notification"""
         return deferToThread(
             self.ap_settings.storage.save_notification,
-            uaid=self.uaid,
+            uaid=self.ps.uaid,
             chid=channel_id,
             version=version,
         ).addErrback(self.log_err)
@@ -426,7 +461,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         # Locate the node that has this client connected
         d = deferToThread(
             self.ap_settings.router.get_uaid,
-            self.uaid
+            self.ps.uaid
         )
         d.addCallback(self._notify_node)
         d.addErrback(self.log_err, extra="Failed to get UAID for redeliver")
@@ -435,8 +470,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         """Checks the result of lookup node to send the notify if the client is
         connected elsewhere now"""
         if not result:
-            self.metrics.increment("error.notify_uaid_failure",
-                                   tags=self.base_tags)
+            self.ps.metrics.increment("error.notify_uaid_failure",
+                                      tags=self.base_tags)
             return
 
         node_id = result.get("node_id")
@@ -444,11 +479,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return
 
         # If it's ourselves, we can stop
-        if result.get("connected_at") == self.connected_at:
+        if result.get("connected_at") == self.ps.connected_at:
             return
 
         # Send the notify to the node
-        url = node_id + "/notif/" + self.uaid
+        url = node_id + "/notif/" + self.ps.uaid
         d = self.ap_settings.agent.request(
             "PUT",
             url.encode("utf8"),
@@ -478,31 +513,31 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if cmd != "hello":
             return self.sendClose()
 
-        if self.uaid:
+        if self.ps.uaid:
             return self.returnError("hello", "duplicate hello", 401)
 
         uaid = data.get("uaid")
-        self.use_webpush = data.get("use_webpush", False)
-        router_type = "webpush" if self.use_webpush else "simplepush"
-        if self.use_webpush:
-            self.updates_sent = defaultdict(lambda: [])
-            self.direct_updates = defaultdict(lambda: [])
+        self.ps.use_webpush = data.get("use_webpush", False)
+        router_type = "webpush" if self.ps.use_webpush else "simplepush"
+        if self.ps.use_webpush:
+            self.ps.updates_sent = defaultdict(lambda: [])
+            self.ps.direct_updates = defaultdict(lambda: [])
 
         _, uaid = validate_uaid(uaid)
-        self.uaid = uaid
+        self.ps.uaid = uaid
 
         self.transport.pauseProducing()
         user_item = dict(
-            uaid=self.uaid,
+            uaid=self.ps.uaid,
             node_id=self.ap_settings.router_url,
-            connected_at=self.connected_at,
+            connected_at=self.ps.connected_at,
             router_type=router_type,
         )
         d = self.deferToThread(self.ap_settings.router.register_user,
                                user_item)
         d.addCallback(self._check_other_nodes)
         d.addErrback(self.err_hello)
-        self._register = d
+        self.ps._register = d
         return d
 
     def err_hello(self, failure):
@@ -523,9 +558,9 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             self.sendMessage(json.dumps(msg).encode('utf8'), False)
             return
 
-        existing = self.ap_settings.clients.get(self.uaid)
+        existing = self.ap_settings.clients.get(self.ps.uaid)
         if existing:
-            if self.connected_at <= existing.connected_at:
+            if self.ps.connected_at <= existing.ps.connected_at:
                 self.sendClose()
                 return
             else:
@@ -536,7 +571,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             node_id = previous["node_id"]
             last_connect = previous.get("connected_at")
             if last_connect and node_id != self.ap_settings.router_url:
-                url = "%s/notif/%s/%s" % (node_id, self.uaid, last_connect)
+                url = "%s/notif/%s/%s" % (node_id, self.ps.uaid, last_connect)
                 d = self.ap_settings.agent.request(
                     "DELETE",
                     url.encode("utf8"),
@@ -550,21 +585,21 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def finish_hello(self, *args):
         """callback for successful hello message, that sends hello reply"""
-        self._register = None
-        msg = {"messageType": "hello", "uaid": self.uaid, "status": 200}
+        self.ps._register = None
+        msg = {"messageType": "hello", "uaid": self.ps.uaid, "status": 200}
         if self.autoPingInterval:
             msg["ping"] = self.autoPingInterval
-        if self.use_webpush:
+        if self.ps.use_webpush:
             msg["use_webpush"] = True
-        self.ap_settings.clients[self.uaid] = self
+        self.ap_settings.clients[self.ps.uaid] = self
         self.sendJSON(msg)
-        self.metrics.increment("updates.client.hello", tags=self.base_tags)
+        self.ps.metrics.increment("updates.client.hello", tags=self.base_tags)
         self.process_notifications()
 
     def process_notifications(self):
         """Run a notification check against storage"""
         # Bail immediately if we are closed.
-        if self._should_stop:
+        if self.ps._should_stop:
             return
 
         # Are we paused? Try again later.
@@ -574,29 +609,29 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return
 
         # Webpush with any outstanding storage-based must all be cleared
-        if self.use_webpush and any(self.updates_sent.values()):
+        if self.ps.use_webpush and any(self.ps.updates_sent.values()):
             d = self.deferToLater(1, self.process_notifications)
             d.addErrback(self.trap_cancel)
             return
 
         # Are we already running?
-        if self._notification_fetch:
+        if self.ps._notification_fetch:
             # Cancel the prior, last one wins
-            self._notification_fetch.cancel()
+            self.ps._notification_fetch.cancel()
 
-        self._check_notifications = False
-        self._more_notifications = True
+        self.ps._check_notifications = False
+        self.ps._more_notifications = True
 
-        if self.use_webpush:
+        if self.ps.use_webpush:
             d = self.deferToThread(self.ap_settings.message.fetch_messages,
-                                   self.uaid)
+                                   self.ps.uaid)
         else:
             d = self.deferToThread(
-                self.ap_settings.storage.fetch_notifications, self.uaid)
+                self.ap_settings.storage.fetch_notifications, self.ps.uaid)
         d.addCallback(self.finish_notifications)
         d.addErrback(self.trap_cancel)
         d.addErrback(self.error_notifications)
-        self._notification_fetch = d
+        self.ps._notification_fetch = d
 
     def error_notifications(self, fail):
         """errBack for notification check failing"""
@@ -606,7 +641,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def finish_notifications(self, notifs):
         """callback for processing notifications from storage"""
-        self._notification_fetch = None
+        self.ps._notification_fetch = None
 
         # Are we paused, try again later
         if self.paused:
@@ -614,7 +649,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return
 
         # Process notifications differently based on webpush style or not
-        if self.use_webpush:
+        if self.ps.use_webpush:
             return self.finish_webpush_notifications(notifs)
 
         updates = []
@@ -626,28 +661,28 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             version = int(s['version'])
             if self._newer_notification_sent(chid, version):
                 continue
-            if chid in self.direct_updates:
+            if chid in self.ps.direct_updates:
                 # We're going to send a newer one, ignore the direct older
                 # one for acks
-                del self.direct_updates[chid]
-            self.updates_sent[chid] = version
+                del self.ps.direct_updates[chid]
+            self.ps.updates_sent[chid] = version
             updates.append({"channelID": chid, "version": version})
         if updates:
             msg = {"messageType": "notification", "updates": updates}
             self.sendJSON(msg)
 
         # Were we told to check notifications again?
-        if self._check_notifications:
-            self._check_notifications = False
+        if self.ps._check_notifications:
+            self.ps._check_notifications = False
             self.deferToLater(1, self.process_notifications)
 
     def finish_webpush_notifications(self, notifs):
         """webpush notification processor"""
         if not notifs:
             # No more notifications, we can stop.
-            self._more_notifications = False
-            if self._check_notifications:
-                self._check_notifications = False
+            self.ps._more_notifications = False
+            if self.ps._check_notifications:
+                self.ps._check_notifications = False
                 self.deferToLater(1, self.process_notifications)
             return
 
@@ -660,8 +695,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             # If the TTL is too old, don't deliver and fire a delete off
             if now >= notif["ttl"]:
                 self.force_retry(
-                    self.ap_settings.message.delete_message, self.uaid, chid,
-                    version)
+                    self.ap_settings.message.delete_message, self.ps.uaid,
+                    chid, version)
                 continue
             data = notif.get("data")
             msg = dict(
@@ -672,7 +707,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             if data:
                 msg["data"] = data
                 msg["headers"] = notif["headers"]
-            self.updates_sent[chid].append(
+            self.ps.updates_sent[chid].append(
                 Notification(channel_id=chid, version=version,
                              data=notif["data"], headers=notif.get("headers"),
                              ttl=notif["ttl"])
@@ -681,8 +716,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def _send_ping(self):
         """Helper for ping sending that tracks when the ping was sent"""
-        self.last_ping = time.time()
-        self.metrics.increment("updates.client.ping", tags=self.base_tags)
+        self.ps.last_ping = time.time()
+        self.ps.metrics.increment("updates.client.ping", tags=self.base_tags)
         return self.sendMessage("{}", False)
 
     def process_ping(self):
@@ -699,7 +734,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
         """
         now = time.time()
-        last_ping_ago = now - self.last_ping
+        last_ping_ago = now - self.ps.last_ping
         if last_ping_ago >= 55:
             self._send_ping()
         else:
@@ -716,7 +751,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             return self.bad_message("register")
         self.transport.pauseProducing()
 
-        d = self.deferToThread(self.ap_settings.make_endpoint, self.uaid, chid)
+        d = self.deferToThread(self.ap_settings.make_endpoint, self.ps.uaid,
+                               chid)
         d.addCallback(self.finish_register, chid)
         d.addErrback(self.error_register)
         return d
@@ -729,9 +765,9 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def finish_register(self, endpoint, chid):
         """callback for successful endpoint creation, sends register reply"""
-        if self.use_webpush:
+        if self.ps.use_webpush:
             d = self.deferToThread(self.ap_settings.message.register_channel,
-                                   self.uaid, chid)
+                                   self.ps.uaid, chid)
             d.addCallback(self.send_register_finish, endpoint, chid)
             return d
         else:
@@ -745,7 +781,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
                "status": 200
                }
         self.sendJSON(msg)
-        self.metrics.increment("updates.client.register", tags=self.base_tags)
+        self.ps.metrics.increment("updates.client.register",
+                                  tags=self.base_tags)
 
     def process_unregister(self, data):
         """Process an unregister message"""
@@ -757,28 +794,28 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         except ValueError:
             return self.bad_message("unregister")
 
-        self.metrics.increment("updates.client.unregister",
-                               tags=self.base_tags)
+        self.ps.metrics.increment("updates.client.unregister",
+                                  tags=self.base_tags)
 
         # Clear out any existing tracked messages for this channel
-        if self.use_webpush:
-            self.direct_updates[chid] = []
-            self.updates_sent[chid] = []
+        if self.ps.use_webpush:
+            self.ps.direct_updates[chid] = []
+            self.ps.updates_sent[chid] = []
         else:
-            self.direct_updates.pop(chid, None)
-            self.updates_sent.pop(chid, None)
+            self.ps.direct_updates.pop(chid, None)
+            self.ps.updates_sent.pop(chid, None)
 
-        if self.use_webpush:
+        if self.ps.use_webpush:
             # Unregister the channel, delete all messages stored
             self.force_retry(self.ap_settings.message.unregister_channel,
-                             self.uaid, chid)
+                             self.ps.uaid, chid)
             self.force_retry(
                 self.ap_settings.message.delete_messages_for_channel,
-                self.uaid, chid)
+                self.ps.uaid, chid)
         else:
             # Delete any record from storage, we don't wait for this
             self.force_retry(self.ap_settings.storage.delete_notification,
-                             self.uaid, chid)
+                             self.ps.uaid, chid)
 
         data["status"] = 200
         self.sendJSON(data)
@@ -798,7 +835,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if not chid or not version:
             return
 
-        if self.use_webpush:
+        if self.ps.use_webpush:
             return self._handle_webpush_ack(chid, version)
         else:
             return self._handle_simple_ack(chid, version)
@@ -806,15 +843,15 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def _handle_webpush_ack(self, chid, version):
         """Handle clearing out a webpush ack"""
         ver_filter = lambda x: x.version == version
-        found = filter(ver_filter, self.direct_updates[chid])
+        found = filter(ver_filter, self.ps.direct_updates[chid])
         if found:
-            self.direct_updates[chid].remove(found[0])
+            self.ps.direct_updates[chid].remove(found[0])
             return
 
-        found = filter(ver_filter, self.updates_sent[chid])
+        found = filter(ver_filter, self.ps.updates_sent[chid])
         if found:
             d = self.force_retry(self.ap_settings.message.delete_message,
-                                 self.uaid, chid, version)
+                                 self.ps.uaid, chid, version)
             # We don't remove the update until we know the delete ran
             # This is because we don't use range queries on dynamodb and we
             # need to make sure this notification is deleted from the db before
@@ -829,22 +866,23 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
         """
         try:
-            self.updates_sent[chid].remove(notif)
+            self.ps.updates_sent[chid].remove(notif)
         except AttributeError:
             pass
 
     def _handle_simple_ack(self, chid, version):
         """Handle clearing out a simple ack"""
-        if chid in self.direct_updates and \
-           self.direct_updates[chid] <= version:
-            del self.direct_updates[chid]
+        if chid in self.ps.direct_updates and \
+           self.ps.direct_updates[chid] <= version:
+            del self.ps.direct_updates[chid]
             return
-        if chid in self.updates_sent and self.updates_sent[chid] <= version:
-            del self.updates_sent[chid]
+        if chid in self.ps.updates_sent and \
+           self.ps.updates_sent[chid] <= version:
+            del self.ps.updates_sent[chid]
         else:
             return
         return self.force_retry(self.ap_settings.storage.delete_notification,
-                                self.uaid, chid, version)
+                                self.ps.uaid, chid, version)
 
     def process_ack(self, data):
         """Process an ack message, delete notifications from storage if
@@ -853,7 +891,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if not updates or not isinstance(updates, list):
             return
 
-        self.metrics.increment("updates.client.ack", tags=self.base_tags)
+        self.ps.metrics.increment("updates.client.ack", tags=self.base_tags)
         defers = filter(None, map(self.ack_update, updates))
 
         if defers:
@@ -871,11 +909,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
         # When using webpush, we don't check again if we have outstanding
         # notifications
-        if self.use_webpush and any(self.updates_sent.values()):
+        if self.ps.use_webpush and any(self.ps.updates_sent.values()):
                 return
 
         # Should we check again?
-        if self._check_notifications or self._more_notifications:
+        if self.ps._check_notifications or self.ps._more_notifications:
             self.process_notifications()
 
     def bad_message(self, typ):
@@ -885,8 +923,8 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
     def _newer_notification_sent(self, channel_id, version):
         """Returns whether a newer channel_id/version has already been sent"""
-        return self.updates_sent.get(channel_id, 0) > version or \
-            self.direct_updates.get(channel_id, 0) > version
+        return self.ps.updates_sent.get(channel_id, 0) > version or \
+            self.ps.direct_updates.get(channel_id, 0) > version
 
     ####################################
     # Utility function for external use
@@ -898,11 +936,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
 
         """
         chid, version = (update["channelID"], update["version"])
-        if not self.use_webpush and \
+        if not self.ps.use_webpush and \
            self._newer_notification_sent(chid, version):
             return
 
-        if self.use_webpush:
+        if self.ps.use_webpush:
             response = dict(
                 messageType="notification",
                 channelID=chid,
@@ -912,14 +950,14 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
             if data:
                 response["data"] = data
                 response["headers"] = update["headers"]
-            self.direct_updates[chid].append(
+            self.ps.direct_updates[chid].append(
                 Notification(channel_id=chid, version=version,
                              data=data, headers=update.get("headers"),
                              ttl=update["ttl"])
             )
             self.sendJSON(response)
         else:
-            self.direct_updates[chid] = version
+            self.ps.direct_updates[chid] = version
             msg = {"messageType": "notification", "updates": [update]}
             self.sendJSON(msg)
 


### PR DESCRIPTION
* Refactor of attribute assignment to the Websocket instance to avoid memory
  increases due to Python reallocating the underlying dict datastructure. Issue
  #149.

Closes #149.

@kitcambridge, @jrconlin r?