### PR TITLE
bug: ensure message table objects for current month are available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Autopush Changelog
 ==================
 
+1.10.1 (**dev**)
+================
+
+Bug Fixes
+---------
+
+* Run looping task call to update message table objects on the endpoint as well
+  as the connection node. Issue #319.
+
 1.10.0 (2016-01-29)
 ===================
 

--- a/autopush/__init__.py
+++ b/autopush/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.10.0'  # pragma: nocover
+__version__ = '1.10.1'  # pragma: nocover

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -497,5 +497,9 @@ def endpoint_main(sysargs=None, use_files=True):
     else:
         reactor.listenTCP(args.port, site)
 
+    # Start the table rotation checker/updater
+    l = task.LoopingCall(settings.update_rotating_tables)
+    l.start(60)
+
     reactor.suggestThreadPoolSize(50)
     reactor.run()


### PR DESCRIPTION
This add's the looping task that the connection nodes have that ensures
the table objects for this months message table are available for use.

Fixes #319 

@jrconlin r?