### PR TITLE
Add HAWK and DELETE to client REST interfaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,14 @@ Features
 
 * Server provided SenderID values for GCM router using clients
   The GCM router will randomly select one of a list of SenderIDs stored in
-  S3 under the "org.mozilla.services.autopush"/"senderids" key. The values can
-  be loaded into S3 either via the S3 console, or by runnig an instance of
+  S3 under the "oms-autopush"/"senderids" key. The values can
+  be loaded into S3 either via the S3 console, or by running an instance of
   autopush and passing the values as the "senderid_list" argument. Issue #185.
 * REST Registration will now return a valid ChannelID if one is not specified.
   Issue #182
 * Add hello timeout. Issue #169.
+* Convert proprietary AUTH to use HAWK for client REST interfaces. Issue #201
+* Add DELETE /uaid[/chid] functions to client REST interfaces. Issue #183
 
 Bug Fixes
 ---------
@@ -26,6 +28,7 @@ Bug Fixes
   exceptions ignored. Issue #208.
 * Fix improper attribute reference in delete call. Issue #211.
 * Always include TTL header in response to a WebPush notification. Issue #194.
+* increased unit test coverage due to removeal of proprietary AUTH
 
 WebPush
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,10 @@ Features
 * REST Registration will now return a valid ChannelID if one is not specified.
   Issue #182.
 * Add hello timeout. Issue #169.
-* Convert proprietary AUTH to use HAWK for client REST interfaces. Issue #201
-* Add DELETE /uaid[/chid] functions to client REST interfaces. Issue #183
+* Convert proprietary AUTH to use HAWK for client REST interfaces. Issue #201.
+* Add DELETE /uaid[/chid] functions to client REST interfaces. Issue #183.
 * Add .editorconfig for consistent styling in editors. Issue #218.
-* Added --human_logs to display more human friendly logging
+* Added --human_logs to display more human friendly logging.
 * If you specify the --s3_bucket=None, the app will only use local memory
   and will not call out to the S3 repository. It is STRONGLY suggested that
   you specify the full --senderid_list data set.
@@ -34,7 +34,7 @@ Bug Fixes
   exceptions ignored. Issue #208.
 * Fix improper attribute reference in delete call. Issue #211.
 * Always include TTL header in response to a WebPush notification. Issue #194.
