### PR TITLE
Add Router header to successful outpound subscription updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Features
 * Added VAPID auth support to incoming Push POSTs. Issue #325.
   This does not yet use token caches since that will introduce database
   changes as well as impact a fair bit more code.
+* Added "Router" header to outbound successful subscription updates.
+  Issue #334.
 
 Bug Fixes
 ---------

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -231,8 +231,7 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
             return self._write_response(
                 response.status_code,
                 errno=response.errno or 999,
-                message=response.response_body,
-                )
+                message=response.response_body)
 
     def _router_fail_err(self, fail):
         """errBack for router failures"""

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -206,13 +206,15 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
             self.set_header(name, val)
         if 200 <= response.status_code < 300:
             self.set_status(response.status_code)
+            self.set_header("Router", self.router_key)
             self.write(response.response_body)
             self.finish()
         else:
             return self._write_response(
                 response.status_code,
                 errno=response.errno or 999,
-                message=response.response_body)
+                message=response.response_body,
+                )
 
     def _router_fail_err(self, fail):
         """errBack for router failures"""

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -494,6 +494,7 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.router_mock.get_uaid.assert_called_with('123')
             self.status_mock.assert_called_with(404)
+            ok_('Router' not in self.endpoint._headers)
             self._check_error(404, 103, "Not Found")
         self.finish_deferred.addCallback(handle_finish)
 
@@ -510,6 +511,7 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.assertTrue(result)
             self.endpoint.set_status.assert_called_with(200)
+            eq_(self.endpoint._headers.get('Router'), 'simplepush')
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.put(dummy_uaid)
@@ -532,6 +534,7 @@ class EndpointTestCase(unittest.TestCase):
 
         def handle_finish(result):
             self.assertTrue(result)
+            eq_(self.endpoint._headers.get('Router'), 'webpush')
             self.endpoint.set_status.assert_called_with(200)
 
         self.finish_deferred.addCallback(handle_finish)
@@ -619,8 +622,10 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.assertTrue(result)
             self.endpoint.set_status.assert_called_with(201)
-            self.endpoint.set_header.assert_called_with(
+            self.endpoint.set_header.assert_any_call(
                 "Location", "Somewhere")
+            self.endpoint.set_header.assert_any_call(
+                "Router", "webpush")
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.post(dummy_uaid)
@@ -647,8 +652,10 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.assertTrue(result)
             self.endpoint.set_status.assert_called_with(201)
-            self.endpoint.set_header.assert_called_with(
+            self.endpoint.set_header.assert_any_call(
                 "Location", "Somewhere")
+            self.endpoint.set_header.assert_any_call(
+                "Router", "webpush")
             args, kwargs = mock_log.call_args
             eq_("Successful delivery", args[0])
             log_patcher.stop()
@@ -678,8 +685,10 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.assertTrue(result)
             self.endpoint.set_status.assert_called_with(201)
-            self.endpoint.set_header.assert_called_with(
+            self.endpoint.set_header.assert_any_call(
                 "Location", "Somewhere")
+            self.endpoint.set_header.assert_any_call(
+                "Router", "webpush")
             args, kwargs = mock_log.call_args
             eq_("Router miss, message stored.", args[0])
             log_patcher.stop()

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -953,8 +953,10 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.assertTrue(result)
             self.endpoint.set_status.assert_called_with(201)
-            self.endpoint.set_header.assert_called_with(
+            self.endpoint.set_header.assert_any_call(
                 "Location", "Somewhere")
+            self.endpoint.set_header.assert_any_call(
+                "Router", "webpush")
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.post(dummy_uaid)


### PR DESCRIPTION
In order to assist in determining errors with users, it would be useful to know how a given message was routed. The "Routing" header provides how the system believes the message should be routed ("simplepush", "webpush", "gcm", etc.)

Resolves: #334
@bbangert r?