### PR TITLE
bug: silence missing TTL errors from sentry log

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -246,7 +246,7 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
         fail.trap(RouterException)
         exc = fail.value
         if exc.log_exception:
-            log.err(fail, **self._client_info)
+            log.err(fail, **self._client_info)  # pragma nocover
         if 200 <= exc.status_code < 300:
             log.msg("Success", status_code=exc.status_code,
                     logged_status=exc.logged_status or "",

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -115,7 +115,8 @@ class WebPushRouter(SimpleRouter):
                 "Missing TTL Header",
                 response_body="Missing TTL Header, see: %s" % TTL_URL,
                 status_code=400,
-                errno=111
+                errno=111,
+                log_exception=False,
             )
         if notification.ttl == 0:
             location = "%s/m/%s" % (self.ap_settings.endpoint_url,

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -317,7 +317,8 @@ class EndpointTestCase(unittest.TestCase):
                 "Missing TTL Header",
                 status_code=400,
                 response_body="Missing TTL Header",
-                errno=111
+                errno=111,
+                log_exception=False,
             )
 
         self.wp_router_mock.route_notification.side_effect = raise_error
@@ -1108,7 +1109,8 @@ class EndpointTestCase(unittest.TestCase):
                 "Provisioned throughput error",
                 status_code=503,
                 response_body="Retry Request",
-                errno=201
+                errno=201,
+                log_exception=False
             )
 
         self.wp_router_mock.route_notification.side_effect = raise_error


### PR DESCRIPTION
Missing TTL headers are being logged resulting in high levels of noise
in the Sentry logs. Set the "log_exception" param to False to prevent
the message from going to the system log.

issue #366

@bbangert r?