### PR TITLE
Bug/metrics restore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,13 @@
 Autopush Changelog
 ==================
 
-1.5.0 (**dev**)
-===============
+1.5.0 (2015-09-02)
+==================
+
+Bug Fixes
+---------
+
+* Don't cancel a deferred that was already called.
 
 Features
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Features
 * Refactor of attribute assignment to the Websocket instance to avoid memory
   increases due to Python reallocating the underlying dict datastructure. Issue
   #149.
+* Add close_handshake_timeout option, with default of 0 to let our own close
+  timer handle clean-up.
 
 1.4.1 (2015-08-31)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,6 @@ Bug Fixes
 * Don't cancel a deferred that was already called.
 * Restore logging of simplepush successfull/stored delivery based on status.
 * Restore updates.handled endpoint timer to track time to deliver.
-* Remove logging of connection closing.
 
 Features
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Bug Fixes
 ---------
 
 * Don't cancel a deferred that was already called.
+* Restore logging of simplepush successfull/stored delivery based on status.
+* Restore updates.handled endpoint timer to track time to deliver.
+* Remove logging of connection closing.
 
 Features
 --------

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import sys
+import time
 
 import twisted.internet.base
 from cryptography.fernet import Fernet, InvalidToken
@@ -89,6 +90,7 @@ class EndpointTestCase(unittest.TestCase):
 
         d = self.finish_deferred = Deferred()
         self.endpoint.finish = lambda: d.callback(True)
+        self.endpoint.start_time = time.time()
 
     def test_uaid_lookup_results(self):
         fresult = dict(router_type="test")

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -279,11 +279,6 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if hasattr(self, "_shutdown_ran"):
             return
 
-        # Uh-oh, we have not been shut-down properly, report detailed data
-        self.ps.metrics.increment("client.error.sendClose_failed",
-                                  tags=self.base_tags)
-        log.msg("sendClose failed to result in onClose", state=str(self.state))
-
         self.transport.abortConnection()
         # Add a last callback to verify onClose finally was run
         reactor.callLater(60, self.verifyNuke)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -405,11 +405,6 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         self.ps.metrics.timing("client.socket.lifespan", duration=elapsed,
                                tags=self.base_tags)
 
-        # Log out the connection close and info
-        log.msg("Connection Close", code=code, reason=reason,
-                was_clean=wasClean, lifespan=elapsed,
-                ping_time_out=self.ps.ping_time_out)
-
         # Cleanup our client entry
         if self.ps.uaid and self.ap_settings.clients.get(self.ps.uaid) == self:
             del self.ap_settings.clients[self.ps.uaid]

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -377,9 +377,10 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if self.uaid and self.ap_settings.clients.get(self.uaid) == self:
             del self.ap_settings.clients[self.uaid]
 
-        # Cancel any outstanding deferreds
+        # Cancel any outstanding deferreds that weren't already called
         for d in self._callbacks:
-            d.cancel()
+            if not d.called:
+                d.cancel()
 
         # Attempt to deliver any notifications not originating from storage
         if self.direct_updates:

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -279,6 +279,11 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
         if hasattr(self, "_shutdown_ran"):
             return
 
+        # Uh-oh, we have not been shut-down properly, report detailed data
+        self.ps.metrics.increment("client.error.sendClose_failed",
+                                  tags=self.base_tags)
+        log.msg("sendClose failed to result in onClose", state=str(self.state))
+
         self.transport.abortConnection()
         # Add a last callback to verify onClose finally was run
         reactor.callLater(60, self.verifyNuke)


### PR DESCRIPTION
* Don't cancel a deferred that was already called.
* Restore logging of simplepush successfull/stored delivery based on status.
* Restore updates.handled endpoint timer to track time to deliver.
* Remove logging of connection closing.
* Add changelog for close connection timer.
* Remove metric logging of sendClose timer since its now the default.

Closes #154, #155.

@kitcambridge, @jrconlin r?