### PR TITLE
Use the message token as the message ID

### DIFF
--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -17,7 +17,6 @@ from repoze.lru import LRUCache
 from twisted.internet.threads import deferToThread
 from twisted.internet.defer import (
     inlineCallbacks,
-    maybeDeferred,
     returnValue,
 )
 from twisted.internet.error import (
@@ -58,10 +57,6 @@ class SimpleRouter(object):
         """Verifies this routing call can be done successfully"""
         return True
 
-    def prepare_notification(self, uaid, notification):
-        """Prepares a notification for delivery."""
-        return notification
-
     def stored_response(self, notification):
         return RouterResponse(202, "Notification Stored")
 
@@ -79,8 +74,6 @@ class SimpleRouter(object):
 
         # Preflight check, hook used by webpush to verify channel id
         yield self.preflight_check(uaid, notification.channel_id)
-        notification = yield maybeDeferred(self.prepare_notification, uaid,
-                                           notification)
 
         # Node_id is present, attempt delivery.
         # - Send Notification to node

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -8,10 +8,8 @@ table for retrieval by the client.
 import json
 import time
 from StringIO import StringIO
-from collections import namedtuple
 
 from twisted.internet.threads import deferToThread
-from twisted.internet.defer import (inlineCallbacks, returnValue)
 from twisted.web.client import FileBodyProducer
 
 from autopush.protocol import IgnoreBody
@@ -19,28 +17,14 @@ from autopush.router.interface import RouterException, RouterResponse
 from autopush.router.simple import SimpleRouter
 
 
-class Notification(namedtuple("Notification",
-                   "version data channel_id headers ttl location")):
-    """Incoming WebPush notification"""
-
-
 class WebPushRouter(SimpleRouter):
     """SimpleRouter subclass to store individual messages appropriately"""
 
-    @inlineCallbacks
-    def prepare_notification(self, uaid, notification):
-        location = yield deferToThread(self.ap_settings.make_message_endpoint,
-                                       uaid, notification.channel_id,
-                                       notification.version)
-        returnValue(Notification(version=notification.version,
-                                 data=notification.data,
-                                 channel_id=notification.channel_id,
-                                 headers=notification.headers,
-                                 ttl=notification.ttl, location=location))
-
     def delivered_response(self, notification):
+        location = "%s/m/%s" % (self.ap_settings.endpoint_url,
+                                notification.version)
         return RouterResponse(status_code=201, response_body="",
-                              headers={"Location": notification.location})
+                              headers={"Location": location})
     stored_response = delivered_response
 
     def _crypto_headers(self, notification):

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -156,7 +156,3 @@ class AutopushSettings(object):
         """ Create an endpoint from the identifiers"""
         return self.endpoint_url + '/push/' + \
             self.fernet.encrypt((uaid + ':' + chid).encode('utf8'))
-
-    def make_message_endpoint(self, uaid, chid, message_id):
-        return '%s/m/%s' % (self.endpoint_url, self.fernet.encrypt(':'.join([
-            'm', uaid, chid, str(message_id)]).encode('utf8')))

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -109,7 +109,7 @@ class MessageTestCase(unittest.TestCase):
         return self.finish_deferred
 
     def test_delete_token_wrong_kind(self):
-        self.fernet_mock.decrypt.return_value = "r:123:456:789"
+        self.fernet_mock.decrypt.return_value = "r:123:456"
 
         def handle_finish(result):
             self.status_mock.assert_called_with(401)
@@ -120,21 +120,21 @@ class MessageTestCase(unittest.TestCase):
         return self.finish_deferred
 
     def test_delete_success(self):
-        self.fernet_mock.decrypt.return_value = "m:123:456:789"
+        self.fernet_mock.decrypt.return_value = "m:123:456"
         self.message_mock.configure_mock(**{
             "delete_message.return_value": True})
 
         def handle_finish(result):
             self.message_mock.delete_message.assert_called_with(
-                "123", "456", "789")
+                "123", "456", "123-456")
             self.status_mock.assert_called_with(204)
         self.finish_deferred.addCallback(handle_finish)
 
-        self.message.delete('')
+        self.message.delete("123-456")
         return self.finish_deferred
 
     def test_delete_db_error(self):
-        self.fernet_mock.decrypt.return_value = "m:123:456:789"
+        self.fernet_mock.decrypt.return_value = "m:123:456"
         self.message_mock.configure_mock(**{
             "delete_message.side_effect":
             ProvisionedThroughputExceededException(None, None)})


### PR DESCRIPTION
I realized we don't need a separate message ID; we can just use the encrypted token as the DynamoDB hash key. Since each token uses a 128-bit IV, it's as unique as a UUID. We still decrypt and verify the token to extract the UAID and channel ID; we just use the original, encrypted form as the message ID.

This is particularly helpful for receipts, where we need to send push promises containing the message URL. By reusing the token as the message ID (and version), we avoid having to store and pass around the URL. It also makes for shorter message URLs, and drops `prepare_notification`—which I didn't really like.

@bbangert, @jrconlin r?