### PR TITLE
Add message table rotation for webpush users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Autopush Changelog
 Features
 --------
 
+* Add message table rotation for webpush users. Issue #191.
+
 Bug Fixes
 ---------
 

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -312,9 +312,9 @@ class Message(object):
         try:
             result = self.table.get_item(consistent=True, uaid=uaid,
                                          chidmessageid=" ")
-            return result["chids"] or set([])
+            return (True, result["chids"] or set([]))
         except ItemNotFound:
-            return set([])
+            return False, set([])
 
     @track_provisioned
     def save_channels(self, uaid, channels):

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -22,11 +22,11 @@ from boto.dynamodb2.types import NUMBER
 log = logging.getLogger(__file__)
 
 
-def next_month(delta=1):
+def get_month(delta=0):
     """Basic helper function to get a datetime.date object iterations months
     ahead/behind of now."""
     new = last = datetime.date.today()
-    # Move  until we hit a new month, this avoids having to manually
+    # Move until we hit a new month, this avoids having to manually
     # check year changes as we push forward or backward since the Python
     # timedelta math handles it for us
     for _ in range(abs(delta)):
@@ -42,7 +42,7 @@ def next_month(delta=1):
 def make_rotating_tablename(prefix, delta=0):
     """Creates a tablename for table rotation based on a prefix with a given
     month delta."""
-    date = next_month(delta=delta)
+    date = get_month(delta=delta)
     return "{}_{}_{}".format(prefix, date.year, date.month)
 
 

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -543,9 +543,9 @@ class Router(object):
     def update_message_month(self, uaid, month):
         """Update the route tables current_message_month"""
         conn = self.table.connection
-        db_key = self.encode(uaid)
+        db_key = self.encode({"uaid": uaid})
         expr = "SET current_month=:curmonth"
