### PR TITLE
Convert arg handlers to ConfigArgParse std.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,12 @@ Bug Fixes
 WebPush
 -------
 
+Backwards Incompatibilities
+---------------------------
+* Do not specify values for boolean flags.
+* 'cors' is now enabled by default. In it's place use --nocors if you wish
+  to disable CORS. Please remove "cors" flag from configuration files.
+
 1.7.1 (2015-10-23)
 ==================
 

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -15,7 +15,6 @@ from autopush.health import (HealthHandler, StatusHandler)
 from autopush.logging import setup_logging
 from autopush.settings import AutopushSettings
 from autopush.ssl import AutopushSSLContextFactory
-from autopush.utils import str2bool
 from autopush.websocket import (
     PushServerProtocol,
     RouterHandler,
@@ -39,7 +38,7 @@ def add_shared_args(parser):
     parser.add_argument('--config-shared',
                         help="Common configuration file path",
                         dest='config_file', is_config_file=True)
-    parser.add_argument('--debug', help='Debug Info.', type=bool,
+    parser.add_argument('--debug', help='Debug Info.', action="store_true",
                         default=False, env_var="DEBUG")
     parser.add_argument('--crypto_key', help="Crypto key for tokens", type=str,
                         default="i_CYcNKa2YXrF_7V1Y-2MFfoEl7b6KX55y_9uvOKfJQ=",
@@ -55,7 +54,8 @@ def add_shared_args(parser):
                         type=str, default=None, env_var="LOCAL_HOSTNAME")
     parser.add_argument('--resolve_hostname',
                         help="Resolve the announced hostname",
-                        type=bool, default=False, env_var="RESOLVE_HOSTNAME")
+                        action="store_true", default=False,
+                        env_var="RESOLVE_HOSTNAME")
     parser.add_argument('--statsd_host', help="Statsd Host", type=str,
                         default="localhost", env_var="STATSD_HOST")
     parser.add_argument('--statsd_port', help="Statsd Port", type=int,
@@ -114,13 +114,15 @@ def add_external_router_args(parser):
     """Parses out external router arguments"""
     # GCM
     parser.add_argument('--external_router', help='enable external routers',
-                        type=bool, default=False, env_var='EXTERNAL_ROUTER')
+                        action="store_true", default=False,
+                        env_var='EXTERNAL_ROUTER')
     label = "GCM Router:"
     parser.add_argument('--gcm_ttl', help="%s Time to Live" % label,
                         type=int, default=60, env_var="GCM_TTL")
     parser.add_argument('--gcm_dryrun',
                         help="%s Dry run (no message sent)" % label,
-                        type=bool, default=False, env_var="GCM_DRYRUN")
+                        action="store_true", default=False,
+                        env_var="GCM_DRYRUN")
     parser.add_argument('--gcm_collapsekey',
                         help="%s string to collapse messages" % label,
                         type=str, default="simplepush",
@@ -130,7 +132,8 @@ def add_external_router_args(parser):
     # Apple Push Notification system (APNs) for iOS
     label = "APNS Router:"
     parser.add_argument('--apns_sandbox', help="%s Use Dev Sandbox" % label,
-                        type=bool, default=True, env_var="APNS_SANDBOX")
+                        action="store_true", default=False,
+                        env_var="APNS_SANDBOX")
     parser.add_argument('--apns_cert_file',
                         help="%s Certificate PEM file" % label,
                         type=str, env_var="APNS_CERT_FILE")
@@ -159,7 +162,6 @@ def _parse_connection(sysargs):
     parser = configargparse.ArgumentParser(
         description='Runs a Connection Node.',
         default_config_files=shared_config_files + config_files)
-    parser.register('type', bool, str2bool)
     parser.add_argument('--config-connection',
                         help="Connection node configuration file path",
                         dest='config_file', is_config_file=True)
@@ -212,14 +214,14 @@ def _parse_endpoint(sysargs):
     parser = configargparse.ArgumentParser(
         description='Runs an Endpoint Node.',
         default_config_files=shared_config_files + config_files)
-    parser.register('type', bool, str2bool)
     parser.add_argument('--config-endpoint',
                         help="Endpoint node configuration file path",
                         dest='config_file', is_config_file=True)
     parser.add_argument('-p', '--port', help='Public HTTP Endpoint Port',
                         type=int, default=8082, env_var="PORT")
-    parser.add_argument('--cors', help='Allow CORS PUTs for update.',
-                        type=bool, default=False, env_var='ALLOW_CORS')
+    parser.add_argument('--no_cors', help='Disallow CORS PUTs for update.',
+                        action="store_true",
+                        default=False, env_var='ALLOW_CORS')
     parser.add_argument('--s3_bucket', help='S3 Bucket for SenderIDs',
                         type=str, default=DEFAULT_BUCKET,
                         env_var='S3-BUCKET')
@@ -396,7 +398,7 @@ def endpoint_main(sysargs=None):
         endpoint_scheme=scheme,
         endpoint_hostname=args.endpoint_hostname or args.hostname,
         endpoint_port=args.port,
-        enable_cors=args.cors,
+        enable_cors=not args.no_cors,
         s3_bucket=args.s3_bucket,
         senderid_expry=args.senderid_expry,
         senderid_list=args.senderid_list,

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -12,7 +12,6 @@ from autopush.main import (
     skip_request_logging,
 )
 from autopush.utils import (
-    str2bool,
     resolve_ip,
     generate_hash,
     validate_hash,
@@ -34,11 +33,6 @@ def tearDown():
 
 
 class UtilsTestCase(unittest.TestCase):
-    def test_str2bool(self):
-        eq_(True, str2bool("t"))
-        eq_(False, str2bool("false"))
-        eq_(True, str2bool("True"))
-
     def test_validate_hash(self):
         key = str(uuid.uuid4())
         payload = str(uuid.uuid4())

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -13,12 +13,6 @@ default_ports = {
 }
 
 
-def str2bool(v):
-    """Convert different string representations of true/false into a Python
-    bool"""
-    return v in ("1", "t", "T", "true", "TRUE", "True")
-
-
 def canonical_url(scheme, hostname, port=None):
     """Return a canonical URL given a scheme/hostname and optional port"""
     if port is None or port == default_ports.get(scheme):


### PR DESCRIPTION
ConfigArgParse has a serious issue with
foo=True
it wants a flag to simply exist or not to indicate value.

* Remove str2bool processing
* Changed default behavior to always enable CORS for endpoints

_**NOTE: THIS WILL REQUIRE MODIFICATION OF THE PUPPET DEPLOYMENT SCRIPT**_

resolves #205 

@bbangert r?
