### PR TITLE
 Fix GCM data block send. Fixes #297

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Features
 Bug Fixes
 ---------
 
-* Fixes for GCM JSON encoding rejections. Issue #297
+* Fixes for GCM JSON encoding rejections and ID assignment. Issue #297
 
 
 1.9.0 (2016-01-15)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Autopush Changelog
 ==================
 
+1.10.0 *dev*
+============
+
+Features
+--------
+
+Bug Fixes
+---------
+
+* Fixes for GCM JSON encoding rejections. Issue #297
+
+
 1.9.0 (2016-01-15)
 ==================
 

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -575,9 +575,9 @@ class Router(object):
                         # this not work
                         r[key] = value
                 result = r
-            return (True, result)
+            return (True, result, data)
         except ConditionalCheckFailedException:
-            return (False, {})
+            return (False, {}, data)
 
     @track_provisioned
     def update_last_connect(self, uaid):

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -508,7 +508,7 @@ class RegistrationHandler(AutoendpointHandler):
         self.chid = params["channelID"]
         if new_uaid:
             d = Deferred()
-            d.addCallback(router.register, params)
+            d.addCallback(router.register, params, router_token)
             d.addCallback(self._save_router_data, router_type)
             d.addCallback(self._create_endpoint)
             d.addCallback(self._return_endpoint, new_uaid, router)

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -42,8 +42,8 @@ class APNSRouter(object):
         self._connect()
         log.msg("Starting APNS router...")
 
-    def register(self, uaid, router_data):
-        """Validate that a token is in the ``router_data``"""
+    def register(self, uaid, router_data, *kwargs):
+        """Validate that an APNs instance token is in the ``router_data``"""
         if not router_data.get("token"):
             raise RouterException("No token registered", status_code=500,
                                   response_body="No token registered")

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -49,7 +49,7 @@ class APNSRouter(object):
                                   response_body="No token registered")
         return router_data
 
-    def amend_msg(self, msg):
+    def amend_msg(self, msg, router_data=None):
         return msg
 
     def check_token(self, token):

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -105,7 +105,7 @@ class GCMRouter(object):
             registration_ids=[router_data.get("token")],
             collapse_key=self.collapseKey,
             time_to_live=self.ttl,
-            dry_run=self.dryRun or "dryrun" in router_data,
+            dry_run=self.dryRun or ("dryrun" in router_data),
             data=data,
         )
         creds = router_data.get("creds", {"senderID": "missing id"})

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -43,12 +43,14 @@ class GCMRouter(object):
         msg["senderid"] = self.creds.get("senderID")
         return msg
 
-    def register(self, uaid, router_data):
-        """Validate that a token is in the ``router_data``"""
-        if not router_data.get("token"):
-            raise self._error("connect info missing 'token'", status=401)
+    def register(self, uaid, router_data, router_token=None, *kwargs):
+        """ Validate that the GCM Instance Token is in the ``router_data``"""
+        if "token" not in router_data:
+            raise self._error("connect info missing GCM Instance 'token'",
+                              status=401)
         # Assign a senderid
-        router_data["creds"] = self.creds = self.senderIDs.choose_ID()
+        router_data["creds"] = self.creds = \
+            self.senderIDs.get_ID(router_token)
         return router_data
 
     def route_notification(self, notification, uaid_data):
@@ -98,12 +100,14 @@ class GCMRouter(object):
             data['con'] = con
             data['enc'] = enc
 
+        # registration_ids are the GCM instance tokens (specified during
+        # registration.
         payload = gcmclient.JSONMessage(
-            registration_ids=[router_data["token"]],
+            registration_ids=[router_data.get("token")],
             collapse_key=self.collapseKey,
             time_to_live=self.ttl,
-            dry_run=self.dryRun,
-            data=udata,
+            dry_run=self.dryRun or "dryrun" in router_data,
+            data=data,
         )
         creds = router_data.get("creds", {"senderID": "missing id"})
         try:

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -16,7 +16,6 @@ class GCMRouter(object):
     ttl = 60
     dryRun = 0
     collapseKey = "simplepush"
