### PR TITLE
Feature/new http

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Features
 
 Bug Fixes
 ---------
-* Fixed some issues around the Bridge API delete functions.
+* Fixed scope issue around the Bridge API delete functions.
 
 * Relax endpoint TLS cert requirement for https scheme. Issue #249.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ WebPush
 
 Backwards Incompatibilities
 ---------------------------
-* The previous Bridge HTTP API has been immediately deprecated.
+* The previous Bridge HTTP API has been removed.
 
 1.8.1 (2015-11-16)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,11 +8,22 @@ Autopush Changelog
 Features
 --------
 
+* New Bridge HTTP API. Issues #238, #250, #251
+  In cooperation with the GCM client work the HTTP Bridge API has been
+  simplified. The new method has been detailed in /api/endpoint.py.
+  In essence: The API is now bearer token based, and uses the form
+  /v1/{BridgeType}/{BridgeToken}/registration[/{uaid}/[subscription/[{chid}]]]
+
 Bug Fixes
 ---------
+* Fixed some issues around the Bridge API delete functions.
 
 WebPush
 -------
+
+Backwards Incompatibilities
+---------------------------
+* The previous Bridge HTTP API has been immediately deprecated.
 
 1.8.1 (2015-11-16)
 ==================

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -263,6 +263,10 @@ class Message(object):
     @track_provisioned
     def all_channels(self, uaid):
         """Retrieve a list of all channels for a given uaid"""
+
+        # Note: This only returns the chids associated with the UAID.
+        # functions that call store_message() would be required to
+        # update that list as well using register_channel()
         try:
             result = self.table.get_item(consistent=True, uaid=uaid,
                                          chidmessageid=" ")
@@ -372,7 +376,7 @@ class Message(object):
         return len(chidmessageids) > 0
 
     @track_provisioned
