### PR TITLE
Clarify endpoint response status codes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Bug Fixes
 ---------
 
 * Reset UAIDs for clients that change their router type. PR #167.
+* Respond with status code 413 for payloads that exceed the maximum size,
+  404 for invalid tokens, and 400 for missing encryption headers. PR #170.
 
 1.6.0 (2015-09-14)
 ==================

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -371,7 +371,7 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
     def _token_err(self, fail):
         """errBack for token decryption fail"""
         fail.trap(InvalidToken, ValueError)
-        self.set_status(401)
+        self.set_status(404)
         log.msg("Invalid token", **self._client_info())
         self.write("Invalid token")
         self.finish()
@@ -484,7 +484,7 @@ class EndpointHandler(AutoendpointHandler):
                 req_fields = ["content-encoding", "encryption"]
                 if data and not all([x in self.request.headers
                                      for x in req_fields]):
-                    self.set_status(401)
+                    self.set_status(400)
                     log.msg("Missing Crypto headers", **self._client_info())
                     self.write("Missing crypto headers.")
                     return self.finish()
@@ -494,7 +494,7 @@ class EndpointHandler(AutoendpointHandler):
         except ValueError:
             ttl = 0
         if data and len(data) > self.ap_settings.max_data:
-            self.set_status(401)
+            self.set_status(413)
             log.msg("Data too large", **self._client_info())
             self.write("Data too large")
             return self.finish()

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -90,7 +90,7 @@ class MessageTestCase(unittest.TestCase):
             "decrypt.side_effect": InvalidToken})
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(401)
+            self.status_mock.assert_called_with(404)
             self.write_mock.assert_called_with('Invalid token')
         self.finish_deferred.addCallback(handle_finish)
 
@@ -101,7 +101,7 @@ class MessageTestCase(unittest.TestCase):
         self.fernet_mock.decrypt.return_value = "123:456"
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(401)
+            self.status_mock.assert_called_with(404)
             self.write_mock.assert_called_with('Invalid token')
         self.finish_deferred.addCallback(handle_finish)
 
@@ -112,7 +112,7 @@ class MessageTestCase(unittest.TestCase):
         self.fernet_mock.decrypt.return_value = "r:123:456"
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(401)
+            self.status_mock.assert_called_with(404)
             self.write_mock.assert_called_with('Invalid token')
         self.finish_deferred.addCallback(handle_finish)
 
@@ -229,7 +229,7 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint._uaid_lookup_results(fresult)
 
         def handle_finish(value):
-            self.endpoint.set_status.assert_called_with(401)
+            self.endpoint.set_status.assert_called_with(400)
 
         self.finish_deferred.addCallback(handle_finish)
         return self.finish_deferred
@@ -378,7 +378,7 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.request.body = b'version=1&data=1234'
 
         def handle_finish(result):
-            self.endpoint.set_status.assert_called_with(401)
+            self.endpoint.set_status.assert_called_with(413)
             self.endpoint.write.assert_called_with('Data too large')
         self.finish_deferred.addCallback(handle_finish)
 
@@ -406,7 +406,7 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.request.body = b'version=123&data=bad-token'
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(401)
+            self.status_mock.assert_called_with(404)
             self.write_mock.assert_called_with('Invalid token')
         self.finish_deferred.addCallback(handle_finish)
 
@@ -418,7 +418,7 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.request.body = b'version=123'
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(401)
+            self.status_mock.assert_called_with(404)
             self.write_mock.assert_called_with("Invalid token")
         self.finish_deferred.addCallback(handle_finish)
 

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -748,7 +748,7 @@ class TestWebPush(IntegrationBase):
         data = str(uuid.uuid4())
         client = yield self.quick_register(use_webpush=True)
         result = yield client.send_notification(data=data, use_header=False,
-                                                status=401)
+                                                status=400)
         eq_(result, None)
         yield self.shut_down(client)
 


### PR DESCRIPTION
Another quick win...

* Use 413 for messages that exceed the maximum size, per the [Web Push draft](https://unicorn-wg.github.io/webpush-protocol/#send).
* Use 404 for invalid tokens, and 400 for missing encryption headers. 401 signals invalid credentials, and [RFC 7235](https://tools.ietf.org/html/rfc7235#section-3.1) mandates a `WWW-Authenticate` response header. Neither is really applicable here. :bike: :house: :art:

@bbangert r?