### PR TITLE
Use Codecov for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
   - "pypy"
 install:
-  - pip install coverage nose mock moto python-coveralls tox
+  - pip install coverage nose mock moto codecov tox
 script: tox
 after_success:
-  - coveralls
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ AutoPush
 .. image:: https://travis-ci.org/mozilla-services/autopush.svg?branch=master
     :target: https://travis-ci.org/mozilla-services/autopush
 
-.. image:: https://coveralls.io/repos/mozilla-services/autopush/badge.svg
-  :target: https://coveralls.io/r/mozilla-services/autopush
+.. image:: https://codecov.io/github/mozilla-services/autopush/coverage.svg
+  :target: https://codecov.io/github/mozilla-services/autopush
 
 Mozilla Push server and Push Endpoint utilizing PyPy, twisted, and DynamoDB.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ autopush
 .. image:: https://travis-ci.org/mozilla-services/autopush.svg?branch=master
     :target: https://travis-ci.org/mozilla-services/autopush
 
-.. image:: https://coveralls.io/repos/mozilla-services/autopush/badge.svg
-  :target: https://coveralls.io/r/mozilla-services/autopush
+.. image:: https://codecov.io/github/mozilla-services/autopush/coverage.svg
+  :target: https://codecov.io/github/mozilla-services/autopush
 
 Mozilla Push server and Push Endpoint utilizing PyPy, twisted, and DynamoDB.
 


### PR DESCRIPTION
Coveralls hasn't been happy for a while. The Esprima folks seem to like Codecov; let's give it a try.