### PR TITLE
Add server generated SenderIDs and ChannelIDs for GCM clients

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,26 @@
 Autopush Changelog
 ==================
 
-1.7.0 (**dev**)
+1.8.0 (**dev**)
+===============
+
+Features
+--------
+* Server provided SenderID values for GCM router using clients
+  The GCM router will randomly select one of a list of SenderIDs stored in
+  S3 under the "org.mozilla.services.autopush"/"senderids" key. The values can
+  be loaded into S3 either via the S3 console, or by runnig an instance of
+  autopush and passing the values as the "senderid_list" argument. Issue #185
+* REST Registration will now return a valid ChannelID if one is not specified.
+  Issue #182
+
+Bug Fixes
+---------
+
+WebPush
+-------
+
+1.7.0 (2015-10-21)
 ===============
 
 Features
@@ -13,13 +32,6 @@ Features
 * Provide service environment information to help clients identify the service
   environment, server provides it along with the hello message. Issue #50.
 * Add actionable JSON errors to the Endpoint responses. Issue #178.
-* Server provided SenderID values for GCM router using clients
-  The GCM router will randomly select one of a list of SenderIDs stored in
-  S3 under the "org.mozilla.services.autopush"/"senderids" key. The values can
-  be loaded into S3 either via the S3 console, or by runnig an instance of
-  autopush and passing the values as the "senderid_list" argument. Issue #185
-* REST Registration will now return a valid ChannelID if one is not specified.
-  Issue #182
 
 Bug Fixes
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Features
 * Provide service environment information to help clients identify the service
   environment, server provides it along with the hello message. Issue #50.
 * Add actionable JSON errors to the Endpoint responses. Issue #178.
+* Server provided SenderID values for GCM router using clients
+  The GCM router will randomly select one of a list of SenderIDs stored in
+  S3 under the "org.mozilla.services.autopush"/"senderids" key. The values can
+  be loaded into S3 either via the S3 console, or by runnig an instance of
+  autopush and passing the values as the "senderid_list" argument. Issue #185
+* REST Registration will now return a valid ChannelID if one is not specified.
+  Issue #182
 
 Bug Fixes
 ---------

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -229,7 +229,8 @@ class Message(object):
         db_key = self.encode({"uaid": uaid, "chidmessageid": " "})
         # Generate our update expression
         expr = "ADD chids :channel_id"