-        expr_values = self.encode(dict(curmonth=month))
+        expr_values = self.encode({":curmonth": month})
         conn.update_item(
             self.table.table_name,
             db_key,

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -317,6 +317,15 @@ class Message(object):
             return set([])
 
     @track_provisioned
+    def save_channels(self, uaid, channels):
+        """Save out a set of channels"""
+        self.table.put_item(data=dict(
+            uaid=uaid,
+            chidmessageid=" ",
+            chids=channels
+        ))
+
+    @track_provisioned
     def store_message(self, uaid, channel_id, message_id, ttl, data=None,
                       headers=None, timestamp=None):
         """Stores a message in the message table for the given uaid/channel with
@@ -529,6 +538,21 @@ class Router(object):
     @track_provisioned
     def drop_user(self, uaid):
         return self.table.delete_item(uaid=uaid)
+
+    @track_provisioned
+    def update_message_month(self, uaid, month):
+        """Update the route tables current_message_month"""
+        conn = self.table.connection
+        db_key = self.encode(uaid)
+        expr = "SET current_month=:curmonth"
+        expr_values = self.encode(dict(curmonth=month))
+        conn.update_item(
+            self.table.table_name,
+            db_key,
+            update_expression=expr,
+            expression_attribute_values=expr_values,
+        )
+        return True
 
     @track_provisioned
     def clear_node(self, item):

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -410,6 +410,10 @@ def connection_main(sysargs=None):
 
     l = task.LoopingCall(periodic_reporter, settings)
     l.start(1.0)
+
+    # Start the table rotation checker/updater
+    l = task.LoopingCall(settings.update_rotating_tables)
+    l.start(60)
     reactor.run()
 
 

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -81,8 +81,9 @@ class SimpleRouter(object):
         self.udp = uaid_data.get("udp")
         router = self.ap_settings.router
 
-        # Preflight check, hook used by webpush to verify channel id
-        yield self.preflight_check(uaid, notification.channel_id)
+        # Preflight check, hook used by webpush to verify channel id, extra
+        # stores any additional data to pass to storing the message
+        extra = yield self.preflight_check(uaid, notification.channel_id)
 
         # Node_id is present, attempt delivery.
         # - Send Notification to node
@@ -111,7 +112,7 @@ class SimpleRouter(object):
         #   - Success (older version): Done, return 202
         #   - Error (db error): Done, return 503
         try:
-            result = yield self._save_notification(uaid, notification)
+            result = yield self._save_notification(uaid, notification, extra)
             if result is False:
                 self.metrics.increment("router.broadcast.miss")
                 returnValue(self.stored_response(notification))
@@ -180,7 +181,7 @@ class SimpleRouter(object):
     ###########################################################
     #                    Blocking Helper Functions
     #############################################################
-    def _save_notification(self, uaid, notification):
+    def _save_notification(self, uaid, notification, extra):
         """Saves a notification, returns a deferred.
 
         This function is split out for the Webpush-style individual

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -179,6 +179,16 @@ class AutopushSettings(object):
 
         self.hello_timeout = hello_timeout
 
+    @property
+    def message(self):
+        """Property that access the current message table"""
+        return self.message_tables[self.current_msg_month]
+
+    @message.setter
+    def message(self, value):
+        """Setter to set the current message table"""
+        self.message_tables[self.current_msg_month] = value
+
     def create_initial_message_tables(self):
         """Initializes a dict of the initial rotating messages tables.
 

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -142,9 +142,7 @@ class AutopushSettings(object):
             storage_read_throughput,
             storage_write_throughput)
         self.message_table = get_rotating_message_table(
-            message_tablename,
-            message_read_throughput,
-            message_write_throughput)
+            message_tablename)
         self._message_prefix = message_tablename
         self.storage = Storage(self.storage_table, self.metrics)
         self.router = Router(self.router_table, self.metrics)

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -214,7 +214,7 @@ class AutopushSettings(object):
         today = datetime.date.today()
         if today.month == self.current_month:
             # No change in month, we're fine.
-            returnValue()
+            returnValue(False)
 
         # Get tables for the new month, and verify they exist before we try to
         # switch over
@@ -225,13 +225,14 @@ class AutopushSettings(object):
         except Exception:
             tblname = make_rotating_tablename(self._message_prefix)
             log.err("Unable to locate new message table: %s" % tblname)
-            returnValue()
+            returnValue(False)
 
         # Both tables found, safe to switch-over
         self.current_month = today.month
-        self.current_msg_month = message_table.table.table_name
+        self.current_msg_month = message_table.table_name
         self.message_tables[self.current_msg_month] = \
-            Message(self.message_table, self.metrics)
+            Message(message_table, self.metrics)
+        returnValue(True)
 
     def update(self, **kwargs):
         """Update the arguments, if a ``crypto_key`` is in kwargs then the

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -1,14 +1,22 @@
 """Autopush Settings Object and Setup"""
+import datetime
 import socket
 
 from cryptography.fernet import Fernet, MultiFernet
 from twisted.internet import reactor
+from twisted.internet.defer import (
+    inlineCallbacks,
+    returnValue,
+)
+from twisted.internet.threads import deferToThread
+from twisted.python import log
 from twisted.web.client import Agent, HTTPConnectionPool
 
 from autopush.db import (
     get_router_table,
     get_storage_table,
-    get_message_table,
+    get_rotating_message_table,
+    make_rotating_tablename,
     preflight_check,
     Storage,
     Router,
@@ -129,15 +137,23 @@ class AutopushSettings(object):
         self.router_table = get_router_table(router_tablename,
                                              router_read_throughput,
                                              router_write_throughput)
-        self.storage_table = get_storage_table(storage_tablename,
-                                               storage_read_throughput,
-                                               storage_write_throughput)
-        self.message_table = get_message_table(message_tablename,
-                                               message_read_throughput,
-                                               message_write_throughput)
+        self.storage_table = get_storage_table(
+            storage_tablename,
+            storage_read_throughput,
+            storage_write_throughput)
+        self.message_table = get_rotating_message_table(
+            message_tablename,
+            message_read_throughput,
+            message_write_throughput)
+        self._message_prefix = message_tablename
         self.storage = Storage(self.storage_table, self.metrics)
         self.router = Router(self.router_table, self.metrics)
-        self.message = Message(self.message_table, self.metrics)
+
+        # Used to determine whether a connection is out of date with current
+        # db objects
+        self.current_msg_month = make_rotating_tablename(self._message_prefix)
+        self.current_month = datetime.date.today().month
+        self.create_initial_message_tables()
 
         # Run preflight check
         preflight_check(self.storage, self.router)
@@ -164,6 +180,50 @@ class AutopushSettings(object):
         self.env = env
 
         self.hello_timeout = hello_timeout
+
+    def create_initial_message_tables(self):
+        """Initializes a dict of the initial rotating messages tables.
+
+        An entry for last months table, and an entry for this months table.
+
+        """
+        last_month = get_rotating_message_table(self._message_prefix, -1)
+        this_month = get_rotating_message_table(self._message_prefix)
+        self.message_tables = {
+            last_month.table_name: Message(last_month, self.metrics),
+            this_month.table_name: Message(this_month, self.metrics),
+        }
+
+    @inlineCallbacks
+    def update_rotating_tables(self):
+        """This method is intended to be tasked to run periodically off the
+        twisted event hub to rotate tables.
+
+        When today is a new month from yesterday, then we swap out all the
+        table objects on the settings object.
+
+        """
+        today = datetime.date.today()
+        if today.month == self.current_month:
+            # No change in month, we're fine.
+            returnValue()
+
+        # Get tables for the new month, and verify they exist before we try to
+        # switch over
+        message_table = get_rotating_message_table(self._message_prefix)
+
+        try:
+            yield deferToThread(message_table.describe)
+        except Exception:
+            tblname = make_rotating_tablename(self._message_prefix)
+            log.err("Unable to locate new message table: %s" % tblname)
+            returnValue()
+
+        # Both tables found, safe to switch-over
+        self.current_month = today.month
+        self.current_msg_month = message_table.table.table_name
+        self.message_tables[self.current_msg_month] = \
+            Message(self.message_table, self.metrics)
 
     def update(self, **kwargs):
         """Update the arguments, if a ``crypto_key`` is in kwargs then the

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -188,12 +188,12 @@ class MessageTestCase(unittest.TestCase):
         message.register_channel(self.uaid, chid)
         message.register_channel(self.uaid, chid2)
 
-        exists, chans = message.all_channels(self.uaid)
+        _, chans = message.all_channels(self.uaid)
         assert(chid in chans)
         assert(chid2 in chans)
 
         message.unregister_channel(self.uaid, chid2)
-        exists, chans = message.all_channels(self.uaid)
+        _, chans = message.all_channels(self.uaid)
         assert(chid2 not in chans)
         assert(chid in chans)
 

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -52,10 +52,10 @@ class DbCheckTestCase(unittest.TestCase):
         with self.assertRaises(Exception):
             preflight_check(storage_table, router_table)
 
-    def test_next_month(self):
-        from autopush.db import next_month
-        month0 = next_month(0)
-        month1 = next_month(1)
+    def test_get_month(self):
+        from autopush.db import get_month
+        month0 = get_month(0)
+        month1 = get_month(1)
         eq_(month0.month+1, month1.month)
 
 

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -52,6 +52,12 @@ class DbCheckTestCase(unittest.TestCase):
         with self.assertRaises(Exception):
             preflight_check(storage_table, router_table)
 
+    def test_next_month(self):
+        from autopush.db import next_month
+        month0 = next_month(0)
+        month1 = next_month(1)
+        eq_(month0.month+1, month1.month)
+
 
 class StorageTestCase(unittest.TestCase):
     def setUp(self):
@@ -190,6 +196,20 @@ class MessageTestCase(unittest.TestCase):
         exists, chans = message.all_channels(self.uaid)
         assert(chid2 not in chans)
         assert(chid in chans)
+
+    def test_save_channels(self):
+        chid = str(uuid.uuid4())
+        chid2 = str(uuid.uuid4())
+        m = get_message_table()
+        message = Message(m, SinkMetrics())
+        message.register_channel(self.uaid, chid)
+        message.register_channel(self.uaid, chid2)
+
+        exists, chans = message.all_channels(self.uaid)
+        new_uaid = uuid.uuid4().hex
+        message.save_channels(new_uaid, chans)
+        _, new_chans = message.all_channels(new_uaid)
+        eq_(chans, new_chans)
 
     def test_all_channels_no_uaid(self):
         m = get_message_table()

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -182,19 +182,20 @@ class MessageTestCase(unittest.TestCase):
         message.register_channel(self.uaid, chid)
         message.register_channel(self.uaid, chid2)
 
-        chans = message.all_channels(self.uaid)
+        exists, chans = message.all_channels(self.uaid)
         assert(chid in chans)
         assert(chid2 in chans)
 
         message.unregister_channel(self.uaid, chid2)
-        chans = message.all_channels(self.uaid)
+        exists, chans = message.all_channels(self.uaid)
         assert(chid2 not in chans)
         assert(chid in chans)
 
     def test_all_channels_no_uaid(self):
         m = get_message_table()
         message = Message(m, SinkMetrics())
-        assert(message.all_channels("asdf") == set([]))
+        exists, chans = message.all_channels("asdf")
+        assert(chans == set([]))
 
     def test_message_storage(self):
         chid = str(uuid.uuid4())

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -21,7 +21,8 @@ from autopush.db import (
     Router,
     Storage,
     Message,
-    ItemNotFound
+    ItemNotFound,
+    create_rotating_message_table,
 )
 from autopush.settings import AutopushSettings
 from autopush.router.interface import IRouter, RouterResponse
@@ -33,6 +34,7 @@ mock_dynamodb2 = mock_dynamodb2()
 def setUp():
     mock_dynamodb2.start()
     mock_s3().start()
+    create_rotating_message_table()
 
 
 def tearDown():

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -22,6 +22,7 @@ from twisted.internet.threads import deferToThread
 from twisted.web.client import Agent
 from twisted.test.proto_helpers import AccumulatingProtocol
 from autopush import __version__
+from autopush.db import create_rotating_message_table
 from autopush.settings import AutopushSettings
 from base64 import urlsafe_b64encode
 
@@ -49,6 +50,11 @@ def setUp():
         "-jar", ddb_jar, "-sharedDb", "-inMemory"
     ])
     ddb_process = subprocess.Popen(cmd, shell=True, env=os.environ)
+
+    # Setup the necessary message tables
+    message_table = os.environ.get("MESSAGE_TABLE", "message_int_test")
+    create_rotating_message_table(prefix=message_table, delta=-1)
+    create_rotating_message_table(prefix=message_table)
 
 
 def tearDown():

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -997,6 +997,155 @@ class TestWebPush(IntegrationBase):
         eq_(result["data"], urlsafe_b64encode(data2))
         yield self.shut_down(client)
 
+    @inlineCallbacks
+    def test_webpush_monthly_rotation(self):
+        from autopush.db import make_rotating_tablename
+        client = yield self.quick_register(use_webpush=True)
+        yield client.disconnect()
+
+        # Move the client back one month to the past
+        last_month = make_rotating_tablename(
+            prefix=self._settings._message_prefix, delta=-1)
+        lm_message = self._settings.message_tables[last_month]
+        yield deferToThread(
+            self._settings.router.update_message_month,
+            client.uaid,
+            last_month
+        )
+
+        # Verify the move
+        c = yield deferToThread(self._settings.router.get_uaid, client.uaid)
+        eq_(c["current_month"], last_month)
+
+        # Move the clients channels back one month
+        exists, chans = yield deferToThread(
+            self._settings.message.all_channels, client.uaid
+        )
+        eq_(exists, True)
+        eq_(len(chans), 1)
+        yield deferToThread(
+            lm_message.save_channels,
+            client.uaid,
+            chans
+        )
+
+        # Remove the channels entry entirely from this month
+        yield deferToThread(self._settings.message.table.delete_item,
+                            uaid=client.uaid,
+                            chidmessageid=" "
+                            )
+
+        # Verify the channel is gone
+        exists, chans = yield deferToThread(
+            self._settings.message.all_channels,
+            client.uaid
+        )
+        eq_(exists, False)
+        eq_(len(chans), 0)
+
+        # Send in a notification, verify it landed in last months notification
+        # table
+        data = uuid.uuid4().hex
+        yield client.send_notification(data=data)
+        notifs = yield deferToThread(lm_message.fetch_messages, client.uaid)
+        eq_(len(notifs), 1)
+
+        # Connect the client, verify the migration
+        yield client.connect()
+        yield client.hello()
+
+        # Pull down the notification
+        result = yield client.get_notification()
+        chan = client.channels.keys()[0]
+        ok_(result is not None)
+        eq_(chan, result["channelID"])
+
+        # Check that the client is going to rotate the month
+        server_client = self._settings.clients[client.uaid]
+        eq_(server_client.ps.rotate_message_table, True)
+
+        # Acknowledge the notification, which triggers the migration
+        yield client.ack(chan, result["version"])
+
+        # Wait up to 2 seconds for the table rotation to occur
+        start = time.time()
+        while time.time()-start < 2:
+            c = yield deferToThread(self._settings.router.get_uaid,
+                                    client.uaid)
+            if c["current_month"] == self._settings.current_msg_month:
+                break
+            else:
+                yield deferToThread(time.sleep, 0.2)
+
+        # Verify the month update in the router table
+        c = yield deferToThread(self._settings.router.get_uaid, client.uaid)
+        eq_(c["current_month"], self._settings.current_msg_month)
+        eq_(server_client.ps.rotate_message_table, False)
+
+        # Verify the channels were moved
+        exists, chans = yield deferToThread(
+            self._settings.message.all_channels,
+            client.uaid
+        )
+        eq_(exists, True)
+        eq_(len(chans), 1)
+
+        yield self.shut_down(client)
+
+    @inlineCallbacks
+    def test_webpush_monthly_rotation_no_channels(self):
+        from autopush.db import make_rotating_tablename
+        client = Client("ws://localhost:9010/", use_webpush=True)
+        yield client.connect()
+        yield client.hello()
+        yield client.disconnect()
+
+        # Move the client back one month to the past
+        last_month = make_rotating_tablename(
+            prefix=self._settings._message_prefix, delta=-1)
+        yield deferToThread(
+            self._settings.router.update_message_month,
+            client.uaid,
+            last_month
+        )
+
+        # Verify the move
+        c = yield deferToThread(self._settings.router.get_uaid, client.uaid)
+        eq_(c["current_month"], last_month)
+
+        # Verify there's no channels
+        exists, chans = yield deferToThread(
+            self._settings.message.all_channels,
+            client.uaid
+        )
+        eq_(exists, False)
+        eq_(len(chans), 0)
+
+        # Connect the client, verify the migration
+        yield client.connect()
+        yield client.hello()
+
+        # Check that the client is going to rotate the month
+        server_client = self._settings.clients[client.uaid]
+        eq_(server_client.ps.rotate_message_table, True)
+
+        # Wait up to 2 seconds for the table rotation to occur
+        start = time.time()
+        while time.time()-start < 2:
+            c = yield deferToThread(self._settings.router.get_uaid,
+                                    client.uaid)
+            if c["current_month"] == self._settings.current_msg_month:
+                break
+            else:
+                yield deferToThread(time.sleep, 0.2)
+
+        # Verify the month update in the router table
+        c = yield deferToThread(self._settings.router.get_uaid, client.uaid)
+        eq_(c["current_month"], self._settings.current_msg_month)
+        eq_(server_client.ps.rotate_message_table, False)
+
+        yield self.shut_down(client)
+
 
 class TestHealth(IntegrationBase):
     @inlineCallbacks

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -3,8 +3,7 @@ import unittest
 from mock import Mock, patch
 from moto import mock_dynamodb2, mock_s3
 from nose.tools import eq_
-from autopush.senderids import SenderIDs
-
+from twisted.trial import unittest as trialtest
 
 from autopush.main import (
     connection_main,
@@ -12,6 +11,7 @@ from autopush.main import (
     make_settings,
     skip_request_logging,
 )
+from autopush.senderids import SenderIDs
 from autopush.utils import (
     resolve_ip,
 )
@@ -43,6 +43,66 @@ class SettingsTestCase(unittest.TestCase):
         mock_socket.getaddrinfo.return_value = ""
         ip = resolve_ip("google.com")
         eq_(ip, "google.com")
+
+
+class SettingsAsyncTestCase(trialtest.TestCase):
+    def test_update_rotating_tables(self):
+        from autopush.db import create_rotating_message_table, next_month
+        # Create the rotating table so the test passes
+        create_rotating_message_table()
+        settings = AutopushSettings(
+            hostname="google.com", resolve_hostname=True)
+
+        # Erase the tables it has on init, and move current month back one
+        last_month = next_month(-1)
+        settings.current_month = last_month.month
+        settings.message_tables = {}
+
+        # Get the deferred back
+        d = settings.update_rotating_tables()
+
+        def check_tables(result):
+            eq_(len(settings.message_tables), 1)
+
+        d.addCallback(check_tables)
+        return d
+
+    @patch("autopush.db.datetime")
+    def test_update_rotating_tables_no_such_table(self, mock_date):
+        from autopush.db import next_month
+        mock_date.date.today.return_value = next_month(-7)
+        settings = AutopushSettings(
+            hostname="google.com", resolve_hostname=True)
+
+        # Erase the tables it has on init, and move current month back one
+        last_month = next_month(-1)
+        settings.current_month = last_month.month
+        settings.message_tables = {}
+
+        # Get the deferred back
+        d = settings.update_rotating_tables()
+
+        def check_tables(result):
+            eq_(len(settings.message_tables), 0)
+
+        d.addCallback(check_tables)
+        return d
+
+    def test_update_not_needed(self):
+        settings = AutopushSettings(
+            hostname="google.com", resolve_hostname=True)
+
+        # Erase the tables it has on init, and move current month back one
+        settings.message_tables = {}
+
+        # Get the deferred back
+        d = settings.update_rotating_tables()
+
+        def check_tables(result):
+            eq_(len(settings.message_tables), 0)
+
+        d.addCallback(check_tables)
+        return d
 
 
 class ConnectionMainTestCase(unittest.TestCase):

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -33,16 +33,16 @@ def tearDown():
 
 class SettingsTestCase(unittest.TestCase):
     def test_resolve_host(self):
-        ip = resolve_ip("google.com")
+        ip = resolve_ip("example.com")
         settings = AutopushSettings(
-            hostname="google.com", resolve_hostname=True)
+            hostname="example.com", resolve_hostname=True)
         eq_(settings.hostname, ip)
 
     @patch("autopush.utils.socket")
     def test_resolve_host_no_interface(self, mock_socket):
         mock_socket.getaddrinfo.return_value = ""
-        ip = resolve_ip("google.com")
-        eq_(ip, "google.com")
+        ip = resolve_ip("example.com")
+        eq_(ip, "example.com")
 
 
 class SettingsAsyncTestCase(trialtest.TestCase):
@@ -51,7 +51,7 @@ class SettingsAsyncTestCase(trialtest.TestCase):
         # Create the rotating table so the test passes
         create_rotating_message_table()
         settings = AutopushSettings(
-            hostname="google.com", resolve_hostname=True)
+            hostname="example.com", resolve_hostname=True)
 
         # Erase the tables it has on init, and move current month back one
         last_month = get_month(-1)

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -47,14 +47,14 @@ class SettingsTestCase(unittest.TestCase):
 
 class SettingsAsyncTestCase(trialtest.TestCase):
     def test_update_rotating_tables(self):
-        from autopush.db import create_rotating_message_table, next_month
+        from autopush.db import create_rotating_message_table, get_month
         # Create the rotating table so the test passes
         create_rotating_message_table()
         settings = AutopushSettings(
             hostname="google.com", resolve_hostname=True)
 
         # Erase the tables it has on init, and move current month back one
-        last_month = next_month(-1)
+        last_month = get_month(-1)
         settings.current_month = last_month.month
         settings.message_tables = {}
 
@@ -69,13 +69,13 @@ class SettingsAsyncTestCase(trialtest.TestCase):
 
     @patch("autopush.db.datetime")
     def test_update_rotating_tables_no_such_table(self, mock_date):
-        from autopush.db import next_month
-        mock_date.date.today.return_value = next_month(-7)
+        from autopush.db import get_month
+        mock_date.date.today.return_value = get_month(-7)
         settings = AutopushSettings(
             hostname="google.com", resolve_hostname=True)
 
         # Erase the tables it has on init, and move current month back one
-        last_month = next_month(-1)
+        last_month = get_month(-1)
         settings.current_month = last_month.month
         settings.message_tables = {}
 

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -113,8 +113,6 @@ class WebsocketTestCase(unittest.TestCase):
         with self.assertRaises(Exception):
             self.proto.onConnect(req)
 
-        req.headers.get.assert_called_with("user-agent")
-
     @patch("autopush.websocket.reactor")
     def test_autoping_no_uaid(self, mock_reactor):
         # restore our sendClose

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -16,6 +16,7 @@ from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectError
 from twisted.trial import unittest
 
+from autopush.db import create_rotating_message_table
 from autopush.settings import AutopushSettings
 from autopush.websocket import (
     PushState,
@@ -35,6 +36,7 @@ mock_dynamodb2 = mock_dynamodb2()
 
 def setUp():
     mock_dynamodb2.start()
+    create_rotating_message_table()
 
 
 def tearDown():

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -620,7 +620,14 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
     def _check_collision(self, result):
         """callback to reset the UAID if router registration fails"""
         registered, previous = result
-        if registered:
+        existing_webpush_rotator = self.ps.use_webpush and \
+            "current_month" in previous
+
+        # If registered and not a webpush user, continue
+        if not self.ps.use_webpush and registered:
+            return self._check_other_nodes(result)
+        # Or if we are a webpush user and have table rotation already
+        if existing_webpush_rotator:
             return self._check_other_nodes(result)
 
         # If registration fails, try resetting the UAID.

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -353,12 +353,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         if data == {}:
             return self.process_ping()
 
-        # Message needs a type
-        if "messageType" not in data:
-            self.sendClose()
-            return
-
-        cmd = data["messageType"]
+        cmd = data.get("messageType")
         # We're no longer idle, prevent early connection closure.
         self.resetTimeout()
         try:
@@ -652,7 +647,6 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
                              extra="Failed to delete old node")
         timeout = self.ap_settings.wake_timeout if self.ps.wake_data else None
         self.setTimeout(timeout)
-
         self.finish_hello()
 
     def finish_hello(self, *args):

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -715,7 +715,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         # Proceed with hello response
         self._finish_webpush_hello()
 
-    def _finish_webpush_hello(self):
+    def _finish_webpush_hello(self, *ignored_result):
         self.transport.resumeProducing()
         msg = {"messageType": "hello", "uaid": self.ps.uaid, "status": 200}
         if self.autoPingInterval:

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -868,12 +868,13 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         d.addErrback(self.err_overload)
         d.addErrback(self.log_err)
 
-    def _register_rotated_channels(self, channels):
+    def _register_rotated_channels(self, result):
         """Register the channels into a new entry in the current month"""
         # Update the current month now, so that we can save the channels into
         # the right location
         self.ps.message_month = self.ap_settings.current_msg_month
 
+        _, channels = result
         if not channels:
             # No previously registered channels, skip to updating the router
             # table

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -113,6 +113,13 @@ class PushState(object):
         'router_type',
         'wake_data',
         'connected_at',
+        'settings',
+
+        # Table rotation
+        'message_month',
+        'message',
+        'rotate_message_table',
+
         'ping_time_out',
         '_check_notifications',
         '_more_notifications',
@@ -120,6 +127,8 @@ class PushState(object):
         '_register',
         'updates_sent',
         'direct_updates',
+
+        # iProducer methods
         'pauseProducing',
         'resumeProducing',
         'stopProducing',
@@ -127,6 +136,7 @@ class PushState(object):
 
     def __init__(self, settings, request):
         self._callbacks = []
+        self.settings = settings
 
         if request:
             self._user_agent = request.headers.get("user-agent")
@@ -149,6 +159,10 @@ class PushState(object):
         self.connected_at = ms_time()
         self.ping_time_out = False
 
+        # Message table rotation initial settings
+        self.message_month = settings.current_msg_month
+        self.rotate_message_table = False
+
         self._check_notifications = False
         self._more_notifications = False
 
@@ -161,6 +175,11 @@ class PushState(object):
 
         # Track Notification's we don't need to delete separately
         self.direct_updates = {}
+
+    @property
+    def message(self):
+        """Property to access the currently used message table"""
+        return self.settings.message_tables[self.message_month]
 
     def pauseProducing(self):
         """IProducer implementation tracking if we should pause output"""
@@ -441,7 +460,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
     def _save_webpush_notif(self, notif):
         """Save a direct_update webpush style notification"""
         return deferToThread(
-            self.ap_settings.message.store_message,
+            self.ps.message.store_message,
             uaid=self.ps.uaid,
             channel_id=notif.channel_id,
             data=notif.data,
@@ -622,6 +641,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             self.sendMessage(json.dumps(msg).encode('utf8'), False)
             return
 
+        # Handle dupes on the same node
         existing = self.ap_settings.clients.get(self.ps.uaid)
         if existing:
             if self.ps.connected_at <= existing.ps.connected_at:
@@ -630,6 +650,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             else:
                 existing.sendClose()
 
+        # TODO: Remove this block, issue #245.
         if previous and "node_id" in previous:
             # Get the previous information returned from dynamodb.
             node_id = previous["node_id"]
@@ -645,18 +666,61 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
                                               UserError))
                 d.addErrback(self.log_err,
                              extra="Failed to delete old node")
+
+        # UDP clients are done at this point and timed out to ensure they
+        # drop their connection
         timeout = self.ap_settings.wake_timeout if self.ps.wake_data else None
         self.setTimeout(timeout)
-        self.finish_hello()
 
-    def finish_hello(self, *args):
+        self.finish_hello(previous)
+
+    def finish_hello(self, previous):
         """callback for successful hello message, that sends hello reply"""
         self.ps._register = None
+        if self.ps.use_webpush:
+            return self._check_message_table_rotation(previous)
+
         msg = {"messageType": "hello", "uaid": self.ps.uaid, "status": 200}
         if self.autoPingInterval:
             msg["ping"] = self.autoPingInterval
-        if self.ps.use_webpush:
-            msg["use_webpush"] = True
+
+        msg['env'] = self.ap_settings.env
+        self.ap_settings.clients[self.ps.uaid] = self
+        self.sendJSON(msg)
+        self.ps.metrics.increment("updates.client.hello", tags=self.base_tags)
+        self.process_notifications()
+
+    def _check_message_table_rotation(self, previous):
+        """Check for webpush users if we need to rotate the message table"""
+        self.transport.pauseProducing()
+        # Check for table rotation
+        cur_month = previous.get("current_month")
+        if not cur_month:
+            # New user, write out the current_month and say hello
+            d = self.deferToThread(
+                self.ap_settings.router.update_message_month,
+                self.ps.uaid, self.ps.message_month)
+            d.addCallback(self._finish_webpush_hello)
+            d.addErrback(self.trap_cancel)
+            d.addErrback(self.err_overload, "hello")
+            d.addErrback(self.err_hello)
+            return d
+
+        if cur_month != self.ps.message_month:
+            # Previous month user or new user, flag for message rotation and
+            # set the message_month to the router month
+            self.ps.message_month = cur_month
+            self.rotate_message_table = True
+
+        # Proceed with hello response
+        self._finish_webpush_hello()
+
+    def _finish_webpush_hello(self):
+        self.transport.resumeProducing()
+        msg = {"messageType": "hello", "uaid": self.ps.uaid, "status": 200}
+        if self.autoPingInterval:
+            msg["ping"] = self.autoPingInterval
+        msg["use_webpush"] = True
         msg['env'] = self.ap_settings.env
         self.ap_settings.clients[self.ps.uaid] = self
         self.sendJSON(msg)
@@ -690,7 +754,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         self.ps._more_notifications = True
 
         if self.ps.use_webpush:
-            d = self.deferToThread(self.ap_settings.message.fetch_messages,
+            d = self.deferToThread(self.ps.message.fetch_messages,
                                    self.ps.uaid)
         else:
             d = self.deferToThread(
@@ -755,6 +819,14 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
                 self.ps._check_notifications = False
                 d = self.deferToLater(1, self.process_notifications)
                 d.addErrback(self.trap_cancel)
+                return
+
+            # Not told to check for notifications, do we need to now rotate
+            # the message table?
+            if self.ps.rotate_message_table:
+                self.transport.pauseProducing()
+                self.ps.rotate_message_table = False
+                self._rotate_message_table()
             return
 
         # Send out all the notifications
@@ -766,7 +838,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             # If the TTL is too old, don't deliver and fire a delete off
             if now >= (notif["ttl"]+notif["timestamp"]):
                 self.force_retry(
-                    self.ap_settings.message.delete_message, self.ps.uaid,
+                    self.ps.message.delete_message, self.ps.uaid,
                     chid, version, updateid=notif["updateid"])
                 continue
 
@@ -785,6 +857,42 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
                              ttl=notif["ttl"], timestamp=notif["timestamp"])
             )
             self.sendJSON(msg)
+
+    def _rotate_message_table(self):
+        """Function to fire off a message table copy of channels + update the
+        router current_month entry"""
+        self.transport.pauseProducing()
+        d = self.deferToThread(self.ps.message.all_channels)
+        d.addCallback(self._register_rotated_channels)
+        d.addErrback(self.trap_cancel)
+        d.addErrback(self.err_overload)
+        d.addErrback(self.log_err)
+
+    def _register_rotated_channels(self, channels):
+        """Register the channels into a new entry in the current month"""
+        # Update the current month now, so that we can save the channels into
+        # the right location
+        self.ps.message_month = self.ap_settings.current_msg_month
+
+        if not channels:
+            # No previously registered channels, skip to updating the router
+            # table
+            return self._update_router_for_message_month()
+
+        # Register the channels, then update the router
+        d = self.deferToThread(self.ps.message.save_channels, self.ps.uaid,
+                               channels)
+        d.addCallback(self._update_router_for_message_month)
+        return d
+
+    def _update_router_for_message_month(self):
+        """Update the router for the message month"""
+        # This is returned so that the error handling in _rotate_message_table
+        # still applies since the deferred chain is fully followed.
+        d = self.deferToThread(self.ap_settings.router.update_message_month,
+                               self.ps.uaid, self.ps.message_month)
+        d.addCallback(lambda x: self.transport.resumeProducing())
+        return d
 
     def _send_ping(self):
         """Helper for ping sending that tracks when the ping was sent"""

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -28,11 +28,11 @@ Tables are post-fixed with the year/month they are meant for, ie:
     messages-2015-02
 
 Tables must be created and have their read/write units properly allocated by a
-separate process in advance of the month swith-over as autopush nodes will
+separate process in advance of the month switch-over as autopush nodes will
 assume the tables already exist. Scripts are provided that can be run weekly to
 ensure all necessary tables are present, and tables old enough are dropped.
 
-Within a few days of the new month, the loads on the prior months table will
+Within a few days of the new month, the load on the prior months table will
 fall as all clients transition solely to the new month. The read/write units
 on the prior month then may be lowered.
 
@@ -40,10 +40,7 @@ Message Table
 -------------
 
 Due to the complexity of having notifications spread across two tables, several
-rules are used to avoid losing messages during the month transition. These rules
-are important to follow as its unlikely perfect time will be kept and connection
-nodes need to ensure they don't miss notifications that may be in a table they
-weren't expecting.
+rules are used to avoid losing messages during the month transition.
 
 The logic for connection nodes is more complex, since only the connection node
 knows when the client connects, and how many messages it has read through.
@@ -61,8 +58,8 @@ notifications for the prior month.
 **Rules for Endpoints**
 
 1. Check the router table to see the current_month the client is on.
-2. Read the ' ' entry from the appropriate month message table to see if its
-   a valid channel.
+2. Read the chan list entry from the appropriate month message table to see if
+   its a valid channel.
 
    If its valid, move to step 3.
 3. Store the notification in the current months table if valid. (Note that this

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -8,12 +8,95 @@ Endpoint nodes handle all notification PUT requests, looking up in DynamoDB to
 see what Push server the UAID is connected to. The Endpoint nodes then attempt
 delivery to the Push server.
 
-Push server's accept websocket connections (this can easily be HTTP/2 for
-WebPush), and deliver notifications to connected clients. They check DynamoDB
-for missed notifications as necessary.
+Push connection nodess accept websocket connections (this can easily be HTTP/2
+for WebPush), and deliver notifications to connected clients. They check
+DynamoDB for missed notifications as necessary.
 
 There will be many more Push servers to handle the connection node, while more
 Endpoint nodes can be handled as needed for notification throughput.
+
+Table Rotation
+==============
+
+To avoid costly table scans, autopush uses a rotating message and router table.
+As clients remain disconnected for over 60 days, they will be forgotten
+entirely and their router and message table entries will drop out of the
+system.
+
+Tables are post-fixed with the year/month they are meant for, ie:
+
+    messages-2015-02
+
+Tables must be created and have their read/write units properly allocated by a
+separate process in advance of the month swith-over as autopush nodes will
+assume the tables already exist. Scripts are provided that can be run weekly to
+ensure all necessary tables are present, and tables old enough are dropped.
+
+Within a few days of the new month, the loads on the prior months table will
+fall as all clients transition solely to the new month. The read/write units
+on the prior month then may be lowered.
+
+Message Table
+-------------
+
+Due to the complexity of having notifications spread across two tables, several
+rules are used to avoid losing messages during the month transition. These rules
+are important to follow as its unlikely perfect time will be kept and connection
+nodes need to ensure they don't miss notifications that may be in a table they
+weren't expecting.
+
+The logic for connection nodes is more complex, since only the connection node
+knows when the client connects, and how many messages it has read through.
+
+A new field will be added to the router table to indicate the last month the
+client has read connections through. This is independent of the last_connected
+since it is possible for a client to connect, fail to read its notifications,
+then reconnect.
+
+To avoid issues with time synchronization, the node the client is connected to
+acts as the source of truth for when the month has flipped over. Clients are
+only moved to the new table on connect, and only after reading/acking all the
+notifications for the prior month.
+
+**Rules for Endpoints**
+
+1. Check the router table to see the current_month the client is on.
+2. Read the ' ' entry from the appropriate month message table to see if its
+   a valid channel.
+
+   If its valid, move to step 3.
+3. Store the notification in the current months table if valid. (Note that this
+   step does not copy the blank entry of valid channels)
+
+**Rules for Connection Nodes**
+
+After Identification:
+
+1. Check to see if the current_month matches the current month, if it does then
+   proceed normally using the current months message table.
+
+   If the connection node month does not match stored current_month, proceed to
+   step 2.
+2. Read notifications from prior month and send to client.
+
+   Once all acks are received for all the notifications for that month proceed
+   to step 3.
+3. Copy the blank message entry of valid channels to the new month message
+   table.
+4. Update the router table for the current_month.
+
+During switchover, only after the router table update are new commands from the
+client accepted.
+
+Handling of Edge Cases:
+
+* Connection node gets more notifications during step 3, enough to buffer, such
+  that the endpoint starts storing them in the previous current_month. In this
+  case the connection node will check the old table, then the new table to
+  ensure it doesn't lose message during the switch.
+* Connection node dies, or client disconnects during step 3/4. Not a problem as
+  the reconnect will pick it up at the right spot.
+
 
 Push Characteristics
 ====================


### PR DESCRIPTION
This PR add's message table rotation for webpush users, and retains a current_month attribute in the router table for the user indicating which message table to use for notifications.

Table rotation occurs when a client connects, after it has ack'd all remaining notifications in the table it was last on. Then the channels entry is copied over, and the current_month updated.

Webpush users with an account prior to table rotation will have their UAID reset so they can re-register channels properly with the table rotation scheme.

Closes #191.

@jrconlin r?