### PR TITLE
bug: fix the multiple write issue for new webpush users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Autopush Changelog
 ==================
 
+1.9.2 (2016-01-22)
+==================
+
+Bug Fixes
+---------
+
+* Reduce new UAID's to a single write, this time for real. Issue #300.
+
 1.9.1 (2016-01-22)
 ==================
 

--- a/autopush/__init__.py
+++ b/autopush/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.9.1'  # pragma: nocover
+__version__ = '1.9.2'  # pragma: nocover

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -528,7 +528,7 @@ class WebsocketTestCase(unittest.TestCase):
 
         # Fail out the register_user call
         self.proto.ap_settings.router.register_user = \
-            Mock(return_value=(False, {}, None))
+            Mock(return_value=(False, {}, {}))
 
         self._send_message(dict(messageType="hello", channelIDs=[]))
 


### PR DESCRIPTION
This fixes the multiple write issue for new webpush and simplepush users by
updating the previous value the way moto does (incorrectly in moto's case).

Fixes #300, again.