### PR TITLE
bug: use appropriate 400, 410 instead of 404 for permanent errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,9 @@ Features
 Bug Fixes
 ---------
 
-*  Do not send useless 'ver' across GCM bridge. Issue #323.
+* Use appropriate 400, 404, 410 status codes for differing message endpoint
+  results, rather than always a 404. Issue #312.
+* Do not send useless 'ver' across GCM bridge. Issue #323.
 
 1.10.1 (2016-02-01)
 ===================

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -248,13 +248,13 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
         """errBack for uaid lookup not finding the user"""
         fail.trap(ItemNotFound)
         log.msg("UAID not found in AWS.", **self._client_info)
-        self._write_response(404, 103)
+        self._write_response(410, 103)
 
     def _token_err(self, fail):
         """errBack for token decryption fail"""
         fail.trap(InvalidToken, ValueError)
         log.msg("Invalid token", **self._client_info)
-        self._write_response(404, 102)
+        self._write_response(400, 102)
 
     def _auth_err(self, fail):
         """errBack for invalid auth token"""
@@ -266,7 +266,7 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
         """errBack for unknown chid"""
         fail.trap(ItemNotFound, ValueError)
         log.msg("CHID not found in AWS.", **self._client_info)
-        self._write_response(404, 106)
+        self._write_response(410, 106)
 
     #############################################################
     #                    Utility Methods

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -146,7 +146,7 @@ class SimpleRouter(object):
         except ItemNotFound:
             self.metrics.increment("updates.client.deleted")
             raise RouterException("User was deleted",
-                                  status_code=404,
+                                  status_code=410,
                                   response_body="Invalid UAID",
                                   errno=105)
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -106,7 +106,7 @@ class MessageTestCase(unittest.TestCase):
             "decrypt.side_effect": InvalidToken})
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(404)
+            self.status_mock.assert_called_with(400)
         self.finish_deferred.addCallback(handle_finish)
 
         self.message.delete('')
@@ -116,7 +116,7 @@ class MessageTestCase(unittest.TestCase):
         self.fernet_mock.decrypt.return_value = "123:456"
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(404)
+            self.status_mock.assert_called_with(400)
         self.finish_deferred.addCallback(handle_finish)
 
         self.message.delete('')
@@ -126,7 +126,7 @@ class MessageTestCase(unittest.TestCase):
         self.fernet_mock.decrypt.return_value = "r:123:456"
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(404)
+            self.status_mock.assert_called_with(400)
         self.finish_deferred.addCallback(handle_finish)
 
         self.message.delete('')
@@ -480,7 +480,7 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.request.body = b'version=123&data=bad-token'
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(404)
+            self.status_mock.assert_called_with(400)
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.put('')
@@ -491,7 +491,7 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.request.body = b'version=123'
 
         def handle_finish(result):
-            self.status_mock.assert_called_with(404)
+            self.status_mock.assert_called_with(400)
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.put('')
@@ -509,8 +509,8 @@ class EndpointTestCase(unittest.TestCase):
 
         def handle_finish(result):
             self.router_mock.get_uaid.assert_called_with('123')
-            self.status_mock.assert_called_with(404)
-            self._check_error(404, 103, "Not Found")
+            self.status_mock.assert_called_with(410)
+            self._check_error(410, 103, "")
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.version, self.endpoint.data = 789, None
@@ -1572,7 +1572,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.request.headers["Authorization"] = self.auth
 
         def handle_finish(value):
-            self._check_error(404, 106, "Not Found")
+            self._check_error(410, 106, "")
             messages.delete_user(dummy_uaid)
 
         self.finish_deferred.addCallback(handle_finish)
@@ -1625,7 +1625,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.request.headers["Authorization"] = self.auth
 
         def handle_finish(value):
-            self.reg.set_status.assert_called_with(404)
+            self.reg.set_status.assert_called_with(410)
 
         self.router_mock.drop_user = Mock()
         self.router_mock.drop_user.return_value = False

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -219,10 +219,6 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
                     headers.update({
                         'Crypto-Key': headers.get('Crypto-Key') + ';' + ckey
                     })
-                else:
-                    headers.update({
-                        'Crypto-Key': ckey
-                    })
             body = data or ""
             method = "POST"
             status = status or 201

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -547,7 +547,7 @@ class SimplePushRouterTestCase(unittest.TestCase):
         def verify_deliver(fail):
             exc = fail.value
             ok_(exc, RouterException)
-            eq_(exc.status_code, 404)
+            eq_(exc.status_code, 410)
         d.addBoth(verify_deliver)
         return d
 

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -87,6 +87,7 @@ Unless otherwise specified, all calls return the following error codes:
 -  400 - Bad Parameters
 
    - errno 101 - Missing neccessary crypto keys
+   - errno 102 - Invalid URL endpoint
    - errno 108 - Router type is invalid
    - errno 110 - Invalid crypto keys specified
 
@@ -94,14 +95,13 @@ Unless otherwise specified, all calls return the following error codes:
 
    - errno 109 - Invalid authentication
 
--  404 - `{UAID}` not found or invalid
+-  410 - `{UAID}` or `{CHID}` not found
 
-   - errno 102 - Invalid URL endpoint
    - errno 103 - Expired URL endpoint
    - errno 105 - Endpoint became unavailable during request
    - errno 106 - Invalid subscription
 
-- 413 - Payload too large
+-  413 - Payload too large
 
    - errno 104 - Data payload too large
 


### PR DESCRIPTION
Previously 404 was returned for multiple classes of errors when the endpoints
would never in fact be good, so a 410 is appropriate. In one case a 404 was
returned instead of a 400 which properly addresses the fact that the URL was
not validly constructed.

Closes #312 

@jrconlin r?