### PR TITLE
Convert the outbound encrypted GCM data to base64

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Features
 * Fixed document reference to HTTP API to be a deep link.
 * Pass either Encryption-Key or Crypto-Key per WebPush spec change. Issue #258
 * Removed refences to obsolete simplepush_test package.
+* Convert outbound GCM data to base64. This should resolve potential
+  transcription issues with binary encoded data going over the bridge.
+  Issue #289
 
 Bug Fixes
 ---------

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -295,6 +295,7 @@ def make_settings(args, **kwargs):
             return
         router_conf["gcm"] = {"ttl": args.gcm_ttl,
                               "dryrun": args.gcm_dryrun,
+                              "max_data": args.max_data,
                               "collapsekey": args.gcm_collapsekey,
                               "senderIDs": senderIDs,
                               "senderid_list": list}

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -88,8 +88,11 @@ class GCMRouter(object):
             udata = urlsafe_b64encode(notification.data)
             mdata = self.config.get('max_data', 4096)
             if len(udata) > mdata:
-                raise self._error("Converted buffer too long by %d bytes" % (
-                    len(udata) - mdata), 413)
+                raise self._error("This message is intended for a " +
+                                  "constrained device and is limited " +
+                                  "to 3070 bytes. Converted buffer too " +
+                                  "long by %d bytes" % (len(udata) - mdata),
+                                  413, errno=104)
             # TODO: if the data is longer than max_data, raise error
             data['body'] = udata
             data['con'] = con
@@ -119,7 +122,8 @@ class GCMRouter(object):
     def _error(self, err, status, **kwargs):
         """Error handler that raises the RouterException"""
         log.err(err, **kwargs)
-        return RouterException(err, status_code=status, response_body=err)
+        return RouterException(err, status_code=status, response_body=err,
+                               **kwargs)
 
     def _process_reply(self, reply):
         """Process GCM send reply"""

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -155,7 +155,7 @@ class EndpointMainTestCase(unittest.TestCase):
         gcm_ttl = 999
         gcm_dryrun = False
         gcm_collapsekey = "collapse"
-
+        max_data = 4096
         # filler
         crypto_key = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
         datadog_api_key = "datadog_api_key"

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -247,6 +247,7 @@ class GCMRouterTestCase(unittest.TestCase):
         def check_results(result):
             ok_(isinstance(result.value, RouterException))
             eq_(result.value.status_code, 413)
+            eq_(result.value.errno, 104)
 
         d.addBoth(check_results)
         return d

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -133,6 +133,14 @@ Send a notification to the given endpoint identified by it's `token`.
     `the WebPush spec
     <https://tools.ietf.org/html/draft-thomson-webpush-http2-02#section-5>`_.
 
+    .. note::
+
+        Some bridged connections require data transcription and may limit the
+        length of data that can be sent. For instance, using a GCM bridge
+        will require that the data be converted to base64. This means that
+        data may be limited to only 2744 bytes instead of the normal 4096
+        bytes.
+
 **Parameters:**
 
     :form version: (*Optional*) Version of notification, defaults to current


### PR DESCRIPTION
* Fixes #289
* Throws 413 error if the encoded, outbound message is more than
  max_data (this should prevent unexpected developer confusion if the
  bridge rejects a block that is nearly max_data length.)
* Added note to docs.

@bbangert r?