### PR TITLE
Add Auth token handling for Sender IDs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,16 +11,16 @@ Features
 * Server provided SenderID values for GCM router using clients
   The GCM router will randomly select one of a list of SenderIDs stored in
   S3 under the "org.mozilla.services.autopush"/"senderids" key. The values can
-  be loaded into S3 either via the S3 console, or by runnig an instance of
+  be loaded into S3 either via the S3 console, or by running an instance of
   autopush and passing the values as the "senderid_list" argument. Issue #185.
 * REST Registration will now return a valid ChannelID if one is not specified.
-  Issue #182
+  Issue #182.
 * Add hello timeout. Issue #169.
-* Add .editorconfig for consistent styling in editors. Issue #218.
+* Add .editorconfig for consistent styling in editors. Issue #2.
 * Added --human_logs to display more human friendly logging
 * If you specify the --s3_bucket=None, the app will only use local memory
   and will not call out to the S3 repository. It is STRONGLY suggested that
-  you specify the full --senderid_list data set.
+  you specify the full --senderid_list data set
 
 =======
 
@@ -33,7 +33,7 @@ Bug Fixes
   exceptions ignored. Issue #208.
 * Fix improper attribute reference in delete call. Issue #211.
 * Always include TTL header in response to a WebPush notification. Issue #194.
-* Fixed issue with local senderid data cache. (discovered while debugging)
+* Fixed issue with local senderid data cache. (discovered while debugging.)
 
 WebPush
 -------
@@ -46,7 +46,7 @@ Backwards Incompatibilities
 * Do not specify --gcm_apikey. Instead, store the API key and senderid as
   values in S3. The data may still be written as a JSON string such as:
   ' "`_senderID_`": {"auth": "`_api_key`"}}'
-  activate the GCM bridge by specifying --gcm_enabled
+  activate the GCM bridge by specifying --gcm_enabled.
 
 1.7.2 (2015-10-24)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,11 +16,11 @@ Features
 * REST Registration will now return a valid ChannelID if one is not specified.
   Issue #182.
 * Add hello timeout. Issue #169.
-* Add .editorconfig for consistent styling in editors. Issue #2.
-* Added --human_logs to display more human friendly logging
+* Add .editorconfig for consistent styling in editors. Issue #218.
+* Added --human_logs to display more human friendly logging.
 * If you specify the --s3_bucket=None, the app will only use local memory
   and will not call out to the S3 repository. It is STRONGLY suggested that
-  you specify the full --senderid_list data set
+  you specify the full --senderid_list data set.
 
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Features
 * REST Registration will now return a valid ChannelID if one is not specified.
   Issue #182
 * Add hello timeout. Issue #169.
+* Added --human_logs to display more human friendly logging
+* If you specify the --s3_bucket=None, the app will only use local memory
+  and will not call out to the S3 repository. It is STRONGLY suggested that
+  you specify the full --senderid_list data set.
+
 
 Bug Fixes
 ---------
@@ -26,6 +31,7 @@ Bug Fixes
   exceptions ignored. Issue #208.
 * Fix improper attribute reference in delete call. Issue #211.
 * Always include TTL header in response to a WebPush notification. Issue #194.
+* Fixed issue with local senderid data cache. (discovered while debugging)
 
 WebPush
 -------
@@ -35,6 +41,10 @@ Backwards Incompatibilities
 * Do not specify values for boolean flags.
 * 'cors' is now enabled by default. In it's place use --nocors if you wish
   to disable CORS. Please remove "cors" flag from configuration files.
+* Do not specify --gcm_apikey. Instead, store the API key and senderid as
+  values in S3. The data may still be written as a JSON string such as:
+  ' "`_senderID_`": {"auth": "`_api_key`"}}'
+  activate the GCM bridge by specifying --gcm_enabled
 
 1.7.2 (2015-10-24)
 ==================

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -760,7 +760,8 @@ class RegistrationHandler(AutoendpointHandler):
         new_uaid = False
         if uaid:
             if not self._validate_auth(uaid):
-                return self._error(401, "Invalid Authentication")
+                return self._write_response(
+                    401, 109, message="Unauthorized")
         else:
             # No UAID supplied, make our own
             uaid = uuid.uuid4().hex
@@ -769,7 +770,8 @@ class RegistrationHandler(AutoendpointHandler):
         router_type = params.get("type")
         if new_uaid and router_type not in self.ap_settings.routers:
             log.msg("Invalid parameters", **self._client_info())
