### PR TITLE
Up close handshake and add chid logging to endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Features
   #149.
 * Add close_handshake_timeout option, with default of 0 to let our own close
   timer handle clean-up.
+* Up defult close handshake timer to 10 seconds for slower clients.
 
 1.4.1 (2015-08-31)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Features
 * Add close_handshake_timeout option, with default of 0 to let our own close
   timer handle clean-up.
 * Up default close handshake timer to 10 seconds for slower clients.
+* Add channel id logging to endpoint.
 
 1.4.1 (2015-08-31)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Features
   #149.
 * Add close_handshake_timeout option, with default of 0 to let our own close
   timer handle clean-up.
-* Up defult close handshake timer to 10 seconds for slower clients.
+* Up default close handshake timer to 10 seconds for slower clients.
 
 1.4.1 (2015-08-31)
 ==================

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -316,6 +316,7 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
                                                   self.request.remote_ip),
             "uaid_hash": self.uaid_hash,
             "router_key": getattr(self, "router_key", ""),
+            "channel_id": getattr(self, "chid", ""),
         }
 
     #############################################################

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -268,7 +268,7 @@ class SimplePushServerProtocol(WebSocketServerProtocol):
     def sendClose(self, code=None, reason=None):
         """Override to add tracker that ensures the connection is truly
         torn down"""
-        reactor.callLater(5+self.closeHandshakeTimeout, self.nukeConnection)
+        reactor.callLater(10+self.closeHandshakeTimeout, self.nukeConnection)
         return WebSocketServerProtocol.sendClose(self, code, reason)
 
     @log_exception


### PR DESCRIPTION
* Up default close handshake timer to 10 seconds for slower clients.
* Add channel id logging to endpoint.

@kitcambridge, @jrconlin r?