-    creds = {}
 
     def __init__(self, ap_settings, router_conf):
         """Create a new GCM router and connect to GCM"""
@@ -39,18 +38,18 @@ class GCMRouter(object):
             return (False, self.senderIDs.choose_ID().get('senderID'))
         return (True, token)
 
-    def amend_msg(self, msg):
-        msg["senderid"] = self.creds.get("senderID")
+    def amend_msg(self, msg, data=None):
+        if data is not None:
+            msg["senderid"] = data.get('creds', {}).get('senderID')
         return msg
 
     def register(self, uaid, router_data, router_token=None, *kwargs):
-        """ Validate that the GCM Instance Token is in the ``router_data``"""
+        """Validate that the GCM Instance Token is in the ``router_data``"""
         if "token" not in router_data:
             raise self._error("connect info missing GCM Instance 'token'",
                               status=401)
         # Assign a senderid
-        router_data["creds"] = self.creds = \
-            self.senderIDs.get_ID(router_token)
+        router_data["creds"] = self.senderIDs.get_ID(router_token)
         return router_data
 
     def route_notification(self, notification, uaid_data):

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -43,7 +43,7 @@ class IRouter(object):
         the given settings and router conf."""
         raise NotImplementedError("__init__ must be implemented")
 
-    def register(self, uaid, routing_data):
+    def register(self, uaid, routing_data, *kwargs):
         """Register the uaid with the connect dict however is preferred and
         return a dict that will be stored as routing_data for this user in the
         future.

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -56,10 +56,11 @@ class IRouter(object):
         """
         raise NotImplementedError("register must be implemented")
 
-    def amend_msg(self, msg):
+    def amend_msg(self, msg, router_data=None):
         """Modify an outbound response message to include router info
 
         :param msg: A dict of the response data to be sent to the client
+        :param router_data: a dictionary of router data
         :returns: A potentially modified dict to return to the client
 
         Some routers may require additional info to be returned to clients.

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -58,7 +58,7 @@ class SimpleRouter(object):
         """Return no additional routing data"""
         return {}
 
-    def amend_msg(self, msg):
+    def amend_msg(self, msg, router_data=None):
         return msg
 
     def check_token(self, token):

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -54,7 +54,7 @@ class SimpleRouter(object):
         self.conf = router_conf
         self.waker = None
 
-    def register(self, uaid, connect):
+    def register(self, uaid, connect, *kwargs):
         """Return no additional routing data"""
         return {}
 

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -115,7 +115,7 @@ class WebPushRouter(SimpleRouter):
             timestamp=int(time.time()),
         )
 
-    def amend_msg(self, msg):
+    def amend_msg(self, msg, router_data=None):
         return msg
 
     def check_token(self, token):

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -131,7 +131,7 @@ class SenderIDs(object):
 
     def get_ID(self, id=None):
         """Return the associated record for a given SenderID"""
-        if id is None:
+        if not id:
             return self.choose_ID()
         record = self._senderIDs.get(id)
         return record

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -129,11 +129,13 @@ class SenderIDs(object):
         """Return a list of senderIDs"""
         return self._senderIDs
 
-    def get_ID(self, id):
+    def get_ID(self, id=None):
         """Return the associated record for a given SenderID"""
+        if id is None:
+            return self.choose_ID()
         record = self._senderIDs.get(id)
-        if record:
-            record["senderID"] = id
+        if record is None:
+            return None
         return record
 
     def choose_ID(self):

--- a/autopush/senderids.py
+++ b/autopush/senderids.py
@@ -134,8 +134,6 @@ class SenderIDs(object):
         if id is None:
             return self.choose_ID()
         record = self._senderIDs.get(id)
