### PR TITLE
Reset UAIDs for clients that change their router type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Autopush Changelog
 ==================
 
 1.7.0 (**dev**)
-==================
+===============
 
 Features
 --------
@@ -12,6 +12,10 @@ Features
   Some devices which use SimplePush routing offer a feature to wake on
   a carrier provided UDP ping. See issue #106 for details.
 
+Bug Fixes
+---------
+
+* Reset UAIDs for clients that change their router type. PR #167.
 
 1.6.0 (2015-09-14)
 ==================


### PR DESCRIPTION
If an existing client opts in to data delivery via the `use_webpush` flag, we should reset its ID so that its existing subscriptions are invalidated. (It's possible for the client to keep track of this, too; I just thought it would be cleaner for the server to handle it, since we already store the router type).

@bbangert, @jrconlin r?