### PR TITLE
Add remote-host to base metrics tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Features
 * Fixed document reference to HTTP API to be a deep link.
 * Pass either Encryption-Key or Crypto-Key per WebPush spec change. Issue #258
 * Removed refences to obsolete simplepush_test package.
+* Record Requesting Hostname to metrics. Issue #228
 
 Bug Fixes
 ---------

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -445,6 +445,10 @@ class RegistrationHandler(AutoendpointHandler):
         tags = self._base_tags
         tags.append("user-agent:%s" %
                     self.request.headers.get("user-agent"))
+        tags.append("remote-host:%s" %
+                    self.request.headers.get("x-forwarded-for",
+                                             self.request.remote_ip))
+        return tags
 
     def _relocate(self, router_type, router_token, uaid="", chid=""):
         relo = "%s/v1/%s/%s/register" % (self.ap_settings.endpoint_url,

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -445,9 +445,7 @@ class RegistrationHandler(AutoendpointHandler):
         tags = self._base_tags
         tags.append("user-agent:%s" %
                     self.request.headers.get("user-agent"))
-        tags.append("remote-host:%s" %
-                    self.request.headers.get("x-forwarded-for",
-                                             self.request.remote_ip))
+        tags.append("host:%s" % self.request.host)
         return tags
 
     def _relocate(self, router_type, router_token, uaid="", chid=""):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -179,7 +179,7 @@ class EndpointTestCase(unittest.TestCase):
         self.senderIDs_mock.get_ID.return_value = "test_senderid"
 
         self.request_mock = Mock(body=b'', arguments={}, headers={},
-                                 remote_ip='1.2.3.4')
+                                 host='1.2.3.4')
         self.endpoint = endpoint.EndpointHandler(Application(),
                                                  self.request_mock,
                                                  ap_settings=settings)
@@ -795,11 +795,10 @@ class RegistrationTestCase(unittest.TestCase):
         self.settings = settings
 
     def test_base_tags(self):
-        self.reg.request = Mock(headers={'user-agent': 'test',
-                                         'x-forwarded-for': '4.3.2.1'},
-                                remote_ip='1.2.3.4')
+        self.reg.request = Mock(headers={'user-agent': 'test'},
+                                host='1.2.3.4:8080')
         tags = self.reg.base_tags()
-        eq_(tags, ['user-agent:test', 'remote-host:4.3.2.1'])
+        eq_(tags, ['user-agent:test', 'host:1.2.3.4:8080'])
 
     def _check_error(self, code, errno, error, message=None):
         d = json.loads(self.write_mock.call_args[0][0])

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -179,7 +179,7 @@ class EndpointTestCase(unittest.TestCase):
         self.senderIDs_mock.get_ID.return_value = "test_senderid"
 
         self.request_mock = Mock(body=b'', arguments={}, headers={},
-                                 host='1.2.3.4')
+                                 host='example.com:8080')
         self.endpoint = endpoint.EndpointHandler(Application(),
                                                  self.request_mock,
                                                  ap_settings=settings)
@@ -796,9 +796,9 @@ class RegistrationTestCase(unittest.TestCase):
 
     def test_base_tags(self):
         self.reg.request = Mock(headers={'user-agent': 'test'},
-                                host='1.2.3.4:8080')
+                                host='example.com:8080')
         tags = self.reg.base_tags()
-        eq_(tags, ['user-agent:test', 'host:1.2.3.4:8080'])
+        eq_(tags, ['user-agent:test', 'host:example.com:8080'])
 
     def _check_error(self, code, errno, error, message=None):
         d = json.loads(self.write_mock.call_args[0][0])

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -178,7 +178,8 @@ class EndpointTestCase(unittest.TestCase):
         self.senderIDs_mock = settings.senderIDs = Mock(spec=SenderIDs)
         self.senderIDs_mock.get_ID.return_value = "test_senderid"
 
-        self.request_mock = Mock(body=b'', arguments={}, headers={})
+        self.request_mock = Mock(body=b'', arguments={}, headers={},
+                                 remote_ip='1.2.3.4')
         self.endpoint = endpoint.EndpointHandler(Application(),
                                                  self.request_mock,
                                                  ap_settings=settings)