-        if record is None:
-            return None
         return record
 
     def choose_ID(self):

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -465,9 +465,9 @@ class RouterTestCase(unittest.TestCase):
 
         router.table.connection = Mock()
         router.table.connection.update_item.side_effect = raise_condition
-        result = router.register_user(dict(uaid="asdf", node_id="asdf",
-                                           connected_at=1234))
-        eq_(result, (False, {}))
+        router_data = dict(uaid="asdf", node_id="asdf", connected_at=1234)
+        result = router.register_user(router_data)
+        eq_(result, (False, {}, router_data))
 
     def test_node_clear(self):
         r = get_router_table()

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -910,6 +910,7 @@ class RegistrationTestCase(unittest.TestCase):
             ok_(call_args is not None)
             args = call_args[0]
             call_arg = json.loads(args[0])
+            eq_(call_arg["uaid"], dummy_uaid)
             eq_(call_arg["channelID"], dummy_chid)
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
             ok_("secret" in call_arg)

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -777,6 +777,8 @@ class RegistrationTestCase(unittest.TestCase):
         self.senderIDs_mock.get_ID.return_value = "test_senderid"
         self.router_mock.check_token = Mock()
         self.router_mock.check_token.return_value = (True, 'test')
+        self.router_mock.register_user = Mock()
+        self.router_mock.register_user.return_value = (True, {}, {})
         settings.routers["test"] = self.router_mock
 
         self.request_mock = Mock(body=b'', arguments={}, headers={})

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -908,7 +908,6 @@ class RegistrationTestCase(unittest.TestCase):
             ok_(call_args is not None)
             args = call_args[0]
             call_arg = json.loads(args[0])
-            eq_(call_arg["uaid"], dummy_uaid)
             eq_(call_arg["channelID"], dummy_chid)
             eq_(call_arg["endpoint"], "http://localhost/push/abcd123")
             ok_("secret" in call_arg)

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -396,7 +396,8 @@ class GCMRouterTestCase(unittest.TestCase):
     def test_ammend(self):
         self.router.register("uaid", {"token": "connect_data"})
         resp = {"key": "value"}
-        result = self.router.amend_msg(resp)
+        result = self.router.amend_msg(resp,
+                                       self.router_data.get('router_data'))
         eq_({"key": "value", "senderid": "test123"},
             result)
 

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -168,7 +168,7 @@ class GCMRouterTestCase(unittest.TestCase):
                                              {"auth": "12345678abcdefg"}}}
         self.gcm = fgcm
         self.router = GCMRouter(settings, self.gcm_config)
-        self.headers = {"content-encoding": "text/plain",
+        self.headers = {"content-encoding": "aesgcm",
                         "encryption": "test",
                         "encryption-key": "test"}
         # Data will most likely be binary values.
@@ -233,7 +233,11 @@ class GCMRouterTestCase(unittest.TestCase):
             ok_(isinstance(result, RouterResponse))
             assert(self.router.gcm.send.called)
             # Make sure the data was encoded as base64
-            eq_(self.router.gcm.send.call_args[0][0].data, 'q60d6g==')
+            data = self.router.gcm.send.call_args[0][0].data
+            eq_(data['body'], 'q60d6g==')
+            eq_(data['enc'], 'test')
+            eq_(data['enckey'], 'test')
+            eq_(data['con'], 'aesgcm')
         d.addCallback(check_results)
         return d
 
@@ -392,8 +396,9 @@ class GCMRouterTestCase(unittest.TestCase):
     def test_ammend(self):
         self.router.register("uaid", {"token": "connect_data"})
         resp = {"key": "value"}
+        result = self.router.amend_msg(resp)
         eq_({"key": "value", "senderid": "test123"},
-            self.router.amend_msg(resp))
+            result)
 
 
 class SimplePushRouterTestCase(unittest.TestCase):

