### PR TITLE
bug: overwrite records during monthly migration to avoid disconnect edge-case

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Autopush Changelog
 Bug Fixes
 ---------
 
+* Use non-conditional update for save_messages as put_item relies on a flakey
+  conditional check that doesn't apply in our case. Issue #320.
 * Run looping task call to update message table objects on the endpoint as well
   as the connection node. Issue #319.
 

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -366,7 +366,7 @@ class Message(object):
             uaid=hasher(uaid),
             chidmessageid=" ",
             chids=channels
-        ))
+        ), overwrite=True)
 
     @track_provisioned
     def store_message(self, uaid, channel_id, message_id, ttl, data=None,


### PR DESCRIPTION
During monthly rotation, if a user drops the connection after the monthly
rotation has begun, but before it completed, then the message table will be
updated but not the router table. This means that the next call will fail
since put_item wasn't called with overwrite=True. This patch fixes that
and includes an integration test to verify the fix.

Closes #320

@jrconlin r?