### PR TITLE
bug: Fix delete error reporting. resolves bugzilla:1215253

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -675,7 +675,7 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
         """errBack for unknown chid"""
         fail.trap(ItemNotFound, ValueError)
         log.msg("CHID not found in AWS.", **self._client_info())
-        self._write_response(404, 103)
+        self._write_response(404, 106)
 
     #############################################################
     #                    Utility Methods
@@ -1049,10 +1049,13 @@ class RegistrationHandler(AutoendpointHandler):
     def _delete_channel(self, uaid, chid):
         message = self.ap_settings.message
         message.delete_messages_for_channel(uaid, chid)
-        message.unregister_channel(uaid, chid)
+        if not message.unregister_channel(uaid, chid):
+            raise ItemNotFound("ChannelID not found")
 
     def _delete_uaid(self, uaid, router):
         message = self.ap_settings.message
+        # The following will always return "True" unless something
+        # very odd has happened in dynamodb.
         message.delete_user(uaid)
         if not router.drop_user(uaid):
             raise ItemNotFound("UAID not found")

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -182,6 +182,14 @@ class MessageTestCase(unittest.TestCase):
         assert(len(results) == 1)
         eq_(results[0]["chids"], set([]))
 
+        # Test for the very unlikely case that there's no 'chid'
+        m.connection.update_item = Mock()
+        m.connection.update_item.return_value = {
+            'Attributes': {'uaid': {'S': self.uaid}},
+            'ConsumedCapacityUnits': 0.5}
+        r = message.unregister_channel(self.uaid, "test")
+        eq_(r, False)
+
     def test_all_channels(self):
         chid = str(uuid.uuid4())
         chid2 = str(uuid.uuid4())
@@ -492,4 +500,8 @@ class RouterTestCase(unittest.TestCase):
         # Register a node user
         router.register_user(dict(uaid=uaid, node_id="asdf",
                                   connected_at=1234))
-        router.drop_user(uaid)
+        result = router.drop_user(uaid)
+        eq_(result, True)
+        # Deleting already deleted record should return false.
+        result = router.drop_user(uaid)
+        eq_(result, False)


### PR DESCRIPTION
Checked over the delete code to ensure that proper states and errors are
being returned. Added tests to better guard against changes.

* Removed "all" flag for delete_message
* check state where possible and without increasing read costs.

@bbangert r?