--- a/autopush/tests/test_senderids.py
+++ b/autopush/tests/test_senderids.py
@@ -124,6 +124,8 @@ class SenderIDsTestCase(unittest.TestCase):
         self.senderIDs = SenderIDs(settings)
         fetch = self.senderIDs.get_ID('test123')
         eq_(fetch, {"senderID": "test123", "auth": "abc"})
+        fetch = self.senderIDs.get_ID()
+        ok_(fetch is not None)
         return self.senderIDs.stop()
 
     def test_get_norecord(self):

--- a/autopush/tests/test_senderids.py
+++ b/autopush/tests/test_senderids.py
@@ -11,7 +11,8 @@ from twisted.trial import unittest
 
 TEST_BUCKET = "oma_test"
 
-test_list = {"test123": {"auth": "abc"}, "test456": {"auth": "def"}}
+test_list = {"test123": {"senderID": "test123", "auth": "abc"},
+             "test456": {"senderID": "test456", "auth": "def"}}
 
 
 class SenderIDsTestCase(unittest.TestCase):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -496,7 +496,7 @@ class WebsocketTestCase(unittest.TestCase):
 
         def register_user(data):
             registered = len(mock_register.mock_calls) > 1
-            return (registered, {})
+            return (registered, {}, {})
 
         mock_register.side_effect = register_user
 
@@ -514,7 +514,7 @@ class WebsocketTestCase(unittest.TestCase):
 
         # Fail out the register_user call
         self.proto.ap_settings.router.register_user = \
-            Mock(return_value=(False, {}))
+            Mock(return_value=(False, {}, None))
 
         self._send_message(dict(messageType="hello", channelIDs=[]))
 
@@ -859,7 +859,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.ps.uaid = uaid
         connected = int(time.time())
         res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
-        self.proto._check_other_nodes((True, res))
+        self.proto._check_other_nodes((True, res, None))
         mock_agent.request.assert_called_with(
             "DELETE",
             "%s/notif/%s/%s" % (nodeId, uaid, connected))
@@ -874,7 +874,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.ps.uaid = uaid
         connected = int(time.time())
         res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
-        self.proto._check_other_nodes((True, res))
+        self.proto._check_other_nodes((True, res, None))
         d.errback(ConnectError())
         return d
 
@@ -894,7 +894,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.sendClose = Mock()
         self.proto.ps.uaid = uaid
         res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
-        self.proto._check_other_nodes((True, res))
+        self.proto._check_other_nodes((True, res, None))
         # the current one should be dropped.
         eq_(ff.sendClose.call_count, 0)
         eq_(self.proto.sendClose.call_count, 1)
@@ -914,7 +914,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.sendClose = Mock()
         self.proto.ps.uaid = uaid
         res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
-        self.proto._check_other_nodes((True, res))
+        self.proto._check_other_nodes((True, res, None))
         # the existing one should be dropped.
         eq_(ff.sendClose.call_count, 1)
         eq_(self.proto.sendClose.call_count, 0)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -626,7 +626,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
 
     def _check_collision(self, result):
         """callback to reset the UAID if router registration fails"""
-        registered, previous = result
+        registered, previous, data = result
         existing_webpush_rotator = self.ps.use_webpush and \
             "current_month" in previous
 
@@ -647,7 +647,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         """callback to check other nodes for clients and send them a delete as
         needed"""
         self.transport.resumeProducing()
-        registered, previous = result
+        registered, previous, _ = result
         if not registered:
             # Registration failed
             msg = {"messageType": "hello", "reason": "already_connected",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,7 +14,7 @@ apns==2.0.1
 argparse==1.2.1
 autobahn==0.10.4
 boto==2.38.0
-cffi==1.1.2
+#cffi==1.1.2
 characteristic==14.3.0
 cryptography==0.9.1
 cyclone==1.1


### PR DESCRIPTION
* pass "router_token" for senderid lookup
* Clean up comments to be more clear about what each token is.
* Add ability for clients to request "dry run"
* better exam of gcm data response block.
* fix test SenderID hash to match reality.

@bbangert r?