@@ -792,6 +793,13 @@ class RegistrationTestCase(unittest.TestCase):
         d = self.finish_deferred = Deferred()
         self.reg.finish = lambda: d.callback(True)
         self.settings = settings
+
+    def test_base_tags(self):
+        self.reg.request = Mock(headers={'user-agent': 'test',
+                                         'x-forwarded-for': '4.3.2.1'},
+                                remote_ip='1.2.3.4')
+        tags = self.reg.base_tags()
+        eq_(tags, ['user-agent:test', 'remote-host:4.3.2.1'])
 
     def _check_error(self, code, errno, error, message=None):
         d = json.loads(self.write_mock.call_args[0][0])

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -173,6 +173,14 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.onConnect(req)
         eq_(self.proto.ps._user_agent, "Me")
 
+    def test_base_tags(self):
+        req = Mock()
+        req.headers = {'user-agent': "tester"}
+        req.peer = "tcp:1.2.3.4:8080"
+        ps = PushState(settings=self.proto.ap_settings, request=req)
+        eq_(ps._base_tags, ['user-agent:tester',
+                            'remote-host:tcp:1.2.3.4:8080'])
+
     def test_reporter(self):
         from autopush.websocket import periodic_reporter
         self.proto.ap_settings.factory = Mock()

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -176,10 +176,10 @@ class WebsocketTestCase(unittest.TestCase):
     def test_base_tags(self):
         req = Mock()
         req.headers = {'user-agent': "tester"}
-        req.host = "1.2.3.4:8080"
+        req.host = "example.com:8080"
         ps = PushState(settings=self.proto.ap_settings, request=req)
         eq_(ps._base_tags, ['user-agent:tester',
-                            'host:1.2.3.4:8080'])
+                            'host:example.com:8080'])
 
     def test_reporter(self):
         from autopush.websocket import periodic_reporter

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -176,10 +176,10 @@ class WebsocketTestCase(unittest.TestCase):
     def test_base_tags(self):
         req = Mock()
         req.headers = {'user-agent': "tester"}
-        req.peer = "tcp:1.2.3.4:8080"
+        req.host = "1.2.3.4:8080"
         ps = PushState(settings=self.proto.ap_settings, request=req)
         eq_(ps._base_tags, ['user-agent:tester',
-                            'remote-host:tcp:1.2.3.4:8080'])
+                            'host:1.2.3.4:8080'])
 
     def test_reporter(self):
         from autopush.websocket import periodic_reporter

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -138,14 +138,21 @@ class PushState(object):
     def __init__(self, settings, request):
         self._callbacks = []
         self.settings = settings
+        remote_host = ""
 
         if request:
             self._user_agent = request.headers.get("user-agent")
+            # Peer returns the remote protocol, IP & socket.
+            # e.g. "tcp4:127.0.0.1:32767"
+            remote_host = request.peer
         else:
             self._user_agent = None
         self._base_tags = []
         if self._user_agent:
             self._base_tags.append("user-agent:%s" % self._user_agent)
+        if remote_host:
+            self._base_tags.append("remote-host:%s" % remote_host)
+
         self._should_stop = False
         self._paused = False
         self.metrics = settings.metrics

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -138,20 +138,19 @@ class PushState(object):
     def __init__(self, settings, request):
         self._callbacks = []
         self.settings = settings
-        remote_host = ""
+        host = ""
 
         if request:
             self._user_agent = request.headers.get("user-agent")
-            # Peer returns the remote protocol, IP & socket.
-            # e.g. "tcp4:127.0.0.1:32767"
-            remote_host = request.peer
+            # Get the name of the server the request asked for.
+            host = request.host
         else:
             self._user_agent = None
         self._base_tags = []
         if self._user_agent:
             self._base_tags.append("user-agent:%s" % self._user_agent)
-        if remote_host:
-            self._base_tags.append("remote-host:%s" % remote_host)
+        if host:
+            self._base_tags.append("host:%s" % host)
 
         self._should_stop = False
         self._paused = False


### PR DESCRIPTION
* Added for websocket and Registration handlers
* Note: Websocket adds a slightly different format.
  "protocol:ip:socket" (e.g. "tcp4:1.2.3.4:1234") I'm not
  sure how ipv6 is registered ("tcp6:[1:2:3:4]:1.2.3.4"?) so not
  quite sure how or if I should trim it down.

Fixes: #292

@bbangert r?