### PR TITLE
feat: upgrade autobahn/twisted to 0.12/15.5

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -78,6 +78,7 @@ def stdout(message):
         return
     msg = {}
     ts = message.pop("timestamp")
+    message.pop("time")
     del message["task_level"]
     msg["Hostname"] = HOSTNAME
     if message["error"]:
@@ -93,10 +94,11 @@ def stdout(message):
             msg[key.title()] = message.pop(key)
 
     msg["Timestamp"] = ts * 1000 * 1000 * 1000
-    msg["Fields"] = message
+    msg["Fields"] = {k: v for k, v in message.items()
+                     if not k.startswith("log_")}
     msg["EnvVersion"] = "2.0"
     msg["Logger"] = LOGGER
-    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.write(json.dumps(msg, skipkeys=True) + "\n")
 
 
 def setup_logging(logger_name, human=False):

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import twisted.internet
 import twisted.trial.unittest
@@ -21,7 +20,6 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
 
     def tearDown(self):
         self.mock_raven.stop()
-        log.startLogging(sys.stdout)
 
     def test_sentry_logging(self):
         os.environ["SENTRY_DSN"] = "some_locale"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ ConfigArgParse==0.9.3
 Flask==0.10.1
 Jinja2==2.7.3
 MarkupSafe==0.23
-Twisted==15.1.0
+Twisted==15.5.0
 Werkzeug==0.10.4
 apns==2.0.1
 argparse==1.2.1
-autobahn==0.10.4
+autobahn==0.12.1
 boto==2.38.0
 cffi==1.1.2
 characteristic==14.3.0
@@ -15,7 +15,7 @@ cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0
 ecdsa==0.13
-eliot==0.7.1
+eliot==0.11.0
 enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4
@@ -35,7 +35,7 @@ pycparser==2.14
 pyflakes==0.8.1
 Pympler==0.4.2
 python-jose==0.5.6
-raven==5.3.1
+raven==5.10.2
 readline==6.2.4.1
 repoze.lru==0.6
 requests==2.7.0
@@ -43,10 +43,10 @@ service-identity==14.0.0
 simplejson==3.8.0
 translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
-txaio==1.0.0
+txaio==2.2.1
 virtualenv==13.1.0
 wsaccel==0.6.2
 wsgiref==0.1.2
 xmltodict==0.9.2
 zope.deprecation==4.1.2
-zope.interface==4.1.2
+zope.interface==4.1.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,11 +8,11 @@ ConfigArgParse==0.9.3
 Flask==0.10.1
 Jinja2==2.7.3
 MarkupSafe==0.23
-Twisted==15.1.0
+Twisted==15.5.0
 Werkzeug==0.10.4
 apns==2.0.1
 argparse==1.2.1
-autobahn==0.10.4
+autobahn==0.12.1
 boto==2.38.0
 #cffi==1.1.2
 characteristic==14.3.0
@@ -21,7 +21,7 @@ cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0
 ecdsa==0.13
-eliot==0.7.1
+eliot==0.11.0
 enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4
@@ -50,11 +50,11 @@ service-identity==14.0.0
 simplejson==3.8.0
 translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
-txaio==1.0.0
+txaio==2.2.1
 virtualenv==13.1.0
 websocket-client==0.32.0
 wsaccel==0.6.2
 wsgiref==0.1.2
 xmltodict==0.9.2
 zope.deprecation==4.1.2
-zope.interface==4.1.2
+zope.interface==4.1.3


### PR DESCRIPTION
Update the requirements to use the latest autobahn, and the recent
twisted/txaio/raven/eliot as well. Minor fixes to logging to ensure
the log output works with the new keys twisted 15.5 introduced.

Closes #351, #180 

@jrconlin r?