### PR TITLE
feat: tag webpush notifications for more thorough logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Autopush Changelog
 Features
 --------
 
+* Tag logged notifications based on whether they're for a webpush user or not.
+  Issue #315.
 * Add maintenance.py script for use in AWS Lambda. Issue #254.
 * Add use_webpush base tag for websocket connections using web_push.
   Issue #205.

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -222,6 +222,7 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
             log.err(fail, **self._client_info())
         if 200 <= exc.status_code < 300:
             log.msg("Success", status_code=exc.status_code,
+                    logged_status=exc.logged_status or "",
                     **self._client_info())
         self._router_response(exc)
 
@@ -428,9 +429,9 @@ class EndpointHandler(AutoendpointHandler):
                                                            uaid_data))
             return d
         else:
-            if response.status_code == 200:
+            if response.status_code == 200 or response.logged_status == 200:
                 log.msg("Successful delivery", **self._client_info())
-            elif response.status_code == 202:
+            elif response.status_code == 202 or response.logged_status == 202:
                 log.msg("Router miss, message stored.", **self._client_info())
             time_diff = time.time() - self.start_time
             self.metrics.timing("updates.handled", duration=time_diff)

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -9,7 +9,7 @@ class RouterException(AutopushException):
     """
     def __init__(self, message, status_code=500, response_body="",
                  router_data=None, headers={}, log_exception=True,
-                 errno=None):
+                 errno=None, logged_status=None):
         """Create a new RouterException"""
         super(AutopushException, self).__init__(message)
         self.status_code = status_code
@@ -17,6 +17,7 @@ class RouterException(AutopushException):
         self.log_exception = log_exception
         self.response_body = response_body or message
         self.errno = errno
+        self.logged_status = logged_status
 
 
 class RouterResponse(object):
@@ -28,13 +29,14 @@ class RouterResponse(object):
 
     """
     def __init__(self, status_code=200, response_body="", router_data=None,
-                 headers={}, errno=None):
+                 headers={}, errno=None, logged_status=None):
         """Create a new RouterResponse"""
         self.status_code = status_code
         self.response_body = response_body
         self.router_data = router_data
         self.headers = headers
         self.errno = errno
+        self.logged_status = logged_status
 
 
 class IRouter(object):

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -29,8 +29,16 @@ class WebPushRouter(SimpleRouter):
                                 notification.version)
         return RouterResponse(status_code=201, response_body="",
                               headers={"Location": location,
-                                       "TTL": notification.ttl})
-    stored_response = delivered_response
+                                       "TTL": notification.ttl},
+                              logged_status=200)
+
+    def stored_response(self, notification):
+        location = "%s/m/%s" % (self.ap_settings.endpoint_url,
+                                notification.version)
+        return RouterResponse(status_code=201, response_body="",
+                              headers={"Location": location,
+                                       "TTL": notification.ttl},
+                              logged_status=202)
 
     def _crypto_headers(self, notification):
         """Creates a dict of the crypto headers for this request."""
@@ -100,7 +108,8 @@ class WebPushRouter(SimpleRouter):
         if notification.ttl == 0:
             raise RouterException("Finished Routing", status_code=201,
                                   log_exception=False,
-                                  headers={"TTL": str(notification.ttl)})
+                                  headers={"TTL": str(notification.ttl)},
+                                  logged_status=204)
         headers = None
         if notification.data:
             headers = self._crypto_headers(notification)


### PR DESCRIPTION
This tags the router responses with additional information for webpush calls
so that our logging statements can determine the three cases under which we
return a 201: delivered, stored, dropped due to TTL 0.

Fixes #315 

@jrconlin r?