### PR TITLE
Bug 1225253 - Implement DELETE.

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -860,11 +860,13 @@ class RegistrationHandler(AutoendpointHandler):
                                                tags=self.base_tags())
             d = deferToThread(self._deleteChannel, message, uaid, chid)
             d.addErrback(self._response_err)
+            d.addCallback(self._success)
             return d
         # nuke uaid
         d = deferToThread(self._deleteUaid, message, uaid,
                           self.ap_settings.router)
         d.addErrback(self._response_err)
+        d.addCallback(self._success)
         return d
 
     #############################################################


### PR DESCRIPTION
@jrconlin This needs review and a Part 3 -- tests.  I am not at all familiar with your testing regimen, so can you both run the existing test suite, and add tests exercising this functionality?

It's worth noting that `DELETE uaid/chid` gives a 401 when `uaid` is unknown, since the auth validation fails first.  I think this is wrong -- it should return 404 -- but I'm not going to address it right now.