-            return self._error(400, "Invalid arguments")
+            return self._write_response(
+                400, 108, message="Invalid arguments")
         self.chid = params["channelID"]
         if new_uaid:
             router = self.ap_settings.routers[router_type]
@@ -796,7 +798,8 @@ class RegistrationHandler(AutoendpointHandler):
         self.start_time = time.time()
 
         if not self._validate_auth(uaid):
-            return self._error(401, "Invalid Authentication")
+            return self._write_response(
+                401, 109, message="Invalid Authentication")
 
         params = self._load_params()
         self.uaid = uaid
@@ -804,7 +807,8 @@ class RegistrationHandler(AutoendpointHandler):
         router_data = params.get("data")
         if router_type not in self.ap_settings.routers or not router_data:
             log.msg("Invalid parameters", **self._client_info())
-            return self._error(400, "Invalid arguments")
+            return self._write_response(
+                400, 108, message="Invalid arguments")
 
         self.add_header("Content-Type", "application/json")
         router = self.ap_settings.routers[router_type]
@@ -878,11 +882,6 @@ class RegistrationHandler(AutoendpointHandler):
         hashed = self.request.headers.get("Authorization", "").strip()
         key = generate_hash(secret, uaid)
         return validate_hash(key, self.request.body, hashed)
-
-    def _error(self, code, msg):
-        """Writes out an error status code"""
-        self.set_status(code, msg)
-        self.finish()
 
     def _load_params(self):
         """Load and parse a JSON body out of the request body, or return an

--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -23,6 +23,7 @@ LOGGER = None
 TWISTED_LOG_MESSAGE = MessageType("twisted:log",
                                   fields(error=bool, message=unicode),
                                   u"A log message from Twisted.")
+HUMAN = False
 
 
 class EliotObserver(object):
@@ -69,14 +70,12 @@ class EliotObserver(object):
 def stdout(message):
     """Format a message appropriately for structured logging capture of stdout
     and then write it to stdout"""
-    # uncomment to get concise human readable logging messages.
-    """
-    if message['error']:
-        sys.stdout.write("ERROR: %s\n" % message['message'])
-    else:
-        sys.stdout.write("       %s\n" % message['message'])
-    return
-    # """
+    if HUMAN:
+        if message['error']:
+            sys.stdout.write("ERROR: %s\n" % message['message'])
+        else:
+            sys.stdout.write("       %s\n" % message['message'])
+        return
     msg = {}
     ts = message.pop("timestamp")
     del message["task_level"]
@@ -100,11 +99,12 @@ def stdout(message):
     sys.stdout.write(json.dumps(msg) + "\n")
 
 
-def setup_logging(logger_name):
+def setup_logging(logger_name, human=False):
     """Patch in the Eliot logger and twisted log interception"""
-    global LOGGER
+    global LOGGER, HUMAN
     LOGGER = "-".join([logger_name,
                        pkg_resources.get_distribution("autopush").version])
+    HUMAN = human
     add_destination(stdout)
     ellie = EliotObserver()
     ellie.start()

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -113,6 +113,9 @@ def add_shared_args(parser):
     parser.add_argument('--gcm_enabled', help="Enable GCM Bridge",
                         action="store_true", default=False,
                         env_var="GCM_ENABLED")
+    parser.add_argument('--human_logs', help="Enable human readable logs",
+                        action="store_true", default=False)
+    # No ENV because this is for humans
 
 
 def add_external_router_args(parser):
@@ -321,7 +324,7 @@ def connection_main(sysargs=None):
         env=args.env,
         hello_timeout=args.hello_timeout,
     )
-    setup_logging("Autopush")
+    setup_logging("Autopush", args.human_logs)
 
     r = RouterHandler
     r.ap_settings = settings
@@ -419,7 +422,7 @@ def endpoint_main(sysargs=None):
         senderid_list=senderid_list,
     )
 