-* increased unit test coverage due to removeal of proprietary AUTH
+* Increased unit test coverage due to removal of proprietary AUTH.
 * Fixed issue with local senderid data cache. (discovered while debugging.)
 
 WebPush

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -15,7 +15,6 @@ from boto.dynamodb2.exceptions import (
 from boto.dynamodb2.fields import HashKey, RangeKey, GlobalKeysOnlyIndex
 from boto.dynamodb2.layer1 import DynamoDBConnection
 from boto.dynamodb2.table import Table
-from boto.dynamodb2.items import Item
 from boto.dynamodb2.types import NUMBER
 
 
@@ -483,7 +482,6 @@ class Router(object):
 
     @track_provisioned
     def drop_user(self, uaid):
-        db_key = self.encode({"uaid": uaid})
         return self.table.delete_item(uaid=uaid)
 
     @track_provisioned

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -78,8 +78,6 @@ class APNSRouter(object):
             for time_sent in self.messages.keys():
                 if time_sent < now - self.config.get("expry", 10):
                     del self.messages[time_sent]
-                else:
-                    break
         return RouterResponse(status_code=200, response_body="Message sent")
 
     def _error(self, err):

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -223,6 +223,26 @@ class MessageTestCase(unittest.TestCase):
         all_messages = list(message.fetch_messages(self.uaid))
         eq_(len(all_messages), 0)
 
+    def test_delete_all_for_user(self):
+        chid = str(uuid.uuid4())
+        chid2 = str(uuid.uuid4())
+        m = get_message_table()
+        message = Message(m, SinkMetrics())
+        message.register_channel(self.uaid, chid)
+        message.register_channel(self.uaid, chid2)
+
+        data1 = str(uuid.uuid4())
+        data2 = str(uuid.uuid4())
+        ttl = int(time.time())+100
+        time1, time2, time3 = self._nstime(), self._nstime(), self._nstime()+1
+        message.store_message(self.uaid, chid, time1, ttl, data1, {})
+        message.store_message(self.uaid, chid2, time2, ttl, data2, {})
+        message.store_message(self.uaid, chid2, time3, ttl, data1, {})
+
+        message.delete_all_for_user(self.uaid)
+        all_messages = list(message.fetch_messages(self.uaid))
+        eq_(len(all_messages), 0)
+
     def test_message_delete_pagination(self):
         def make_messages(channel_id, count):
             m = []

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -9,7 +9,7 @@ from boto.dynamodb2.exceptions import (
 )
 from boto.dynamodb2.layer1 import DynamoDBConnection
 from boto.dynamodb2.items import Item
-from mock import Mock, patch
+from mock import Mock
 from moto import mock_dynamodb2
 from nose.tools import eq_
 
@@ -450,4 +450,3 @@ class RouterTestCase(unittest.TestCase):
         router.register_user(dict(uaid=uaid, node_id="asdf",
                                   connected_at=1234))
         router.drop_user(uaid)
-

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1121,15 +1121,15 @@ class RegistrationTestCase(unittest.TestCase):
     def test_delete_uaid(self, *args):
         # import pdb;pdb.set_trace()
         self.reg.ap_settings.message.store_message(
-                dummy_uaid,
-                dummy_chid,
-                "1",
-                10000)
+            dummy_uaid,
+            dummy_chid,
+            "1",
+            10000)
         self.reg.ap_settings.message.store_message(
-                dummy_uaid,
-                "test",
-                "2",
-                10000)
+            dummy_uaid,
+            "test",
+            "2",
+            10000)
         self.reg.request.headers["Authorization"] = "HAWK test"
         path = "%s" % dummy_uaid
         self.reg.delete(path)

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1139,3 +1139,17 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.request.headers["Authorization"] = "HAWK test"
         self.reg.delete("/%s/" % dummy_uaid)
         return
+
+    @patch('hawkauthlib.check_signature', return_value=False)
+    def test_delete_bad_auth(self, *args):
+        self.reg.request.headers["Authorization"] = "HAWK test"
+
+        def handle_finish(value):
+            self.reg.set_status.assert_called_with(401)
+
+        self.finish_deferred.addCallback(handle_finish)
+        self.reg.delete("/%s/" % dummy_uaid)
+        return
+
+
+

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1116,8 +1116,8 @@ class RegistrationTestCase(unittest.TestCase):
     def test_delete_chid(self, *args):
         self.reg.request.headers["Authorization"] = "HAWK test"
         path = "%s/%s" % (dummy_uaid, dummy_chid)
-        self.reg.delete(path)
-        return
+        d = self.reg.delete(path)
+        return d
 
     @patch('hawkauthlib.check_signature', return_value=True)
     def test_delete_uaid(self, *args):
@@ -1133,14 +1133,14 @@ class RegistrationTestCase(unittest.TestCase):
             10000)
         self.reg.request.headers["Authorization"] = "HAWK test"
         path = "%s" % dummy_uaid
-        self.reg.delete(path)
-        return
+        d = self.reg.delete(path)
+        return d
 
     @patch('hawkauthlib.check_signature', return_value=True)
     def test_delete_bad_uaid(self, *args):
         self.reg.request.headers["Authorization"] = "HAWK test"
-        self.reg.delete("/%s/" % dummy_uaid)
-        return
+        d = self.reg.delete("/%s/" % dummy_uaid)
+        return d
 
     @patch('hawkauthlib.check_signature', return_value=False)
     def test_delete_bad_auth(self, *args):