-    def delete_all_for_user(self, uaid):
+    def delete_user(self, uaid):
         """Deletes all messages and channel info for a given uaid"""
         results = self.table.query_2(
             uaid__eq=uaid,
@@ -383,6 +387,9 @@ class Message(object):
         chidmessageids = [x["chidmessageid"] for x in results]
         if chidmessageids:
             self.delete_messages(uaid, chidmessageids)
+        self.table.delete_item(uaid=uaid,
+                               chidmessageid=" ",
+                               consistent=True)
 
     @track_provisioned
     def fetch_messages(self, uaid, limit=10):

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -369,6 +369,7 @@ class Message(object):
         chidmessageids = [x["chidmessageid"] for x in results]
         if chidmessageids:
             self.delete_messages(uaid, chidmessageids)
+        return len(chidmessageids) > 0
 
     @track_provisioned
     def delete_all_for_user(self, uaid):

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -311,7 +311,7 @@ class Message(object):
         """Retrieve a list of all channels for a given uaid"""
 
         # Note: This only returns the chids associated with the UAID.
-        # functions that call store_message() would be required to
+        # Functions that call store_message() would be required to
         # update that list as well using register_channel()
         try:
             result = self.table.get_item(consistent=True, uaid=uaid,

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -1063,7 +1063,7 @@ class RegistrationHandler(AutoendpointHandler):
         message.unregister_channel(uaid, chid)
 
     def _deleteUaid(self, message, uaid, router):
-        message.delete_all_for_user(uaid)
+        message.delete_user(uaid)
         if not router.drop_user(uaid):
             raise ItemNotFound("UAID not found")
 

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -37,8 +37,8 @@ assigned during **Registration**
 
    :{CHID}: The Channel Subscription ID
 
-Push assigns each channel subscription for a given {UAID} a unique
-identifier. This value is assigned during **Channel Subscription**
+Push assigns a unique identifier for each subscription for a given {UAID}.
+This value is assigned during **Channel Subscription**
 
    :{message-id}: The unique Message ID
 
@@ -67,7 +67,7 @@ returned with the following format:
 Unless otherwise specified, all calls return the following error codes:
 
 -  20x - Success
--  301 - Moved + `Location:` if `{token}` is invalid
+-  301 - Moved + `Location:` if `{token}` is invalid (Bridge API Only)
 -  400 - Bad Parameters
 
    - errno 101 - Missing neccessary crypto keys
@@ -225,9 +225,10 @@ service.
 
    :{instanceid}: The bridge specific private identifier token
 
-Each protocol requires a unique token that addresses the instance of the
+Each protocol requires a unique token that addresses the
 application on a given user's device. This is usually the product of the
-application registering the token with the native bridge protocol agent.
+application registering the {instanceid} with the native bridge protocol
+agent.
 
    :{auth_token}: The Authorization token
 

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -746,7 +746,7 @@ class MessageHandler(AutoendpointHandler):
     def put(self, token):
         """Updates a pending message.
 
-        If the message was already acknowledged, than this will instead create
+        If the message was already acknowledged, then this will instead create
         a new message.
 
         """
@@ -1059,8 +1059,6 @@ class RegistrationHandler(AutoendpointHandler):
         d.callback(uaid)
 
     def _deleteChannel(self, message, uaid, chid):
-        if chid not in message.all_channels(uaid):
-            raise ItemNotFound("CHID not found")
         message.delete_messages_for_channel(uaid, chid)
         message.unregister_channel(uaid, chid)
 

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -682,7 +682,7 @@ class AutoendpointHandler(cyclone.web.RequestHandler):
 
     def _chid_not_found_err(self, fail):
         """errBack for unknown chid"""
-        fail.trap(ItemNotFound)
+        fail.trap(ItemNotFound, ValueError)
         log.msg("CHID not found in AWS.", **self._client_info())
         self._write_response(404, 103)
 

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -52,6 +52,9 @@ class APNSRouter(object):
     def amend_msg(self, msg):
         return msg
 
+    def check_token(self, token):
+        return (True, token)
+
     def route_notification(self, notification, uaid_data):
         """Start the APNS notification routing, returns a deferred"""
         router_data = uaid_data["router_data"]

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -63,15 +63,15 @@ class GCMRouter(object):
         # Payload data is optional.  If present, all of Content-Encoding,
         # Encryption, and Encryption-Key are required.  If one or more are
         # missing, a 400 response is produced.
-        con = notification.headers.get('content-encoding', None)
-        enc = notification.headers.get('encryption', None)
-        enckey = notification.headers.get('encryption-key', None)
         if notification.data:
             lead = "notification with data is missing header:"
+            con = notification.headers.get('content-encoding', None)
             if not con:
                 self._error("%s Content-Encoding" % lead, 400)
+            enc = notification.headers.get('encryption', None)
             if not enc:
                 self._error("%s Encryption" % lead, 400)
+            enckey = notification.headers.get('encryption-key', None)
             if not enckey:
                 self._error("%s Encryption-Key" % lead, 400)
             data['body'] = notification.data

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -53,6 +53,26 @@ class GCMRouter(object):
 
     def _route(self, notification, router_data):
         """Blocking GCM call to route the notification"""
+        data={"chid": notification.channel_id,
+              "ver": notification.version}
+        # Payload data is optional.  If present, all of Content-Encoding,
+        # Encryption, and Encryption-Key are required.  If one or more are
+        # missing, a 400 response is produced.
+        con = notification.headers.get('content-encoding', None)
+        enc = notification.headers.get('encryption', None)
+        enckey = notification.headers.get('encryption-key', None)
+        if notification.data:
+            if not con:
+                self._error("notification with data is missing header: Content-Encoding", 400)
+            if not enc:
+                self._error("notification with data is missing header: Encryption", 400)
+            if not enckey:
+                self._error("notification with data is missing header: Encryption-Key", 400)
+            data['body'] = notification.data
+            data['con'] = con
+            data['enc'] = enc
+            data['enckey'] = enckey
+
         payload = gcmclient.JSONMessage(
             registration_ids=[router_data["token"]],
             collapse_key=self.collapseKey,

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -33,6 +33,11 @@ class GCMRouter(object):
             raise IOError("GCM Bridge not initiated in main")
         log.msg("Starting GCM router...")
 
+    def check_token(self, token):
+        if token not in self.senderIDs.senderIDs():
+            return (False, self.senderIDs.choose_ID().get('senderID'))
+        return (True, token)
+
     def amend_msg(self, msg):
         msg["senderid"] = self.creds.get("senderID")
         return msg
@@ -53,8 +58,8 @@ class GCMRouter(object):
 
     def _route(self, notification, router_data):
         """Blocking GCM call to route the notification"""
-        data={"chid": notification.channel_id,
-              "ver": notification.version}
+        data = {"chid": notification.channel_id,
+                "ver": notification.version}
         # Payload data is optional.  If present, all of Content-Encoding,
         # Encryption, and Encryption-Key are required.  If one or more are
         # missing, a 400 response is produced.
@@ -62,12 +67,13 @@ class GCMRouter(object):
         enc = notification.headers.get('encryption', None)
         enckey = notification.headers.get('encryption-key', None)
         if notification.data:
+            lead = "notification with data is missing header:"
             if not con:
-                self._error("notification with data is missing header: Content-Encoding", 400)
+                self._error("%s Content-Encoding" % lead, 400)
             if not enc:
-                self._error("notification with data is missing header: Encryption", 400)
+                self._error("%s Encryption" % lead, 400)
             if not enckey:
-                self._error("notification with data is missing header: Encryption-Key", 400)
+                self._error("%s Encryption-Key" % lead, 400)
             data['body'] = notification.data
             data['con'] = con
             data['enc'] = enc
@@ -78,9 +84,7 @@ class GCMRouter(object):
             collapse_key=self.collapseKey,
             time_to_live=self.ttl,
             dry_run=self.dryRun,
-            data={"Msg": notification.data,
-                  "Chid": notification.channel_id,
-                  "Ver": notification.version}
+            data=data,
         )
         creds = router_data.get("creds", {"senderID": "missing id"})
         try:

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -67,6 +67,15 @@ class IRouter(object):
         """
         raise NotImplementedError("amend_msg must be implemented")
 
+    def check_token(self, token):
+        """Check if a given token is still valid.
+
+        ":param token: A router base token
+        ":returns: (ValidBool, AlternateToken)
+
+        """
+        raise NotImplementedError("check_token must be implemented")
+
     def route_notification(self, notification, uaid_data):
         """Route a notification
 

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -61,6 +61,9 @@ class SimpleRouter(object):
     def amend_msg(self, msg):
         return msg
 
+    def check_token(self, token):
+        return (True, token)
+
     def preflight_check(self, uaid, channel_id):
         """Verifies this routing call can be done successfully"""
         return True

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -104,3 +104,6 @@ class WebPushRouter(SimpleRouter):
 
     def amend_msg(self, msg):
         return msg
+
+    def check_token(self, token):
+        return (True, token)

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -223,7 +223,7 @@ class MessageTestCase(unittest.TestCase):
         all_messages = list(message.fetch_messages(self.uaid))
         eq_(len(all_messages), 0)
 
-    def test_delete_all_for_user(self):
+    def test_delete_user(self):
         chid = str(uuid.uuid4())
         chid2 = str(uuid.uuid4())
         m = get_message_table()
@@ -239,7 +239,7 @@ class MessageTestCase(unittest.TestCase):
         message.store_message(self.uaid, chid2, time2, ttl, data2, {})
         message.store_message(self.uaid, chid2, time3, ttl, data1, {})
 
-        message.delete_all_for_user(self.uaid)
+        message.delete_user(self.uaid)
         all_messages = list(message.fetch_messages(self.uaid))
         eq_(len(all_messages), 0)
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -180,7 +180,7 @@ class MessageTestCase(unittest.TestCase):
             self.status_mock.assert_called_with(413)
             data = self.write_mock.call_args[0][0]
             d = json.loads(data)
-            self.assertEqual(d.get("message"), "Data payload too large")
+            eq_(d.get("message"), "Data payload too large")
 
         self.finish_deferred.addCallback(handle_finish)
         self.message.put("")

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -846,11 +846,12 @@ class RegistrationTestCase(unittest.TestCase):
             args = call_args[0]
             call_arg = json.loads(args[0])
             eq_(call_arg["uaid"], dummy_uaid)
+            eq_(call_arg["channelID"], dummy_chid)
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
             ok_("secret" in call_arg)
 
         self.finish_deferred.addCallback(handle_finish)
-        self.reg.post()
+        self.reg.post("simplepush", "")
         return self.finish_deferred
 
     @patch('uuid.uuid4', return_value=uuid.UUID(dummy_uaid))

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1051,9 +1051,29 @@ class RegistrationTestCase(unittest.TestCase):
             cl = messages.all_channels(dummy_uaid)
             eq_(len(ml), 1)
             eq_((True, set(['test'])), cl)
+            messages.delete_user(dummy_uaid)
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.delete("test", "test", uaid=dummy_uaid, chid=dummy_chid)
+        return self.finish_deferred
+
+    def test_delete_bad_chid(self):
+        messages = self.reg.ap_settings.message
+        messages.register_channel(dummy_uaid, dummy_chid)
+        messages.store_message(
+            dummy_uaid,
+            dummy_chid,
+            "1",
+            10000)
+        # TODO: self.reg.ap_settings.message.all_channels(dummy_uaid) = [] ??
+        self.reg.request.headers["Authorization"] = self.auth
+
+        def handle_finish(value):
+            self._check_error(404, 103, "Not Found")
+            messages.delete_user(dummy_uaid)
+
+        self.finish_deferred.addCallback(handle_finish)
+        self.reg.delete("test", "test", uaid=dummy_uaid, chid="invalid")
         return self.finish_deferred
 
     def test_delete_uaid(self):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1028,12 +1028,15 @@ class RegistrationTestCase(unittest.TestCase):
         return self.finish_deferred
 
     def test_delete_chid(self):
-        self.reg.ap_settings.message.store_message(
+        messages = self.reg.ap_settings.message
+        messages.register_channel(dummy_uaid, dummy_chid)
+        messages.store_message(
             dummy_uaid,
             dummy_chid,
             "1",
             10000)
-        self.reg.ap_settings.message.store_message(
+        messages.register_channel(dummy_uaid, "test")
+        messages.store_message(
             dummy_uaid,
             "test",
             "2",
@@ -1042,28 +1045,33 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.request.headers["Authorization"] = self.auth
 
         def handle_finish(value):
-            ml = self.reg.ap_settings.message.fetch_messages(dummy_uaid)
+            ml = messages.fetch_messages(dummy_uaid)
+            cl = messages.all_channels(dummy_uaid)
             eq_(len(ml), 1)
+            eq_(set(['test']), cl)
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.delete("test", "test", uaid=dummy_uaid, chid=dummy_chid)
         return self.finish_deferred
 
     def test_delete_uaid(self):
-        self.reg.ap_settings.message.store_message(
+        messages = self.reg.ap_settings.message
+        messages.store_message(
             dummy_uaid,
             dummy_chid,
             "1",
             10000)
-        self.reg.ap_settings.message.store_message(
+        messages.store_message(
             dummy_uaid,
             "test",
             "2",
             10000)
 
         def handle_finish(value):
-            ml = self.reg.ap_settings.message.fetch_messages(dummy_uaid)
+            ml = messages.fetch_messages(dummy_uaid)
+            cl = messages.all_channels(dummy_uaid)
             eq_(len(ml), 0)
+            eq_(cl, set([]))
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.request.headers["Authorization"] = self.auth

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1050,7 +1050,7 @@ class RegistrationTestCase(unittest.TestCase):
             ml = messages.fetch_messages(dummy_uaid)
             cl = messages.all_channels(dummy_uaid)
             eq_(len(ml), 1)
-            eq_(set(['test']), cl)
+            eq_((True, set(['test'])), cl)
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.delete("test", "test", uaid=dummy_uaid, chid=dummy_chid)
@@ -1073,7 +1073,7 @@ class RegistrationTestCase(unittest.TestCase):
             ml = messages.fetch_messages(dummy_uaid)
             cl = messages.all_channels(dummy_uaid)
             eq_(len(ml), 0)
-            eq_(cl, set([]))
+            eq_((False, set([])), cl)
 
         self.finish_deferred.addCallback(handle_finish)
         self.reg.request.headers["Authorization"] = self.auth

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -697,7 +697,7 @@ class EndpointTestCase(unittest.TestCase):
 
 dummy_uaid = "00000000123412341234567812345678"
 dummy_chid = "11111111123412341234567812345678"
-CORS_HEAD = "GET,PUT,DELETE"
+CORS_HEAD = "POST,PUT,DELETE"
 
 
 class RegistrationTestCase(unittest.TestCase):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1040,8 +1040,14 @@ class RegistrationTestCase(unittest.TestCase):
             10000)
         # TODO: self.reg.ap_settings.message.all_channels(dummy_uaid) = [] ??
         self.reg.request.headers["Authorization"] = self.auth
-        d = self.reg.delete("test", "test", uaid=dummy_uaid, chid=dummy_chid)
-        return d
+
+        def handle_finish(value):
+            ml = self.reg.ap_settings.message.fetch_messages(dummy_uaid)
+            eq_(len(ml), 1)
+
+        self.finish_deferred.addCallback(handle_finish)
+        self.reg.delete("test", "test", uaid=dummy_uaid, chid=dummy_chid)
+        return self.finish_deferred
 
     def test_delete_uaid(self):
         self.reg.ap_settings.message.store_message(
@@ -1054,8 +1060,15 @@ class RegistrationTestCase(unittest.TestCase):
             "test",
             "2",
             10000)
+
+        def handle_finish(value):
+            ml = self.reg.ap_settings.message.fetch_messages(dummy_uaid)
+            eq_(len(ml), 0)
+
+        self.finish_deferred.addCallback(handle_finish)
         self.reg.request.headers["Authorization"] = self.auth
         self.reg.delete("test", "test", uaid=dummy_uaid)
+        return self.finish_deferred
 
     def test_delete_bad_uaid(self):
         self.reg.request.headers["Authorization"] = self.auth
@@ -1091,6 +1104,7 @@ class RegistrationTestCase(unittest.TestCase):
 
     def test_delete_bad_router(self):
         self.reg.request.headers['Authorization'] = self.auth
+
         def handle_finish(value):
             self.reg.set_status.assert_called_with(400)
 

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -411,7 +411,7 @@ class TestSimple(IntegrationBase):
         result = yield client.get_notification()
         self.assertTrue(result != {})
         self.assertTrue(len(result["updates"]) == 1)
-        self.assertEquals(result["updates"][0]["channelID"], chan)
+        eq_(result["updates"][0]["channelID"], chan)
         yield self.shut_down(client)
 
     @inlineCallbacks
@@ -426,7 +426,7 @@ class TestSimple(IntegrationBase):
         result = yield client.get_notification()
         self.assertTrue(result != {})
         self.assertTrue(len(result["updates"]) == 1)
-        self.assertEquals(result["updates"][0]["channelID"], chan)
+        eq_(result["updates"][0]["channelID"], chan)
 
         yield client.disconnect()
         yield client.connect()
@@ -434,7 +434,7 @@ class TestSimple(IntegrationBase):
         result = yield client.get_notification()
         self.assertTrue(result != {})
         self.assertTrue(result["updates"] > 0)
-        self.assertEquals(result["updates"][0]["channelID"], chan)
+        eq_(result["updates"][0]["channelID"], chan)
         yield self.shut_down(client)
 
     @inlineCallbacks
@@ -465,7 +465,7 @@ class TestSimple(IntegrationBase):
         yield client.hello()
         result = yield client.get_notification()
         update = result["updates"][0]
-        self.assertEquals(update["channelID"], chan)
+        eq_(update["channelID"], chan)
         yield client.ack(chan, update["version"])
         yield client.disconnect()
         time.sleep(0.2)
@@ -486,7 +486,7 @@ class TestSimple(IntegrationBase):
         yield client.hello()
         result = yield client.get_notification()
         update = result["updates"][0]
-        self.assertEquals(update["channelID"], chan)
+        eq_(update["channelID"], chan)
 
         yield client.unregister(chan)
         yield client.disconnect()
@@ -943,7 +943,7 @@ class TestWebPush(IntegrationBase):
         chan = client.channels.keys()[0]
 
         update = yield client.send_notification(data=data)
-        self.assertEquals(update["channelID"], chan)
+        eq_(update["channelID"], chan)
         yield client.ack(chan, update["version"])
         ok_(client.messages.get(chan, []) != [])
         yield client.disconnect()
@@ -975,7 +975,7 @@ class TestWebPush(IntegrationBase):
         yield client.connect()
         yield client.hello()
         update = yield client.get_notification()
-        self.assertEquals(update["channelID"], chan)
+        eq_(update["channelID"], chan)
 
         # Update the message as it hasn't been ack'dyet
         location = client.messages[chan][0]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,8 @@ Reference Docs
    api
    Changelog <changelog>
 
+* :doc:`Push Service HTTP API <api/endpoint>`
+
 Source Code
 ===========
 


### PR DESCRIPTION
This PR replaces the previous HTTP Bridge API with a new, optimized version. Auth has been converted to a Bearer Token based mechanism for Bridging clients. See (api/endpoint docs for a full description of the API) In addition, the endpoint docs have been cleaned up a bit and made more visible from the top page.

This PR closes the following issues: #238, #250, #251, #215 

@bbangert, @ncalexan r?
