### PR TITLE
fix: allow webpush w/no ttl & cleanup 400 logging

### DIFF
--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -20,6 +20,8 @@ from autopush.protocol import IgnoreBody
 from autopush.router.interface import RouterException, RouterResponse
 from autopush.router.simple import SimpleRouter
 
+TTL_URL = "https://webpush-wg.github.io/webpush-protocol/#rfc.section.6.2"
+
 
 class WebPushRouter(SimpleRouter):
     """SimpleRouter subclass to store individual messages appropriately"""
@@ -29,7 +31,7 @@ class WebPushRouter(SimpleRouter):
                                 notification.version)
         return RouterResponse(status_code=201, response_body="",
                               headers={"Location": location,
-                                       "TTL": notification.ttl},
+                                       "TTL": notification.ttl or 0},
                               logged_status=200)
 
     def stored_response(self, notification):
@@ -105,6 +107,15 @@ class WebPushRouter(SimpleRouter):
         available.
 
         """
+        if notification.ttl is None:
+            # Note that this URL is temporary, as well as this warning as
+            # we will 400 all missing TTL's eventually
+            raise RouterException(
+                "Missing TTL Header",
+                response_body="Missing TTL Header, see: %s" % TTL_URL,
+                status_code=400,
+                errno=111
+            )
         if notification.ttl == 0:
             location = "%s/m/%s" % (self.ap_settings.endpoint_url,
                                     notification.version)

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -91,6 +91,7 @@ Unless otherwise specified, all calls return the following error codes:
    - errno 108 - Router type is invalid
    - errno 110 - Invalid crypto keys specified
    - errno 111 - Missing Required Header
+   - errno 112 - Invalid TTL header value
 
 -  401 - Bad Authorization
 


### PR DESCRIPTION
Allows webpush notifications with no TTL header included as long
as the client is online. Otherwise a 400 is returned with a
descriptive URL including a link to the appropriate docs on how to
include a proper TTL.

Refactors how the TTL setup code is handled, and cleans up the 400
logging for consistency.

Closes #357, #358

@jrconlin r?