### PR TITLE
bug: Normalize encryption headers

### DIFF
--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -53,7 +53,8 @@ class WebPushRouter(SimpleRouter):
         # they're present to avoid empty strings.
         for name in ["encryption-key", "crypto-key"]:
             if name in headers:
-                data[name] = headers[name]
+                # Normalize hyphens in header names.
+                data[name.replace("-", "_")] = headers[name]
         return data
 
     @inlineCallbacks

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -598,6 +598,10 @@ class TestData(IntegrationBase):
             chan = result["channelID"]
             test = tests[chan]
             eq_(result["data"], test["result"])
+            headers = result["headers"]
+            ok_("crypto_key" in headers)
+            ok_("encryption" in headers)
+            ok_("encoding" in headers)
             yield client.ack(chan, result["version"])
 
         yield self.shut_down(client)

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -717,7 +717,7 @@ class WebPushRouterTestCase(unittest.TestCase):
             eq_(result.status_code, 201)
             t_h = self.message_mock.store_message.call_args[1].get('headers')
             eq_(t_h.get('encryption'), self.headers.get('encryption'))
-            eq_(t_h.get('crypto-key'), self.headers.get('crypto-key'))
+            eq_(t_h.get('crypto_key'), self.headers.get('crypto-key'))
             eq_(t_h.get('encoding'), self.headers.get('content-encoding'))
             self.router.metrics.increment.assert_called_with(
                 "router.broadcast.save_hit"


### PR DESCRIPTION
#361 was a bit too aggressive. Firefox expects `Crypto-Key` and `Encryption-Key` to be converted to `crypto_key` and `encryption_key`.

This should be part of tomorrow's deploy.

@jrconlin r?