-    setup_logging("Autoendpoint")
+    setup_logging("Autoendpoint", args.human_logs)
 
     # Endpoint HTTP router
     site = cyclone.web.Application([

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -262,6 +262,7 @@ def make_settings(args, **kwargs):
             router_conf["gcm"] = {"ttl": args.gcm_ttl,
                                   "dryrun": args.gcm_dryrun,
                                   "collapsekey": args.gcm_collapsekey,
+
                                   "senderid_list": args.senderid_list}
 
     return AutopushSettings(

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -269,7 +269,10 @@ def make_settings(args, **kwargs):
                 senderid_expry=args.senderid_expry,
                 use_s3=args.s3_bucket.lower() != "none",
                 senderid_list=list))
-            senderID = senderIDs.getID()
+            # This is an init check to verify that things are configured
+            # correctly. Otherwise errors may creep in later that go
+            # unaccounted.
+            senderID = senderIDs.choose_ID()
             if senderID is None:
                 log.err("No GCM SenderIDs specified or found.")
                 return

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -25,7 +25,7 @@ class GCMRouter(object):
         self.collapseKey = router_conf.get("collapseKey", "simplepush")
         self.senderIDs = router_conf.get("senderIDs", SenderIDs(router_conf))
         try:
-            senderID = self.senderIDs.getID()
+            senderID = self.senderIDs.choose_ID()
             self.gcm = gcmclient.GCM(senderID.get("auth"))
         except:
             raise IOError("GCM Bridge not initiated in main")
@@ -40,7 +40,7 @@ class GCMRouter(object):
         if not router_data.get("token"):
             self._error("connect info missing 'token'", status=401)
         # Assign a senderid
-        router_data["creds"] = self.creds = self.senderIDs.getID()
+        router_data["creds"] = self.creds = self.senderIDs.choose_ID()
         return router_data
 
     def route_notification(self, notification, uaid_data):

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -13,7 +13,7 @@ an acronym for "org.mozilla.services")
 
 The SenderID list has the following format:
 
-     {"`senderId`": {"auth": "`API Key`"}, ...}
+     {"`senderID`": {"auth": "`API Key`"}, ...}
 
 We use a dictionary of dictionaries to allow for future expansion.
 
@@ -85,14 +85,16 @@ class SenderIDs(object):
 
     def update(self, senderIDs):
         """Update the S3 bucket containing the SenderIDs"""
-        if not self._use_s3:
-            # Skip using s3 (For debugging)
-            self._updated = time.time()
-            return
         if not senderIDs:
             return
         if type(senderIDs) is not dict:
-            log.err("Wrong data type for senderIDs. Should be dict. Ignoring")
+            log.err("Wrong data type for senderIDs. Should be dict.")
+            return
+        if not self._use_s3:
+            # Skip using s3 (For debugging)
+            if senderIDs:
+                self._senderIDs = senderIDs
+            self._updated = time.time()
             return
         try:
             bucket = self.conn.get_bucket(self.ID)
@@ -116,6 +118,8 @@ class SenderIDs(object):
     def getID(self):
         """Return a randomly selected SenderID, refreshing if required"""
         self._refresh()
+        if not len(self._senderIDs):
+            return None
         choice = random.choice(self._senderIDs.keys())
         record = self._senderIDs.get(choice)
         record["senderID"] = choice

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -25,6 +25,7 @@ import random
 from boto.exception import S3ResponseError
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key
+from twisted.python import log
 
 # re-read from source every 15 minutes or so.
 SENDERID_EXPRY = 15*60
@@ -35,7 +36,8 @@ class SenderIDs(object):
     """Handle Read, Write and cache of SenderID values from S3"""
     _updated = 0
     _expry = SENDERID_EXPRY
-    _senderIDs = []
+    _senderIDs = {}
+    _use_s3 = True
     KEYNAME = "senderids"
 
     def _write(self, bucket, senderIDs):
@@ -53,6 +55,10 @@ class SenderIDs(object):
 
     def _refresh(self):
         """Refresh the senderIDs from the S3 bucket"""
+        if not self._use_s3:
+            # Skip using s3 (For debugging)
+            self._updated = time.time()
+            return
         # Only refresh if needed.
         if time.time() < self._updated + self._expry:
             return
@@ -60,12 +66,28 @@ class SenderIDs(object):
             bucket = self.conn.get_bucket(self.ID)
             key = Key(bucket)
             key.key = self.KEYNAME
-            self._senderIDs = json.loads(key.get_contents_as_string())
+            candidates = json.loads(key.get_contents_as_string())
+            if candidates:
+                if type(candidates) is not dict:
+                    log.err("Wrong data type stored for senderIDs. "
+                            "Should be dict. Ignoring.")
+                    return
+                self._senderIDs = candidates
+                self._updated = time.time()
         except S3ResponseError:
             self._create(self._senderIDs)
 
     def update(self, senderIDs):
         """Update the S3 bucket containing the SenderIDs"""
+        if not self._use_s3:
+            # Skip using s3 (For debugging)
+            self._updated = time.time()
+            return
+        if not senderIDs:
+            return
+        if type(senderIDs) is not dict:
+            log.err("Wrong data type for senderIDs. Should be dict. Ignoring")
+            return
         try:
             bucket = self.conn.get_bucket(self.ID)
             self._write(bucket, senderIDs)
