### PR TITLE
feat: log notification acks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Autopush Changelog
 Features
 --------
 
+* Log notifications out of autopush nodes for data on when they were
+  actually delivered to clients. Issue #331.
 * Added VAPID auth support to incoming Push POSTs. Issue #325.
   This does not yet use token caches since that will introduce database
   changes as well as impact a fair bit more code.

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -4,7 +4,6 @@ import sys
 import time
 import uuid
 import base64
-import hashlib
 
 import ecdsa
 import twisted.internet.base
@@ -29,6 +28,7 @@ from autopush.db import (
     ItemNotFound,
     create_rotating_message_table,
     has_connected_this_month,
+    hasher
 )
 from autopush.settings import AutopushSettings
 from autopush.router.interface import IRouter, RouterResponse
@@ -390,8 +390,7 @@ class EndpointTestCase(unittest.TestCase):
         d = self.endpoint._init_info()
         eq_(d["authorization"], "bearer token fred")
         self.endpoint.uaid = "faa"
-        eq_(self.endpoint._client_info["uaid_hash"],
-            hashlib.sha224("faa").hexdigest())
+        eq_(self.endpoint._client_info["uaid_hash"], hasher("faa"))
         self.endpoint.chid = "fie"
         eq_(self.endpoint._client_info['channelID'], "fie")
 


### PR DESCRIPTION
Log all notification ack's for simplepush/webpush, along with the router
key, message/channel ids, and uaid hash. Update logging on autoendpoint
to match format and keys for correlation.

Closes #331 

@jrconlin r?