-        expr_values = self.encode({":channel_id": set([channel_id])})
+        expr_values = self.encode({":channel_id": set([channel_id]),
+            })
         conn.update_item(
             self.table.table_name,
             db_key,
@@ -370,6 +371,7 @@ class Router(object):
             exceeds throughput.
 
         """
+        ## Fetch a senderid for this user
         conn = self.table.connection
         db_key = self.encode({"uaid": data.pop("uaid")})
         # Generate our update expression

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -236,8 +236,7 @@ class Message(object):
         db_key = self.encode({"uaid": uaid, "chidmessageid": " "})
         # Generate our update expression
         expr = "ADD chids :channel_id"
-        expr_values = self.encode({":channel_id": set([channel_id]),
-            })
+        expr_values = self.encode({":channel_id": set([channel_id])})
         conn.update_item(
             self.table.table_name,
             db_key,
@@ -432,7 +431,7 @@ class Router(object):
             exceeds throughput.
 
         """
-        ## Fetch a senderid for this user
+        # Fetch a senderid for this user
         conn = self.table.connection
         db_key = self.encode({"uaid": data.pop("uaid")})
         # Generate our update expression

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -111,8 +111,8 @@ def preflight_check(storage, router):
     Failure to run correctly will raise an exception.
 
     """
-    uaid = str(uuid.uuid4())
-    chid = str(uuid.uuid4())
+    uaid = uuid.uuid4().hex
+    chid = uuid.uuid4().hex
     node_id = "mynode:2020"
     connected_at = 0
     version = 12

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -726,7 +726,7 @@ class RegistrationHandler(AutoendpointHandler):
                                         message="Invalid authentication")
 
         self.uaid = uaid
-        self.chid = str(uuid.uuid4())
+        self.chid = uuid.uuid4().hex
         d = deferToThread(self.ap_settings.router.get_uaid, uaid)
         d.addCallback(self._return_router_data)
         d.addErrback(self._overload_err)
@@ -746,7 +746,7 @@ class RegistrationHandler(AutoendpointHandler):
         params = self._load_params()
         # If the client didn't provide a CHID, make one up.
         if "channelID" not in params:
-            params["channelID"] = uuid.uuid4()
+            params["channelID"] = uuid.uuid4().hex
 
         # If there's a UAID, ensure its valid, otherwise we ensure the hash
         # matches up
@@ -756,7 +756,7 @@ class RegistrationHandler(AutoendpointHandler):
                 return self._error(401, "Invalid Authentication")
         else:
             # No UAID supplied, make our own
-            uaid = str(uuid.uuid4())
+            uaid = uuid.uuid4().hex
             new_uaid = True
         self.uaid = uaid
         router_type = params.get("type")

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -594,8 +594,9 @@ class RegistrationHandler(AutoendpointHandler):
         self.start_time = time.time()
         self.add_header("Content-Type", "application/json")
         params = self._load_params()
+        # If the client didn't provide a CHID, make one up.
         if "channelID" not in params:
-            return self._error(400, "Invalid arguments")
+            params["channelID"] = uuid.uuid4()
 
         # If there's a UAID, ensure its valid, otherwise we ensure the hash
         # matches up
@@ -691,10 +692,12 @@ class RegistrationHandler(AutoendpointHandler):
         requestor"""
         if new_uaid:
             hashed = generate_hash(self.ap_settings.crypto_key, self.uaid)
+            senderid = self.ap_settings.senderIDs.getID()
             msg = dict(
                 uaid=self.uaid,
                 secret=hashed,
                 channelID=self.chid,
+                senderid=senderid,
                 endpoint=endpoint,
             )
         else:

--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -70,7 +70,7 @@ def stdout(message):
     """Format a message appropriately for structured logging capture of stdout
     and then write it to stdout"""
     # uncomment to get concise human readable logging messages.
-    """
+    #"""
     if message['error']:
         sys.stdout.write("ERROR: %s\n" % message['message'])
     else:

--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -70,7 +70,7 @@ def stdout(message):
     """Format a message appropriately for structured logging capture of stdout
     and then write it to stdout"""
     # uncomment to get concise human readable logging messages.
-    #"""
+    """
     if message['error']:
         sys.stdout.write("ERROR: %s\n" % message['message'])
     else:

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -24,8 +24,7 @@ from autopush.websocket import (
     DefaultResource,
     StatusResource,
 )
-from autopush.senderids import SenderIDs, SENDERID_EXPRY
-from autopush.settings import S3_BUCKET
+from autopush.senderids import SenderIDs, SENDERID_EXPRY, DEFAULT_BUCKET
 
 
 shared_config_files = [
@@ -222,7 +221,7 @@ def _parse_endpoint(sysargs):
     parser.add_argument('--cors', help='Allow CORS PUTs for update.',
                         type=bool, default=False, env_var='ALLOW_CORS')
     parser.add_argument('--s3_bucket', help='S3 Bucket for SenderIDs',
-                        type=str, default=S3_BUCKET,
+                        type=str, default=DEFAULT_BUCKET,
                         env_var='S3-BUCKET')
     parser.add_argument('--senderid_expry', help='Cache expry for senderIDs',
                         type=int, default=SENDERID_EXPRY,
@@ -406,7 +405,6 @@ def endpoint_main(sysargs=None):
     setup_logging("Autoendpoint")
 
     # Endpoint HTTP router
-    settings.senderIDs = SenderIDs(settings)
     site = cyclone.web.Application([
         (r"/push/([^\/]+)", EndpointHandler, dict(ap_settings=settings)),
         (r"/m/([^\/]+)", MessageHandler, dict(ap_settings=settings)),

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -24,7 +24,7 @@ from autopush.websocket import (
     DefaultResource,
     StatusResource,
 )
-from autopush.senderids import SenderIDs, SENDERID_EXPRY, DEFAULT_BUCKET
+from autopush.senderids import SENDERID_EXPRY, DEFAULT_BUCKET
 
 
 shared_config_files = [

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -24,6 +24,8 @@ from autopush.websocket import (
     DefaultResource,
     StatusResource,
 )
+from autopush.senderids import SenderIDs, SENDERID_EXPRY
+from autopush.settings import S3_BUCKET
 
 
 shared_config_files = [
@@ -219,6 +221,14 @@ def _parse_endpoint(sysargs):
                         type=int, default=8082, env_var="PORT")
     parser.add_argument('--cors', help='Allow CORS PUTs for update.',
                         type=bool, default=False, env_var='ALLOW_CORS')
+    parser.add_argument('--s3_bucket', help='S3 Bucket for SenderIDs',
+                        type=str, default=S3_BUCKET,
+                        env_var='S3-BUCKET')
+    parser.add_argument('--senderid_expry', help='Cache expry for senderIDs',
+                        type=int, default=SENDERID_EXPRY,
+                        env_var='SENDERID_EXPRY')
+    parser.add_argument('--senderid_list', help='SenderIDs to load to S3',
+                        type=int, default=[], action='append')
     add_shared_args(parser)
     add_external_router_args(parser)
 
@@ -387,12 +397,16 @@ def endpoint_main(sysargs=None):
         endpoint_scheme=scheme,
         endpoint_hostname=args.endpoint_hostname or args.hostname,
         endpoint_port=args.port,
-        enable_cors=args.cors
+        enable_cors=args.cors,
+        s3_bucket=args.s3_bucket,
+        senderid_expry=args.senderid_expry,
+        senderid_list=args.senderid_list,
     )
 
     setup_logging("Autoendpoint")
 
     # Endpoint HTTP router
+    settings.senderIDs = SenderIDs(settings)
     site = cyclone.web.Application([
         (r"/push/([^\/]+)", EndpointHandler, dict(ap_settings=settings)),
         (r"/m/([^\/]+)", MessageHandler, dict(ap_settings=settings)),

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -49,7 +49,7 @@ class APNSRouter(object):
                                   response_body="No token registered")
         return router_data
 
-    def amend_msg(msg):
+    def amend_msg(self, msg):
         return msg
 
     def route_notification(self, notification, uaid_data):

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -49,6 +49,9 @@ class APNSRouter(object):
                                   response_body="No token registered")
         return router_data
 
+    def amend_msg(msg):
+        return msg
+
     def route_notification(self, notification, uaid_data):
         """Start the APNS notification routing, returns a deferred"""
         router_data = uaid_data["router_data"]

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -53,6 +53,15 @@ class IRouter(object):
         """
         raise NotImplementedError("register must be implemented")
 
+    def amend_msg(self, msg):
+        """Modify an outbound response message to include router info
+
+        Some routers may require additional info to be returned to clients.
+
+        :param msg: A dict of the response data to be sent to the client
+        """
+        raise NotImplementedError("amend_msg must be implemented")
+
     def route_notification(self, notification, uaid_data):
         """Route a notification
 

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -59,9 +59,11 @@ class IRouter(object):
     def amend_msg(self, msg):
         """Modify an outbound response message to include router info
 
+        :param msg: A dict of the response data to be sent to the client
+        :returns: A potentially modified dict to return to the client
+
         Some routers may require additional info to be returned to clients.
 
-        :param msg: A dict of the response data to be sent to the client
         """
         raise NotImplementedError("amend_msg must be implemented")
 

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -58,6 +58,9 @@ class SimpleRouter(object):
         """Return no additional routing data"""
         return {}
 
+    def amend_msg(self, msg):
+        return msg
+
     def preflight_check(self, uaid, channel_id):
         """Verifies this routing call can be done successfully"""
         return True

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -97,3 +97,6 @@ class WebPushRouter(SimpleRouter):
             message_id=notification.version,
             ttl=notification.ttl+int(time.time()),
         )
+
+    def amend_msg(msg):
+        return msg

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -100,5 +100,5 @@ class WebPushRouter(SimpleRouter):
             timestamp=int(time.time()),
         )
 
-    def amend_msg(msg):
+    def amend_msg(self, msg):
         return msg

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -13,15 +13,14 @@ probably wiser to use the S3 console, otherwise there may be multiple
 instances writing and the possiblity that the list of SenderIDs is
 overwritten with older, less accurate values.
 
-
 """
-from boto.exception import S3ResponseError
-from boto.s3.connection import S3Connection
-from boto.s3.key import Key
-
 import time
 import json
 import random
+
+from boto.exception import S3ResponseError
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
 
 # re-read from source every 15 minutes or so.
 SENDERID_EXPRY = 15*60
@@ -86,6 +85,6 @@ class SenderIDs(object):
         self.ID = args.get("s3_bucket", DEFAULT_BUCKET)
         self._expry = args.get("senderid_expry", SENDERID_EXPRY)
         senderIDs = args.get("senderid_list", [])
-        if len(senderIDs):
+        if senderIDs:
             self.update(senderIDs)
         self._refresh()

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -1,7 +1,20 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Locally caching GCM SenderIDs
 
+GCM requires a valid SenderID. One can use a single hard-coded value, but
+that can be a problem if that lone SenderID is ever disqualified for some
+reason. Instead, the server provides a senderid that the client can use.
+
+This module uses a bucket named "org.mozilla.services.autopush" by default,
+and stores the list of SenderIDs as a JSON string under the key of "senderids".
+
+You can either update the list of SenderIDs using the S3 console, or you
+can load the SenderIDs by using the "--senderid_list" argument. It is
+probably wiser to use the S3 console, otherwise there may be multiple
+instances writing and the possiblity that the list of SenderIDs is
+overwritten with older, less accurate values.
+
+
+"""
 from boto.exception import S3ResponseError
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key
@@ -16,12 +29,14 @@ DEFAULT_BUCKET = "org.mozilla.services.autopush"
 
 
 class SenderIDs(object):
+    """Handle Read, Write and cache of SenderID values from S3"""
     _updated = 0
     _expry = SENDERID_EXPRY
     _senderIDs = []
     KEYNAME = "senderids"
 
     def _write(self, bucket, senderIDs):
+        """Write a list of SenderIDs to S3"""
         key = Key(bucket)
         key.key = self.KEYNAME
         key.set_contents_from_string(json.dumps(senderIDs))
@@ -29,12 +44,12 @@ class SenderIDs(object):
         self._updated = time.time()
 
     def _create(self, senderIDs):
-        """ Create a new bucket containing the senderIDs"""
+        """Create a new bucket containing the senderIDs"""
         bucket = self.conn.create_bucket(self.ID)
         self._write(bucket, senderIDs)
 
     def _refresh(self):
-        """ Refresh the senderIDs from the S3 bucket """
+        """Refresh the senderIDs from the S3 bucket"""
         # Only refresh if needed.
         if time.time() < self._updated + self._expry:
             return
@@ -47,7 +62,7 @@ class SenderIDs(object):
             self._create(self._senderIDs)
 
     def update(self, senderIDs):
-        """ Update the S3 bucket containing the SenderIDs"""
+        """Update the S3 bucket containing the SenderIDs"""
         try:
             bucket = self.conn.get_bucket(self.ID)
             self._write(bucket, senderIDs)
@@ -55,16 +70,18 @@ class SenderIDs(object):
             self._create(senderIDs)
 
     def senderIDs(self):
-        """Return a list of senderIDs, refreshing if required """
+        """Return a list of senderIDs, refreshing if required"""
         if time.time() > self._updated + self._expry:
             self._refresh()
         return self._senderIDs
 
     def getID(self):
+        """Return a randomly selected SenderID, refreshing if required"""
         self._refresh()
         return random.choice(self._senderIDs)
 
     def __init__(self, args):
+        """Optionally load or fetch the set of SenderIDs from S3"""
         self.conn = S3Connection()
         self.ID = args.get("s3_bucket", DEFAULT_BUCKET)
         self._expry = args.get("senderid_expry", SENDERID_EXPRY)

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from boto.exception import S3ResponseError
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
+
+import time
+import json
+import random
+
+# re-read from source every 15 minutes or so.
+SENDERID_EXPRY = 15*60
+DEFAULT_BUCKET = "org.mozilla.services.autopush"
+
+
+class SenderIDs(object):
+    _updated = 0
+    _expry = SENDERID_EXPRY
+    _senderIDs = []
+    KEYNAME = "senderids"
+
+    def _write(self, bucket, senderIDs):
+        key = Key(bucket)
+        key.key = self.KEYNAME
+        key.set_contents_from_string(json.dumps(senderIDs))
+        self._senderIDs = senderIDs
+        self._updated = time.time()
+
+    def _create(self, senderIDs):
+        """ Create a new bucket containing the senderIDs"""
+        bucket = self.conn.create_bucket(self.ID)
+        self._write(bucket, senderIDs)
+
+    def _refresh(self):
+        """ Refresh the senderIDs from the S3 bucket """
+        # Only refresh if needed.
+        if time.time() < self._updated + self._expry:
+            return
+        try:
+            bucket = self.conn.get_bucket(self.ID)
+            key = Key(bucket)
+            key.key = self.KEYNAME
+            self._senderIDs = json.loads(key.get_contents_as_string())
+        except S3ResponseError:
+            self._create(self._senderIDs)
+
+    def update(self, senderIDs):
+        """ Update the S3 bucket containing the SenderIDs"""
+        try:
+            bucket = self.conn.get_bucket(self.ID)
+            self._write(bucket, senderIDs)
+        except S3ResponseError:
+            self._create(senderIDs)
+
+    def senderIDs(self):
+        """Return a list of senderIDs, refreshing if required """
+        if time.time() > self._updated + self._expry:
+            self._refresh()
+        return self._senderIDs
+
+    def getID(self):
+        self._refresh()
+        return random.choice(self._senderIDs)
+
+    def __init__(self, args):
+        self.conn = S3Connection()
+        self.ID = args.get("s3_bucket", DEFAULT_BUCKET)
+        self._expry = args.get("senderid_expry", SENDERID_EXPRY)
+        senderIDs = args.get("senderid_list", [])
+        if len(senderIDs):
+            self.update(senderIDs)
+        self._refresh()

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -26,9 +26,7 @@ from autopush.router import (
     WebPushRouter,
 )
 from autopush.utils import canonical_url, resolve_ip
-from autopush.senderids import SENDERID_EXPRY
-
-S3_BUCKET = "org.mozilla.services.autopush"
+from autopush.senderids import SENDERID_EXPRY, DEFAULT_BUCKET
 
 
 class AutopushSettings(object):
@@ -67,7 +65,7 @@ class AutopushSettings(object):
                  wake_timeout=0,
                  env='development',
                  enable_cors=False,
-                 s3_bucket="org.mozilla.services.autopush",
+                 s3_bucket=DEFAULT_BUCKET,
                  senderid_expry=SENDERID_EXPRY,
                  senderid_list="[]",
                  ):
@@ -157,14 +155,14 @@ class AutopushSettings(object):
         if 'apns' in router_conf:
             self.routers["apns"] = APNSRouter(self, router_conf["apns"])
         if 'gcm' in router_conf:
-            self.routers["gcm"] = GCMRouter(self, router_conf["gcm"])
+            conf = router_conf.get("gcm", {})
+            conf["s3_bucket"] = s3_bucket
+            conf["senderid_expry"] = senderid_expry
+            conf["senderid_list"] = senderid_list
+            self.routers["gcm"] = GCMRouter(self, conf)
 
         # Env
         self.env = env
-
-        self.s3_bucket = s3_bucket
-        self.senderid_expry = senderid_expry
-        self.senderid_list = senderid_list
 
     def update(self, **kwargs):
         """Update the arguments, if a ``crypto_key`` is in kwargs then the

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -26,6 +26,9 @@ from autopush.router import (
     WebPushRouter,
 )
 from autopush.utils import canonical_url, resolve_ip
+from autopush.senderids import SENDERID_EXPRY
+
+S3_BUCKET = "org.mozilla.services.autopush"
 
 
 class AutopushSettings(object):
@@ -63,7 +66,11 @@ class AutopushSettings(object):
                  # Reflected up from UDP Router
                  wake_timeout=0,
                  env='development',
-                 enable_cors=False):
+                 enable_cors=False,
+                 s3_bucket="org.mozilla.services.autopush",
+                 senderid_expry=SENDERID_EXPRY,
+                 senderid_list="[]",
+                 ):
         """Initialize the Settings object
 
         Upon creation, the HTTP agent will initialize, all configured routers
@@ -154,6 +161,10 @@ class AutopushSettings(object):
 
         # Env
         self.env = env
+
+        self.s3_bucket = s3_bucket
+        self.senderid_expry = senderid_expry
+        self.senderid_list = senderid_list
 
     def update(self, **kwargs):
         """Update the arguments, if a ``crypto_key`` is in kwargs then the

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -809,8 +809,6 @@ class RegistrationTestCase(unittest.TestCase):
             'encrypt.return_value': 'abcd123',
         })
 