@@ -78,17 +100,31 @@ class SenderIDs(object):
             self._refresh()
         return self._senderIDs
 
+    def get(self, id):
+        """Return the associated record for a given SenderID"""
+        record = self._senderIDs.get(id)
+        if record:
+            record["senderID"] = id
+        return record
+
     def getID(self):
         """Return a randomly selected SenderID, refreshing if required"""
         self._refresh()
-        return random.choice(self._senderIDs)
+        choice = random.choice(self._senderIDs.keys())
+        record = self._senderIDs.get(choice)
+        record["senderID"] = choice
+        return record
 
     def __init__(self, args):
         """Optionally load or fetch the set of SenderIDs from S3"""
         self.conn = S3Connection()
         self.ID = args.get("s3_bucket", DEFAULT_BUCKET)
         self._expry = args.get("senderid_expry", SENDERID_EXPRY)
-        senderIDs = args.get("senderid_list", [])
+        self._use_s3 = args.get("use_s3", True)
+        senderIDs = args.get("senderid_list", {})
         if senderIDs:
-            self.update(senderIDs)
+            if type(senderIDs) is not dict:
+                log.err("senderid_list is not a dict. Ignoring")
+            else:
+                self.update(senderIDs)
         self._refresh()

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -8,8 +8,14 @@ This module uses a bucket named "oms_autopush" by default,
 and stores the list of SenderIDs as a JSON string under the key of "senderids".
 Please note that AWS uses the bucket ID as part of a TLS hostname. This
 means that the Bucket ID cannot have ".", be over 255 characters in length,