@@ -1150,5 +1150,5 @@ class RegistrationTestCase(unittest.TestCase):
             self.reg.set_status.assert_called_with(401)
 
         self.finish_deferred.addCallback(handle_finish)
-        self.reg.delete("/%s/" % dummy_uaid)
-        return
+        d = self.reg.delete("/%s/" % dummy_uaid)
+        return d

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1150,6 +1150,3 @@ class RegistrationTestCase(unittest.TestCase):
         self.finish_deferred.addCallback(handle_finish)
         self.reg.delete("/%s/" % dummy_uaid)
         return
-
-
-

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1119,7 +1119,6 @@ class RegistrationTestCase(unittest.TestCase):
 
     @patch('hawkauthlib.check_signature', return_value=True)
     def test_delete_uaid(self, *args):
-        # import pdb;pdb.set_trace()
         self.reg.ap_settings.message.store_message(
             dummy_uaid,
             dummy_chid,

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -1,5 +1,4 @@
 import unittest
-import uuid
 
 from mock import Mock, patch
 from moto import mock_dynamodb2, mock_s3
@@ -13,8 +12,6 @@ from autopush.main import (
 )
 from autopush.utils import (
     resolve_ip,
-    generate_hash,
-    validate_hash,
 )
 from autopush.settings import AutopushSettings
 
@@ -30,18 +27,6 @@ def setUp():
 def tearDown():
     mock_dynamodb2.stop()
     mock_s3().stop()
-
-
-class UtilsTestCase(unittest.TestCase):
-    def test_validate_hash(self):
-        key = str(uuid.uuid4())
-        payload = str(uuid.uuid4())
-        hashed = generate_hash(key, payload)
-        print hashed
-
-        eq_(validate_hash(key, payload, hashed), True)
-        eq_(validate_hash(key, payload, str(uuid.uuid4())), False)
-        eq_(validate_hash(key, payload, ""), False)
 
 
 class SettingsTestCase(unittest.TestCase):

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
 import uuid
+import time
 
 from mock import Mock, PropertyMock, patch
 from moto import mock_dynamodb2, mock_s3
@@ -106,7 +107,9 @@ class APNSRouterTestCase(unittest.TestCase):
         return d
 
     def test_message_pruning(self):
-        self.router.messages = {1: {'token': 'dump', 'payload': {}}}
+        now = int(time.time())
+        self.router.messages = {now: {'token': 'dump', 'payload': {}},
+                                now-60: {'token': 'dump', 'payload': {}}}
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -42,13 +42,6 @@ def validate_uaid(uaid):
     return False, uuid.uuid4().hex
 
 
-def validate_hash(key, payload, hashed):
-    """Validates that a UAID matches the HMAC value using the supplied
-    secret"""
-    h = hmac.new(key=key, msg=payload, digestmod=hashlib.sha256)
-    return hmac.compare_digest(hashed, h.hexdigest())
-
-
 def generate_hash(key, payload):
     """Generate a HMAC for the uaid using the secret
 

--- a/docs/api/senderids.rst
+++ b/docs/api/senderids.rst
@@ -1,6 +1,6 @@
 .. _senderids_module:
 
-:mod:`autopush.senderids'
+:mod:`autopush.senderids`
 -------------------------
 
 .. automodule:: autopush.senderids

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4
 greenlet==0.4.5
+hawkauthlib==0.1.1
 httpretty==0.8.9
 idna==2.0
 ipaddress==1.0.14

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,6 +25,7 @@ enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4
 greenlet==0.4.5
+hawkauthlib==0.1.1
 httpretty==0.8.9
 idna==2.0
 ipaddress==1.0.14


### PR DESCRIPTION
* Converted proprietary AUTH to HAWK for client REST calls.  Closes #201.
* Added DELETE function to client REST interface. Closes #183 
* Fixes for doc typo
* fixes to CHANGELOG to point to correct S3 repo
* increased test coverage for db to compensate for removed AUTH testing.

@bbangert r?