-        self.senderIDs_mock.getID.return_value="test123"
-
         def handle_finish(value):
             call_args = self.reg.write.call_args
             ok_(call_args is not None)
@@ -818,7 +816,6 @@ class RegistrationTestCase(unittest.TestCase):
             call_arg = json.loads(args[0])
             eq_(call_arg["uaid"], dummy_uaid)
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
-            eq_(call_arg["senderid"], "test123")
             ok_("secret" in call_arg)
 
         self.finish_deferred.addCallback(handle_finish)
@@ -929,7 +926,6 @@ class RegistrationTestCase(unittest.TestCase):
             call_arg = json.loads(args[0])
             eq_(call_arg["uaid"], dummy_uaid)
             eq_(call_arg["channelID"], dummy_chid)
-            eq_(call_arg["senderid"], "test_senderid")
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
             ok_("secret" in call_arg)
 
@@ -954,7 +950,6 @@ class RegistrationTestCase(unittest.TestCase):
             call_arg = json.loads(args[0])
             eq_(call_arg["uaid"], dummy_chid)
             eq_(call_arg["channelID"], dummy_chid)
-            eq_(call_arg["senderid"], "test_senderid")
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
             ok_("secret" in call_arg)
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -721,7 +721,7 @@ class RegistrationTestCase(unittest.TestCase):
             '\x00\x00\x00\x00\x00\x00\x00\x00'
             '\x00\x00\x00\x00\x00\x00\x00\x00')
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_load_params_arguments(self, u=None):
         self.reg.request.body = json.dumps(dict(
             channelID=dummy_chid,
@@ -735,14 +735,14 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.request.body = b'connect={"type":"test"}'
         self.assertTrue(not self.reg._load_params())
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_load_params_prefer_body(self, t):
         args = self.reg.request.arguments
         args['connect'] = ['{"type":"invalid"}']
         self.reg.request.body = b'connect={"type":"test"}'
         self.assertTrue(self.reg._load_params())
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_load_params_no_conn(self, t):
         self.reg.request.body = b'noconnect={"type":"test"}'
         self.assertTrue(not self.reg._load_params())
@@ -782,7 +782,7 @@ class RegistrationTestCase(unittest.TestCase):
         eq_(reg._headers[ch1], "*")
         eq_(reg._headers[ch2], "GET,PUT")
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     @patch('autopush.endpoint.validate_hash', return_value=True)
     def test_get_valid(self, *args):
         # All is well check.
@@ -810,7 +810,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.get(dummy_uaid)
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_get_no_uuid(self, arg):
         self.fernet_mock.configure_mock(**{
             'encrypt.return_value': 'abcd123',
@@ -824,7 +824,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.get()
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_get_bad_uuid(self, arg):
         self.fernet_mock.configure_mock(**{
             'encrypt.return_value': 'abcd123',
@@ -838,7 +838,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.get('invalid')
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_uaid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))
     def test_post(self, arg):
         self.reg.ap_settings.routers["test"] = self.router_mock
         self.reg.request.body = json.dumps(dict(
@@ -863,7 +863,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post()
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_uaid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))
     def test_post_invalid_args(self, arg):
         self.reg.request.body = json.dumps(dict(
             type="test",
@@ -878,7 +878,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post()
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_uaid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))
     def test_post_bad_router_type(self, arg):
         self.reg.request.body = json.dumps(dict(
             type="test",
@@ -894,7 +894,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post()
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     @patch('autopush.endpoint.validate_hash', return_value=True)
     def test_post_existing_uaid(self, *args):
         self.reg.request.headers["Authorization"] = "Fred Smith"
@@ -917,7 +917,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post(dummy_uaid)
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_uaid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))
     def test_post_bad_uaid(self, arg):
         self.reg.ap_settings.routers["test"] = self.router_mock
         self.reg.request.body = json.dumps(dict(
@@ -934,7 +934,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post('invalid')
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_uaid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))
     def test_post_bad_params(self, arg):
         self.reg.ap_settings.routers["test"] = self.router_mock
         self.reg.request.body = json.dumps(dict(
@@ -949,7 +949,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post(dummy_uaid)
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_uaid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))
     def test_post_uaid_chid(self, arg):
         self.reg.request.body = json.dumps(dict(
             type="simplepush",
@@ -974,7 +974,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post()
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_post_nochid(self, *args):
         self.reg.request.body = json.dumps(dict(
             type="simplepush",
@@ -1024,7 +1024,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.post()
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     @patch('autopush.endpoint.validate_hash', return_value=True)
     def test_put(self, *args):
         self.reg.request.headers["Authorization"] = "Fred"
@@ -1044,7 +1044,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.put(dummy_uaid)
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_put_bad_auth(self, *args):
         self.reg.request.headers["Authorization"] = "Fred Smith"
 
@@ -1056,7 +1056,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.put(dummy_uaid)
         return self.finish_deferred
 
-    @patch('uuid.uuid4', return_value=dummy_chid)
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     @patch('autopush.endpoint.validate_hash', return_value=True)
     def test_put_bad_arguments(self, *args):
         self.reg.request.headers["Authorization"] = "Fred"

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -2,7 +2,7 @@ import unittest
 import uuid
 
 from mock import Mock, patch
-from moto import mock_dynamodb2
+from moto import mock_dynamodb2, mock_s3
 from nose.tools import eq_
 
 from autopush.main import (
@@ -25,10 +25,12 @@ mock_dynamodb2 = mock_dynamodb2()
 
 def setUp():
     mock_dynamodb2.start()
+    mock_s3().start()
 
 
 def tearDown():
     mock_dynamodb2.stop()
+    mock_s3().stop()
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -64,6 +66,7 @@ class SettingsTestCase(unittest.TestCase):
 
 class ConnectionMainTestCase(unittest.TestCase):
     def setUp(self):
+        mock_s3().start()
         patchers = [
             "autopush.main.task",
             "autopush.main.reactor",
@@ -75,6 +78,7 @@ class ConnectionMainTestCase(unittest.TestCase):
             self.mocks[name] = patcher.start()
 
     def tearDown(self):
+        mock_s3().stop()
         for mock in self.mocks.values():
             mock.stop()
 
@@ -99,6 +103,7 @@ class ConnectionMainTestCase(unittest.TestCase):
 
 class EndpointMainTestCase(unittest.TestCase):
     def setUp(self):
+        mock_s3().start()
         patchers = [
             "autopush.main.task",
             "autopush.main.reactor",
@@ -111,6 +116,7 @@ class EndpointMainTestCase(unittest.TestCase):
             self.mocks[name] = patcher.start()
 
     def tearDown(self):
+        mock_s3().stop()
         for mock in self.mocks.values():
             mock.stop()
 

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import uuid
 
 from mock import Mock, PropertyMock, patch
-from moto import mock_dynamodb2
+from moto import mock_dynamodb2, mock_s3
 from nose.tools import eq_, ok_
 from twisted.trial import unittest
 from twisted.internet.error import ConnectError
@@ -29,10 +29,12 @@ mock_dynamodb2 = mock_dynamodb2()
 
 
 def setUp():
+    mock_s3().start()
     mock_dynamodb2.start()
 
 
 def tearDown():
+    mock_s3().stop()
     mock_dynamodb2.stop()
 
 
@@ -147,7 +149,9 @@ class GCMRouterTestCase(unittest.TestCase):
         self._old_gcm = gcmclient.GCM
         gcmclient.GCM = Mock(spec=gcmclient.GCM)
 
-        gcm_config = {'apikey': '12345678abcdefg'}
+        gcm_config = {'apikey': '12345678abcdefg',
+                      's3_bucket': 'org.mozilla.services.autopush.test',
+                      'senderid_list': ['test123']}
         self.router = GCMRouter(settings, gcm_config)
         self.notif = Notification(10, "data", dummy_chid, None, 200)
         self.router_data = dict(router_data=dict(token="connect_data"))
@@ -170,7 +174,7 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_register(self):
         result = self.router.register("uaid", {"token": "connect_data"})
-        eq_(result, {"token": "connect_data"})
+        eq_(result, {"token": "connect_data", "senderid": "test123"})
 
     def test_register_bad(self):
         self.assertRaises(RouterException, self.router.register, "uaid", {})

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -68,7 +68,7 @@ class RouterInterfaceTestCase(TestCase):
         self.assertRaises(NotImplementedError, ir.register, "uaid", {})
         self.assertRaises(NotImplementedError, ir.route_notification, "uaid",
                           {})
-        self.assertRaises(NotImplementedError, ir.amend_msg({}))
+        self.assertRaises(NotImplementedError, ir.amend_msg, {})
 
 
 dummy_chid = str(uuid.uuid4())

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -68,6 +68,7 @@ class RouterInterfaceTestCase(TestCase):
         self.assertRaises(NotImplementedError, ir.register, "uaid", {})
         self.assertRaises(NotImplementedError, ir.route_notification, "uaid",
                           {})
+        self.assertRaises(NotImplementedError, ir.amend_msg({}))
 
 
 dummy_chid = str(uuid.uuid4())
@@ -137,6 +138,10 @@ class APNSRouterTestCase(unittest.TestCase):
         self.router.messages = {1: {'token': 'dump', 'payload': {}}}
         self.router._error(dict(status=1, identifier=10))
         eq_(len(self.router.messages), 1)
+
+    def test_ammend(self):
+        resp = {"key": "value"}
+        eq_(resp, self.router.amend_msg(resp))
 
 
 class GCMRouterTestCase(unittest.TestCase):
@@ -249,6 +254,12 @@ class GCMRouterTestCase(unittest.TestCase):
             self._check_error_call(fail.value, 503)
         d.addBoth(check_results)
         return d
+
+    def test_ammend(self):
+        self.router.register("uaid", {"token": "connect_data"})
+        resp = {"key": "value"}
+        eq_({"key": "value", "senderid": "test123"},
+            self.router.amend_msg(resp))
 
 
 class SimplePushRouterTestCase(unittest.TestCase):
@@ -499,6 +510,10 @@ class SimplePushRouterTestCase(unittest.TestCase):
         eq_(self.router.udp, udp_data)
         return d
 
+    def test_ammend(self):
+        resp = {"key": "value"}
+        eq_(resp, self.router.amend_msg(resp))
+
 
 class WebPushRouterTestCase(unittest.TestCase):
     def setUp(self):
@@ -591,3 +606,7 @@ class WebPushRouterTestCase(unittest.TestCase):
             self.flushLoggedErrors()
         d.addBoth(verify_deliver)
         return d
+
+    def test_ammend(self):
+        resp = {"key": "value"}
+        eq_(resp, self.router.amend_msg(resp))

--- a/autopush/tests/test_senderids.py
+++ b/autopush/tests/test_senderids.py
@@ -1,0 +1,66 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from autopush.senderids import SenderIDs
+from mock import Mock
+from boto.exception import S3ResponseError
+from moto import mock_s3, mock_dynamodb2
+from nose.tools import eq_, ok_
+from twisted.trial import unittest
+
+import json
+
+
+class SenderIDsTestCase(unittest.TestCase):
+    def setUp(self):
+        mock_dynamodb2().start()
+        mock_s3().start()
+
+    def tearDown(self):
+        mock_dynamodb2().stop()
+        mock_s3().stop()
+
+    def test_success(self):
+        settings = dict(
+            s3_bucket="org.mozilla.autopush.test",
+            senderid_expry=10,
+            senderid_list=["test123", "test456"],
+            )
+        senderIDs = SenderIDs(settings)
+        eq_(senderIDs.conn.get_bucket(settings.get("s3_bucket")).
+            get_key('senderids').get_contents_as_string(),
+            json.dumps(settings.get("senderid_list")))
+
+        ok_(senderIDs.getID() in settings.get("senderid_list"))
+        eq_(senderIDs.senderIDs(), settings.get("senderid_list"))
+        senderIDs._expry = 0
+        eq_(senderIDs.senderIDs(), settings.get("senderid_list"))
+
+    def test_ensureCreated(self):
+        settings = dict(
+            s3_bucket="org.mozilla.autopush.test",
+            senderid_expry=0,
+            senderid_list=["test123", "test456"],
+            )
+        senderIDs = SenderIDs(settings)
+        oldConn = senderIDs.conn
+        senderIDs.conn = Mock()
+        senderIDs.conn.get_bucket.side_effect = S3ResponseError(403, "", "")
+        senderIDs._create = Mock()
+        senderIDs._updated = 0
+        senderIDs._refresh()
+        ok_(senderIDs._create.called)
+        senderIDs.conn = oldConn
+
+    def test_update(self):
+        settings = dict(
+            s3_bucket="org.mozilla.autopush.test",
+            senderid_expry=0,
+            senderid_list=["test123", "test456"],
+            )
+        senderIDs = SenderIDs(settings)
+        senderIDs.update(["test789"])
+        eq_(senderIDs.conn.get_bucket(settings.get("s3_bucket")).
+            get_key('senderids').get_contents_as_string(),
+            '["test789"]')

--- a/autopush/tests/test_senderids.py
+++ b/autopush/tests/test_senderids.py
@@ -1,6 +1,4 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
 
 from autopush.senderids import SenderIDs
 from mock import Mock
@@ -8,8 +6,6 @@ from boto.exception import S3ResponseError
 from moto import mock_s3, mock_dynamodb2
 from nose.tools import eq_, ok_
 from twisted.trial import unittest
-
-import json
 
 
 class SenderIDsTestCase(unittest.TestCase):

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -45,7 +45,7 @@ def validate_uaid(uaid):
             return bool(uuid.UUID(uaid)), uaid
         except ValueError:
             pass
-    return False, str(uuid.uuid4())
+    return False, uuid.uuid4().hex
 
 
 def validate_hash(key, payload, hashed):

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -577,7 +577,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             return self._check_other_nodes(result)
 
         # If registration fails, try resetting the UAID.
-        self.ps.uaid = str(uuid.uuid4())
+        self.ps.uaid = uuid.uuid4().hex
         d = self._register_user()
         d.addCallback(self._check_other_nodes)
         return d

--- a/docs/api/senderids.rst
+++ b/docs/api/senderids.rst
@@ -1,0 +1,15 @@
+.. _senderids_module:
+
+:mod:`autopush.senderids'
+-------------------------
+
+.. automodule:: autopush.senderids
+
+Base Class
+++++++++++
+
+.. autoclass:: SenderIDs
+    :members:
+    :private-members:
+    :member-order: bysource
+


### PR DESCRIPTION
Randomly select a GCM senderid from a list stored in an S3 bucket and include it with the initial registration request. This was proposed by the client team as a way to allow for GCM SenderIDs to be rotated in case an ID is disqualified for any reason. 

In addition, if the client doesn't include a ChannelID in the incoming registration request, there's no reason why we can't generate and return one on the server. This simplifies things on the client.

Since the GCM router requires modifying the registration response, it was decided that all routers should be given that option.

@bbangert r?