-and must be globally unique. (In our case, we use "oms_" as a prefix. It's
+and must be globally unique. (In our case, we use "oms_*" as a prefix. It's
 an acronym for "org.mozilla.services")
+
+The SenderID list has the following format:
+
+     {"`senderId`": {"auth": "`API Key`"}, ...}
+
+We use a dictionary of dictionaries to allow for future expansion.
 
 You can either update the list of SenderIDs using the S3 console, or you
 can load the SenderIDs by using the "--senderid_list" argument. It is

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -160,6 +160,7 @@ class AutopushSettings(object):
             conf["s3_bucket"] = s3_bucket
             conf["senderid_expry"] = senderid_expry
             conf["senderid_list"] = senderid_list
+            conf["use_s3"] = s3_bucket != 'None'
             self.routers["gcm"] = GCMRouter(self, conf)
 
         # Env

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -156,12 +156,7 @@ class AutopushSettings(object):
         if 'apns' in router_conf:
             self.routers["apns"] = APNSRouter(self, router_conf["apns"])
         if 'gcm' in router_conf:
-            conf = router_conf.get("gcm", {})
-            conf["s3_bucket"] = s3_bucket
-            conf["senderid_expry"] = senderid_expry
-            conf["senderid_list"] = senderid_list
-            conf["use_s3"] = s3_bucket != 'None'
-            self.routers["gcm"] = GCMRouter(self, conf)
+            self.routers["gcm"] = GCMRouter(self, router_conf["gcm"])
 
         # Env
         self.env = env

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -67,7 +67,7 @@ class AutopushSettings(object):
                  enable_cors=False,
                  s3_bucket=DEFAULT_BUCKET,
                  senderid_expry=SENDERID_EXPRY,
-                 senderid_list="[]",
+                 senderid_list={},
                  hello_timeout=0,
                  ):
         """Initialize the Settings object

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -200,7 +200,7 @@ class EndpointTestCase(unittest.TestCase):
         self.router_mock = settings.router = Mock(spec=Router)
         self.storage_mock = settings.storage = Mock(spec=Storage)
         self.senderIDs_mock = settings.senderIDs = Mock(spec=SenderIDs)
-        self.senderIDs_mock.getID.return_value = "test_senderid"
+        self.senderIDs_mock.get_ID.return_value = "test_senderid"
 
         self.request_mock = Mock(body=b'', arguments={}, headers={})
         self.endpoint = endpoint.EndpointHandler(Application(),
@@ -710,7 +710,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.router_mock = settings.router = Mock(spec=Router)
         self.storage_mock = settings.storage = Mock(spec=Storage)
         self.senderIDs_mock = settings.senderIDs = Mock(spec=SenderIDs)
-        self.senderIDs_mock.getID.return_value = "test_senderid"
+        self.senderIDs_mock.get_ID.return_value = "test_senderid"
 
         self.request_mock = Mock(body=b'', arguments={}, headers={})
         self.reg = endpoint.RegistrationHandler(Application(),

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -218,6 +218,12 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.finish = lambda: d.callback(True)
         self.endpoint.start_time = time.time()
 
+    def _check_error(self, code, errno, error):
+        d = json.loads(self.write_mock.call_args[0][0])
+        eq_(d.get("code"), code)
+        eq_(d.get("errno"), errno)
+        eq_(d.get("error"), error)
+
     def test_uaid_lookup_results(self):
         fresult = dict(router_type="test")
         frouter = Mock(spec=Router)
@@ -505,11 +511,7 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.router_mock.get_uaid.assert_called_with('123')
             self.status_mock.assert_called_with(404)
-            data = self.write_mock.call_args[0][0]
-            d = json.loads(data)
-            self.assertEqual(d.get("code"), 404)
-            self.assertEqual(d.get("errno"), 103)
-            self.assertEqual(d.get("error"), "Not Found")
+            self._check_error(404, 103, "Not Found")
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.version, self.endpoint.data = 789, None
@@ -721,6 +723,12 @@ class RegistrationTestCase(unittest.TestCase):
         d = self.finish_deferred = Deferred()
         self.reg.finish = lambda: d.callback(True)
 
+    def _check_error(self, code, errno, error):
+        d = json.loads(self.write_mock.call_args[0][0])
+        eq_(d.get("code"), code)
+        eq_(d.get("errno"), errno)
+        eq_(d.get("error"), error)
+
     def test_client_info(self):
         h = self.request_mock.headers
         h["user-agent"] = "myself"
@@ -893,8 +901,7 @@ class RegistrationTestCase(unittest.TestCase):
         ))
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(
-                400, 'Invalid arguments')
+            self._check_error(400, 108, "Bad Request")
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.post()
@@ -909,8 +916,7 @@ class RegistrationTestCase(unittest.TestCase):
         ))
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(
-                400, 'Invalid arguments')
+            self._check_error(400, 108, "Bad Request")
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.post()
@@ -949,8 +955,7 @@ class RegistrationTestCase(unittest.TestCase):
         ))
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(
-                401, 'Invalid Authentication')
+            self._check_error(401, 109, "Unauthorized")
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.post('invalid')
@@ -964,8 +969,7 @@ class RegistrationTestCase(unittest.TestCase):
         ))
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(
-                401, 'Invalid Authentication')
+            self._check_error(401, 109, 'Unauthorized')
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.post(dummy_uaid)
@@ -1071,8 +1075,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.request.headers["Authorization"] = "Fred Smith"
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(
-                401, "Invalid Authentication")
+            self._check_error(401, 109, "Unauthorized")
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.put(dummy_uaid)
@@ -1089,8 +1092,7 @@ class RegistrationTestCase(unittest.TestCase):
         ))
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(
-                400, "Invalid arguments")
+            self._check_error(400, 108, "Bad Request")
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.put(dummy_uaid)

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -42,3 +42,9 @@ class EliotLogTestCase(twisted.trial.unittest.TestCase):
             eq_(len(mock_stdout.mock_calls), 1)
             kwargs = mock_stdout.mock_calls[0][1][0]
         ok_("Type" in kwargs)
+
+    def test_human_logs(self):
+        setup_logging("Autopush", True)
+        with patch("sys.stdout") as mock_stdout:
+            log.msg("omg!", Type=7)
+            eq_(len(mock_stdout.mock_calls), 1)

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -46,5 +46,9 @@ class EliotLogTestCase(twisted.trial.unittest.TestCase):
     def test_human_logs(self):
         setup_logging("Autopush", True)
         with patch("sys.stdout") as mock_stdout:
+            mock_stdout.reset_mock()
             log.msg("omg!", Type=7)
+            eq_(len(mock_stdout.mock_calls), 4)
+            mock_stdout.reset_mock()
+            log.err("wtf!", Type=7)
             eq_(len(mock_stdout.mock_calls), 4)

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -47,4 +47,4 @@ class EliotLogTestCase(twisted.trial.unittest.TestCase):
         setup_logging("Autopush", True)
         with patch("sys.stdout") as mock_stdout:
             log.msg("omg!", Type=7)
-            eq_(len(mock_stdout.mock_calls), 1)
+            eq_(len(mock_stdout.mock_calls), 4)

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -124,13 +124,18 @@ class EndpointMainTestCase(unittest.TestCase):
             "--ssl_key=keys/server.key",
         ])
 
+    def test_bad_senderidlist(self):
+        endpoint_main([
+            "--senderid_list='[Invalid'"
+        ])
+
     def test_ping_settings(self):
         class arg:
             # important stuff
             external_router = True
-            gcm_apikey = "gcm.key"
             apns_cert_file = "cert.file"
             apns_key_file = "key.file"
+            gcm_enabled = True
             # less important stuff
             apns_sandbox = False
             gcm_ttl = 999
@@ -159,11 +164,13 @@ class EndpointMainTestCase(unittest.TestCase):
             message_tablename = "None"
             message_read_throughput = 0
             message_write_throughput = 0
+            senderid_list = {}
 
         ap = make_settings(arg)
         # verify that the hostname is what we said.
         eq_(ap.hostname, arg.hostname)
-        eq_(ap.routers["gcm"].gcm.api_key, arg.gcm_apikey)
+        # gcm isn't created until later since we may have to pull
+        # config info from s3
         eq_(ap.routers["apns"].apns.cert_file, arg.apns_cert_file)
         eq_(ap.routers["apns"].apns.key_file, arg.apns_key_file)
         eq_(ap.wake_timeout, 10)

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -96,6 +96,44 @@ class ConnectionMainTestCase(unittest.TestCase):
 
 
 class EndpointMainTestCase(unittest.TestCase):
+    class test_arg:
+        # important stuff
+        external_router = True
+        apns_cert_file = "cert.file"
+        apns_key_file = "key.file"
+        gcm_enabled = True
+        # less important stuff
+        apns_sandbox = False
+        gcm_ttl = 999
+        gcm_dryrun = False
+        gcm_collapsekey = "collapse"
+
+        # filler
+        crypto_key = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+        datadog_api_key = "datadog_api_key"
+        datadog_app_key = "datadog_app_key"
+        datadog_flush_interval = "datadog_flush_interval"
+        hostname = "hostname"
+        statsd_host = "statsd_host"
+        statsd_port = "statsd_port"
+        router_tablename = "None"
+        storage_tablename = "None"
+        storage_read_throughput = 0
+        storage_write_throughput = 0
+        router_read_throughput = 0
+        router_write_throughput = 0
+        resolve_hostname = False
+        # UDP
+        wake_pem = "test"
+        wake_timeout = 10
+        wake_server = "http://example.com"
+        message_tablename = "None"
+        message_read_throughput = 0
+        message_write_throughput = 0
+        senderid_list = '{"12345":{"auth":"abcd"}}'
+        s3_bucket = "None"
+        senderid_expry = 0
+
     def setUp(self):
         mock_s3().start()
         patchers = [
@@ -130,47 +168,18 @@ class EndpointMainTestCase(unittest.TestCase):
         ])
 
     def test_ping_settings(self):
-        class arg:
-            # important stuff
-            external_router = True
-            apns_cert_file = "cert.file"
-            apns_key_file = "key.file"
-            gcm_enabled = True
-            # less important stuff
-            apns_sandbox = False
-            gcm_ttl = 999
-            gcm_dryrun = False
-            gcm_collapsekey = "collapse"
-
-            # filler
-            crypto_key = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
-            datadog_api_key = "datadog_api_key"
-            datadog_app_key = "datadog_app_key"
-            datadog_flush_interval = "datadog_flush_interval"
-            hostname = "hostname"
-            statsd_host = "statsd_host"
-            statsd_port = "statsd_port"
-            router_tablename = "None"
-            storage_tablename = "None"
-            storage_read_throughput = 0
-            storage_write_throughput = 0
-            router_read_throughput = 0
-            router_write_throughput = 0
-            resolve_hostname = False
-            # UDP
-            wake_pem = "test"
-            wake_timeout = 10
-            wake_server = "http://example.com"
-            message_tablename = "None"
-            message_read_throughput = 0
-            message_write_throughput = 0
-            senderid_list = {}
-
-        ap = make_settings(arg)
+        ap = make_settings(self.test_arg)
         # verify that the hostname is what we said.
-        eq_(ap.hostname, arg.hostname)
+        eq_(ap.hostname, self.test_arg.hostname)
         # gcm isn't created until later since we may have to pull
         # config info from s3
-        eq_(ap.routers["apns"].apns.cert_file, arg.apns_cert_file)
-        eq_(ap.routers["apns"].apns.key_file, arg.apns_key_file)
+        eq_(ap.routers["apns"].apns.cert_file, self.test_arg.apns_cert_file)
+        eq_(ap.routers["apns"].apns.key_file, self.test_arg.apns_key_file)
         eq_(ap.wake_timeout, 10)
+
+    def test_bad_senders(self):
+        oldList = self.test_arg.senderid_list
+        self.test_arg.senderid_list = "{}"
+        ap = make_settings(self.test_arg)
+        eq_(ap, None)
+        self.test_arg.senderid_list = oldList

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -145,18 +145,17 @@ class APNSRouterTestCase(unittest.TestCase):
 
 
 class GCMRouterTestCase(unittest.TestCase):
-    def setUp(self):
+
+    @patch("gcmclient.gcm.GCM", spec=gcmclient.gcm.GCM)
+    def setUp(self, fgcm):
         settings = AutopushSettings(
             hostname="localhost",
             statsd_host=None,
         )
-        # Mock out GCM client
-        self._old_gcm = gcmclient.GCM
-        gcmclient.GCM = Mock(spec=gcmclient.GCM)
-
-        gcm_config = {'apikey': '12345678abcdefg',
-                      's3_bucket': 'oms_autopush_test',
-                      'senderid_list': ['test123']}
+        gcm_config = {'s3_bucket': 'oms_autopush_test',
+                      'senderid_list': {'test123':
+                                        {"auth": "12345678abcdefg"}}}
+        self.gcm = fgcm
         self.router = GCMRouter(settings, gcm_config)
         self.notif = Notification(10, "data", dummy_chid, None, 200)
         self.router_data = dict(router_data=dict(token="connect_data"))
@@ -166,10 +165,7 @@ class GCMRouterTestCase(unittest.TestCase):
         mock_result.not_registered = dict()
         mock_result.needs_retry.return_value = False
         self.mock_result = mock_result
-        self.router.gcm.send.return_value = mock_result
-
-    def tearDown(self):
-        gcmclient.GCM = self._old_gcm
+        fgcm.send.return_value = mock_result
 
     def _check_error_call(self, exc, code):
         ok_(isinstance(exc, RouterException))
@@ -179,12 +175,16 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_register(self):
         result = self.router.register("uaid", {"token": "connect_data"})
-        eq_(result, {"token": "connect_data", "senderid": "test123"})
+        # Check the information that will be recorded for this user
+        eq_(result, {"token": "connect_data",
+                     "creds": {"senderID": "test123",
+                               "auth": "12345678abcdefg"}})
 
     def test_register_bad(self):
         self.assertRaises(RouterException, self.router.register, "uaid", {})
 
     def test_router_notification(self):
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -196,7 +196,8 @@ class GCMRouterTestCase(unittest.TestCase):
     def test_router_notification_gcm_auth_error(self):
         def throw_auth(arg):
             raise gcmclient.GCMAuthenticationError()
-        self.router.gcm.send.side_effect = throw_auth
+        self.gcm.send.side_effect = throw_auth
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(fail):
@@ -207,7 +208,8 @@ class GCMRouterTestCase(unittest.TestCase):
     def test_router_notification_gcm_other_error(self):
         def throw_other(arg):
             raise Exception("oh my!")
-        self.router.gcm.send.side_effect = throw_other
+        self.gcm.send.side_effect = throw_other
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(fail):
@@ -217,6 +219,7 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_router_notification_gcm_id_change(self):
         self.mock_result.canonical["old"] = "new"
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -228,6 +231,7 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_router_notification_gcm_not_regged(self):
         self.mock_result.not_registered = {"connect_data": True}
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -239,6 +243,7 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_router_notification_gcm_failed_items(self):
         self.mock_result.failed = dict(connect_data=True)
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(fail):
@@ -248,6 +253,7 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_router_notification_gcm_needs_retry(self):
         self.mock_result.needs_retry.return_value = True
+        self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(fail):

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -273,11 +273,7 @@ class GCMRouterTestCase(unittest.TestCase):
         self.router._process_reply = Mock()
         d = self.router._route(self.notif,
                                self.router_data["router_data"])
-
-        def check_results(result):
-            ok_(isinstance(result, RouterResponse))
-            assert(self.router.gcm.send.called)
-        d.addCallback(check_results)
+        ok_(self.router.gcm is not None)
         return d
 
 

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -183,7 +183,7 @@ class GCMRouterTestCase(unittest.TestCase):
     def test_register_bad(self):
         self.assertRaises(RouterException, self.router.register, "uaid", {})
 
-    def test_router_notification(self):
+    def test_route_notification(self):
         self.router.gcm = self.gcm
         d = self.router.route_notification(self.notif, self.router_data)
 
@@ -266,6 +266,19 @@ class GCMRouterTestCase(unittest.TestCase):
         resp = {"key": "value"}
         eq_({"key": "value", "senderid": "test123"},
             self.router.amend_msg(resp))
+
+    @patch("gcmclient.GCM", spec=gcmclient.GCM)
+    def test_route_gcm(self, fgcm):
+        fgcm.send.return_value = self.mock_result
+        self.router._process_reply = Mock()
+        d = self.router._route(self.notif,
+                               self.router_data["router_data"])
+
+        def check_results(result):
+            ok_(isinstance(result, RouterResponse))
+            assert(self.router.gcm.send.called)
+        d.addCallback(check_results)
+        return d
 
 
 class SimplePushRouterTestCase(unittest.TestCase):

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -177,12 +177,12 @@ class GCMRouterTestCase(unittest.TestCase):
         self.flushLoggedErrors()
 
     def test_init(self):
-        self.router.senderIDs.getID = Mock()
+        self.router.senderIDs.get_ID = Mock()
 
         def throw_ex():
             raise AttributeError
         fsenderids = Mock()
-        fsenderids.getID.side_effect = throw_ex
+        fsenderids.choose_ID.side_effect = throw_ex
         self.assertRaises(IOError, GCMRouter, {}, {"senderIDs": fsenderids})
 
     def test_register(self):

--- a/autopush/tests/test_senderids.py
+++ b/autopush/tests/test_senderids.py
@@ -107,6 +107,15 @@ class SenderIDsTestCase(unittest.TestCase):
         fetch = senderIDs.get('test123')
         eq_(fetch, {"senderID": "test123", "auth": "abc"})
 
+    def test_get_norecord(self):
+        settings = dict(
+            s3_bucket=TEST_BUCKET,
+            senderid_expry=0,
+        )
+        senderIDs = SenderIDs(settings)
+        fetch = senderIDs.getID()
+        eq_(fetch, None)
+
     def test_refresh(self):
         settings = dict(
             s3_bucket=TEST_BUCKET,

--- a/autopush/tests/test_senderids.py
+++ b/autopush/tests/test_senderids.py
@@ -45,8 +45,8 @@ class SenderIDsTestCase(unittest.TestCase):
             json.dumps(settings.get("senderid_list")))
 
         eq_(senderIDs.senderIDs(), settings.get("senderid_list"))
-        # getID may modify the record in memory adding a field.
-        got = senderIDs.getID()
+        # choose_ID may modify the record in memory adding a field.
+        got = senderIDs.choose_ID()
         ok_(got.get('senderID') in settings.get("senderid_list").keys())
         ok_(got.get('auth') ==
             settings.get("senderid_list")[got.get('senderID')]['auth'])
@@ -104,7 +104,7 @@ class SenderIDsTestCase(unittest.TestCase):
             senderid_list=test_list,
             )
         senderIDs = SenderIDs(settings)
-        fetch = senderIDs.get('test123')
+        fetch = senderIDs.get_ID('test123')
         eq_(fetch, {"senderID": "test123", "auth": "abc"})
 
     def test_get_norecord(self):
@@ -113,7 +113,7 @@ class SenderIDsTestCase(unittest.TestCase):
             senderid_expry=0,
         )
         senderIDs = SenderIDs(settings)
-        fetch = senderIDs.getID()
+        fetch = senderIDs.choose_ID()
         eq_(fetch, None)
 
     def test_refresh(self):

--- a/docs/api/senderids.rst
+++ b/docs/api/senderids.rst
@@ -1,6 +1,6 @@
 .. _senderids_module:
 
-:mod:`autopush.senderids'
+:mod:`autopush.senderids`
 -------------------------
 
 .. automodule:: autopush.senderids

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -5,8 +5,6 @@
 
 .. automodule:: autopush.utils
 
-.. autofunction:: str2bool
-
 .. autofunction:: canonical_url
 
 .. autofunction:: resolve_ip


### PR DESCRIPTION
Resolves #220 

In addition, the following were added to help GCM debugging:

Added the flags:
--gcm_enabled - Enable GCM bridge
--s3_bucket=None - will skip using remote S3 (to resolve issues with moto)
--human_logs - Render stdout logs in a more human readable format

Removed the flags:
--gcm_apikey

* Changed the format of the SenderID list
* Updated the docs to fix errors and reflect new state.

@bbangert r?