### PR TITLE
feat: track last month connected using last_connect router field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ Autopush Changelog
 Features
 --------
 
-* Add router table rotation for all users. Issue #253.
+* Utilize router last_connect index to track whether a user has connected in
+  the current month. Issue #253.
 * Add message table rotation for webpush users. Issue #191.
 * Capture Authorization header for endpoint requests for logging. Issue #232.
 * New Bridge HTTP API. Issues #238, #250, #251

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Autopush Changelog
 Features
 --------
 
+* Add router table rotation for all users. Issue #253.
 * Add message table rotation for webpush users. Issue #191.
 * Capture Authorization header for endpoint requests for logging. Issue #232.
 * New Bridge HTTP API. Issues #238, #250, #251
@@ -44,7 +45,6 @@ Configuration Changes
   --gcm_enabled
   --senderid_list
   --senderid_expry
-
 
 Backwards Incompatibilities
 ---------------------------

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -41,6 +41,7 @@ from twisted.internet.defer import Deferred
 from twisted.internet.threads import deferToThread
 from twisted.python import log
 
+from autopush.db import generate_last_connect
 from autopush.router.interface import RouterException
 from autopush.utils import (
     generate_hash,
@@ -620,6 +621,7 @@ class RegistrationHandler(AutoendpointHandler):
             router_type=router_type,
             router_data=router_data,
             connected_at=int(time.time() * 1000),
+            last_connect=generate_last_connect(),
         )
         return deferToThread(self.ap_settings.router.register_user, user_item)
 

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -14,7 +14,7 @@ from moto import mock_dynamodb2
 from nose.tools import eq_
 
 from autopush.db import (
-    get_message_table,
+    get_rotating_message_table,
     get_router_table,
     get_storage_table,
     create_router_table,
@@ -140,7 +140,7 @@ class StorageTestCase(unittest.TestCase):
 
 class MessageTestCase(unittest.TestCase):
     def setUp(self):
-        table = get_message_table()
+        table = get_rotating_message_table()
         self.real_table = table
         self.real_connection = table.connection
         self.uaid = str(uuid.uuid4())
@@ -153,7 +153,7 @@ class MessageTestCase(unittest.TestCase):
 
     def test_register(self):
         chid = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
 
@@ -164,7 +164,7 @@ class MessageTestCase(unittest.TestCase):
 
     def test_unregister(self):
         chid = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
 
@@ -193,7 +193,7 @@ class MessageTestCase(unittest.TestCase):
     def test_all_channels(self):
         chid = str(uuid.uuid4())
         chid2 = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
         message.register_channel(self.uaid, chid2)
@@ -210,7 +210,7 @@ class MessageTestCase(unittest.TestCase):
     def test_save_channels(self):
         chid = str(uuid.uuid4())
         chid2 = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
         message.register_channel(self.uaid, chid2)
@@ -222,7 +222,7 @@ class MessageTestCase(unittest.TestCase):
         eq_(chans, new_chans)
 
     def test_all_channels_no_uaid(self):
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         exists, chans = message.all_channels("asdf")
         assert(chans == set([]))
@@ -230,7 +230,7 @@ class MessageTestCase(unittest.TestCase):
     def test_message_storage(self):
         chid = str(uuid.uuid4())
         chid2 = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
         message.register_channel(self.uaid, chid2)
@@ -257,7 +257,7 @@ class MessageTestCase(unittest.TestCase):
     def test_delete_user(self):
         chid = str(uuid.uuid4())
         chid2 = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
         message.register_channel(self.uaid, chid2)
@@ -286,7 +286,7 @@ class MessageTestCase(unittest.TestCase):
             return m
 
         chid = str(uuid.uuid4())
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         message.register_channel(self.uaid, chid)
 
@@ -306,7 +306,7 @@ class MessageTestCase(unittest.TestCase):
         eq_(len(all_messages), 0)
 
     def test_message_delete_fail_condition(self):
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
 
         def raise_condition(*args, **kwargs):
@@ -320,7 +320,7 @@ class MessageTestCase(unittest.TestCase):
 
     def test_update_message(self):
         chid = uuid.uuid4().hex
-        m = get_message_table()
+        m = get_rotating_message_table()
         message = Message(m, SinkMetrics())
         data1 = str(uuid.uuid4())
         data2 = str(uuid.uuid4())
@@ -333,7 +333,7 @@ class MessageTestCase(unittest.TestCase):
         eq_(data2, messages[0]['#dd'])
 
     def test_update_message_fail(self):
-        message = Message(get_message_table(), SinkMetrics)
+        message = Message(get_rotating_message_table(), SinkMetrics)
         message.store_message(self.uaid,
                               uuid.uuid4().hex,
                               self._nstime(),

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -24,6 +24,7 @@ from autopush.db import (
     Message,
     ItemNotFound,
     create_rotating_message_table,
+    has_connected_this_month,
 )
 from autopush.settings import AutopushSettings
 from autopush.router.interface import IRouter, RouterResponse
@@ -942,6 +943,9 @@ class RegistrationTestCase(unittest.TestCase):
             eq_(call_arg["uaid"], dummy_uaid)
             eq_(call_arg["channelID"], dummy_chid)
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
+            calls = self.reg.ap_settings.router.register_user.call_args
+            call_args = calls[0][0]
+            eq_(True, has_connected_this_month(call_args))
             ok_("secret" in call_arg)
 
         self.finish_deferred.addCallback(handle_finish)

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -65,30 +65,6 @@ class SettingsAsyncTestCase(trialtest.TestCase):
         d.addCallback(check_tables)
         return d
 
-    @patch("autopush.db.datetime")
-    def test_update_rotating_tables_no_such_table(self, mock_date):
-        from autopush.db import get_month
-        mock_date.date.today.return_value = get_month(-7)
-        settings = AutopushSettings(
-            hostname="google.com", resolve_hostname=True)
-
-        # Drop the table created during the creation of autopush settings
-        settings.message.table.delete()
-
-        # Erase the tables it has on init, and move current month back one
-        last_month = get_month(-1)
-        settings.current_month = last_month.month
-        settings.message_tables = {}
-
-        # Get the deferred back
-        d = settings.update_rotating_tables()
-
-        def check_tables(result):
-            eq_(len(settings.message_tables), 0)
-
-        d.addCallback(check_tables)
-        return d
-
     def test_update_not_needed(self):
         settings = AutopushSettings(
             hostname="google.com", resolve_hostname=True)


### PR DESCRIPTION
Utilizes the existing router last_connect global index to track the first
connect of the month for the client. The last_connect number is a number
joining the year/month/hour with a random int to reduce hot key contention
on the index.
    
Additional integration tests were added to verify the last_connect is updated
appropriately for simplepush and webpush clients.
    
This changes the get_rotating_message_table function to automatically create
the table if needed, reducing boiler-plate in the settings object wrapping
that behavior.
    
Registration endpoint handlers saving router data all update the last_connect
as well (new channels do not update the value).
    
Closes #253

@jrconlin r?