### PR TITLE
Rename `SimplePushServerProtocol` to `PushServerProtocol`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Bug Fixes
   sendClose success. Remove final verifyNuke as its never run in the several
   months it was in, indicating that abortConnection is 100% effective.
   Issue #161.
+* Rename `SimplePushServerProtocol` to `PushServerProtocol`. Issue #117.
 
 1.5.1 (2015-09-02)
 ==================

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -17,7 +17,7 @@ from autopush.settings import AutopushSettings
 from autopush.ssl import AutopushSSLContextFactory
 from autopush.utils import str2bool
 from autopush.websocket import (
-    SimplePushServerProtocol,
+    PushServerProtocol,
     RouterHandler,
     NotificationHandler,
     periodic_reporter,
@@ -304,7 +304,7 @@ def connection_main(sysargs=None):
         debug=args.debug,
         debugCodePaths=args.debug,
     )
-    factory.protocol = SimplePushServerProtocol
+    factory.protocol = PushServerProtocol
     factory.protocol.ap_settings = settings
     factory.setProtocolOptions(
         webStatus=False,

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -255,7 +255,7 @@ class IntegrationBase(unittest.TestCase):
         )
         from autopush.settings import AutopushSettings
         from autopush.websocket import (
-            SimplePushServerProtocol,
+            PushServerProtocol,
             RouterHandler,
             NotificationHandler,
             DefaultResource,
@@ -273,7 +273,7 @@ class IntegrationBase(unittest.TestCase):
         # Websocket server
         self._ws_url = "ws://localhost:9010/"
         factory = WebSocketServerFactory(self._ws_url, debug=False)
-        factory.protocol = SimplePushServerProtocol
+        factory.protocol = PushServerProtocol
         factory.protocol.ap_settings = settings
         factory.setProtocolOptions(
             webStatus=False,

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -19,7 +19,7 @@ from twisted.trial import unittest
 from autopush.settings import AutopushSettings
 from autopush.websocket import (
     PushState,
-    SimplePushServerProtocol,
+    PushServerProtocol,
     RouterHandler,
     Notification,
     NotificationHandler,
@@ -43,7 +43,7 @@ def tearDown():
 class WebsocketTestCase(unittest.TestCase):
     def setUp(self):
         twisted.internet.base.DelayedCall.debug = True
-        self.proto = SimplePushServerProtocol()
+        self.proto = PushServerProtocol()
 
         settings = AutopushSettings(
             hostname="localhost",

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -169,7 +169,7 @@ class PushState(object):
         self._should_stop = True
 
 
-class SimplePushServerProtocol(WebSocketServerProtocol):
+class PushServerProtocol(WebSocketServerProtocol):
     """Main Websocket Connection Protocol"""
 
     # Testing purposes

--- a/docs/api/websocket.rst
+++ b/docs/api/websocket.rst
@@ -8,7 +8,7 @@
 Websocket Protocol
 ++++++++++++++++++
 
-.. autoclass:: SimplePushServerProtocol
+.. autoclass:: PushServerProtocol
     :members:
     :special-members: __init__
     :private-members:


### PR DESCRIPTION
Nice, trivial change. Closes #117.

@bbangert r?