### PR TITLE
Hotfix/1.6.0 issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Bug Fixes
 ---------
 
 * Use proper client connected_at in delete handler.
+* Trap provisioned exception error in websocket handler.
 
 1.6.0 (2015-09-14)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Autopush Changelog
 ==================
 
+1.6.1 (2015-09-28)
+==================
+
+Bug Fixes
+---------
+
+* Use proper client connected_at in delete handler.
+
 1.6.0 (2015-09-14)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Bug Fixes
 * Use proper client connected_at in delete handler.
 * Trap provisioned exception error in websocket handler.
 * Clear the node entry for a client even if we know the node is dead.
+* Ignore Cancelled exceptions.
 
 1.6.0 (2015-09-14)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Bug Fixes
 
 * Use proper client connected_at in delete handler.
 * Trap provisioned exception error in websocket handler.
+* Clear the node entry for a client even if we know the node is dead.
 
 1.6.0 (2015-09-14)
 ==================

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -90,6 +90,8 @@ class SimpleRouter(object):
         if node_id:
             key = node_key(node_id)
             if dead_cache.get(key):
+                yield deferToThread(router.clear_node,
+                                    uaid_data).addErrback(self._eat_db_err)
                 self._raise_invalid_node_error()
 
             try:

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -306,7 +306,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
             exc = fail.value
             ok_(exc, RouterException)
             eq_(exc.status_code, 503)
-            eq_(len(self.router_mock.clear_node.mock_calls), 1)
+            eq_(len(self.router_mock.clear_node.mock_calls), 2)
             self.flushLoggedErrors()
 
         def verify_deliver(fail):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1496,10 +1496,13 @@ class NotificationHandlerTestCase(unittest.TestCase):
         eq_(self.status_mock.call_args, ((404,),))
 
     def test_delete(self):
+        from autopush.websocket import PushServerProtocol, PushState
         uaid = str(uuid.uuid4())
         now = int(time.time() * 1000)
-        self.ap_settings.clients[uaid] = mock_client = Mock()
-        mock_client.connected_at = now
+        self.ap_settings.clients[uaid] = mock_client = Mock(
+            spec=PushServerProtocol)
+        mock_client.ps = Mock(spec=PushState)
+        mock_client.ps.connected_at = now
         mock_client.sendClose = Mock()
         self.handler.delete(uaid, "", now)
         assert(mock_client.sendClose.called)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -1012,7 +1012,7 @@ class NotificationHandler(cyclone.web.RequestHandler):
 
         """
         client = self.ap_settings.clients.get(uaid)
-        if client and client.connected_at == int(connectionTime):
+        if client and client.ps.connected_at == int(connectionTime):
             client.sendClose()
             return self.write("Terminated duplicate")
 


### PR DESCRIPTION
* Use proper client connected_at in delete handler.
* Trap provisioned exception error in websocket handler.
* Clear the node entry for a client even if we know the node is dead.
* Ignore Cancelled exceptions.
