### PR TITLE
Bug/issue 194

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Bug Fixes
 * Clean-up several recent deferToLater calls that didn't have their cancelled
   exceptions ignored. Issue #208.
 * Fix improper attribute reference in delete call. Issue #211.
+* Always include TTL header in response to a WebPush notification. Issue #194.
 
 WebPush
 -------

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -266,6 +266,8 @@ from autopush.utils import (
     validate_hash,
 )
 
+# Our max TTL is 60 days realistically with table rotation, so we hard-code it
+MAX_TTL = 60 * 60 * 24 * 60
 status_codes = {
     200: "OK",
     201: "Created",
@@ -536,6 +538,8 @@ class MessageHandler(AutoendpointHandler):
     def _put_message(self, kind, uaid, chid):
         try:
             ttl = int(self.request.headers.get("ttl", "0"))
+            # Cap the TTL to our MAX_TTL
+            ttl = min(ttl, MAX_TTL)
         except ValueError:
             ttl = 0
         data = self.request.body
@@ -570,6 +574,7 @@ class MessageHandler(AutoendpointHandler):
 
     def _put_completed(self, result, uaid, chid, data, ttl, headers):
         if result:
+            self.set_header("TTL", str(ttl))
             self.set_status(201)
             self.write("Accepted")
             return self.finish()
@@ -644,6 +649,8 @@ class EndpointHandler(AutoendpointHandler):
 
         try:
             ttl = int(self.request.headers.get("ttl", "0"))
+            # Cap the TTL to our MAX_TTL
+            ttl = min(ttl, MAX_TTL)
         except ValueError:
             ttl = 0
         if data and len(data) > self.ap_settings.max_data:

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -24,7 +24,8 @@ class WebPushRouter(SimpleRouter):
         location = "%s/m/%s" % (self.ap_settings.endpoint_url,
                                 notification.version)
         return RouterResponse(status_code=201, response_body="",
-                              headers={"Location": location})
+                              headers={"Location": location,
+                                       "TTL": notification.ttl})
     stored_response = delivered_response
 
     def _crypto_headers(self, notification):
@@ -85,7 +86,8 @@ class WebPushRouter(SimpleRouter):
         """
         if notification.ttl == 0:
             raise RouterException("Finished Routing", status_code=201,
-                                  log_exception=False)
+                                  log_exception=False,
+                                  headers={"TTL": str(notification.ttl)})
         headers = None
         if notification.data:
             headers = self._crypto_headers(notification)

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -256,6 +256,28 @@ class EndpointTestCase(unittest.TestCase):
         self.finish_deferred.addCallback(handle_finish)
         return self.finish_deferred
 
+    def test_webpush_ttl_too_large(self):
+        from autopush.endpoint import MAX_TTL
+        fresult = dict(router_type="test")
+        frouter = Mock(spec=Router)
+        frouter.route_notification = Mock()
+        frouter.route_notification.return_value = RouterResponse()
+        self.endpoint.chid = "fred"
+        self.request_mock.headers["ttl"] = MAX_TTL + 100
+        self.request_mock.headers["encryption"] = "stuff"
+        self.request_mock.headers["content-encoding"] = "aes128"
+        self.endpoint.ap_settings.routers["test"] = frouter
+        self.endpoint._uaid_lookup_results(fresult)
+
+        def handle_finish(value):
+            assert(frouter.route_notification.called)
+            args, kwargs = frouter.route_notification.call_args
+            notif = args[0]
+            eq_(notif.ttl, MAX_TTL)
+
+        self.finish_deferred.addCallback(handle_finish)
+        return self.finish_deferred
+
     def test_webpush_bad_routertype(self):
         fresult = dict(router_type="fred")
         self.endpoint.chid = "fred"

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -254,7 +254,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
             ttl_header = resp.getheader("TTL")
             eq_(ttl_header, str(ttl))
 
-    def get_notification(self, timeout=0.2):
+    def get_notification(self, timeout=1):
         self.ws.settimeout(timeout)
         try:
             d = self.ws.recv()

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -201,7 +201,11 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
         http.close()
         eq_(resp.status, status)
         location = resp.getheader("Location", None)
+        log.debug("Response Headers: %s", resp.getheaders())
         if self.use_webpush:
+            if status == 201:
+                ttl_header = resp.getheader("TTL")
+                eq_(ttl_header, str(ttl))
             if ttl != 0 and status == 201:
                 assert(location is not None)
                 if channel in self.messages:
@@ -245,6 +249,10 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
         log.debug("%s Response (%s): %s", method, resp.status, resp.read())
         http.close()
         eq_(resp.status, status)
+        log.debug("Response Headers: %s", resp.getheaders())
+        if status == 201:
+            ttl_header = resp.getheader("TTL")
+            eq_(ttl_header, str(ttl))
 
     def get_notification(self, timeout=0.2):
         self.ws.settimeout(timeout)


### PR DESCRIPTION
* Always include TTL header in response to a WebPush notification. Issue #194.

Closes #194.

@jrconlin r?