### PR TITLE
bug: change message_type to message_source

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -86,7 +86,12 @@ def stdout(message):
     else:
         msg["Severity"] = 5
 
-    for key in ["Type", "Severity", "type", "severity"]:
+    # 'message_type' is used by twisted logging. Preserve this to the
+    # 'Type' tag.
+    if "message_type" in message:
+        msg["Type"] = message.pop("message_type")
+
+    for key in ["Severity", "type", "severity"]:
         if key in message:
             msg[key.title()] = message.pop(key)
 

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1151,7 +1151,7 @@ class WebsocketTestCase(unittest.TestCase):
             args, kwargs = mock_log.msg.call_args
             eq_(args[0], "Ack")
             eq_(kwargs["router_key"], "simplepush")
-            eq_(kwargs["message_type"], "direct")
+            eq_(kwargs["message_source"], "direct")
 
             d.callback(True)
 
@@ -1184,7 +1184,7 @@ class WebsocketTestCase(unittest.TestCase):
         args, kwargs = mock_log.msg.call_args
         eq_(args[0], "Ack")
         eq_(kwargs["router_key"], "webpush")
-        eq_(kwargs["message_type"], "direct")
+        eq_(kwargs["message_source"], "direct")
 
     @patch('autopush.websocket.log', spec=True)
     def test_ack_with_webpush_from_storage(self, mock_log):
@@ -1209,7 +1209,7 @@ class WebsocketTestCase(unittest.TestCase):
         args, kwargs = mock_log.msg.call_args
         eq_(args[0], "Ack")
         eq_(kwargs["router_key"], "webpush")
-        eq_(kwargs["message_type"], "stored")
+        eq_(kwargs["message_source"], "stored")
 
     def test_ack_remove(self):
         self._connect()

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -1093,7 +1093,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             msg = found[0]
             size = len(msg.data) if msg.data else 0
             log.msg("Ack", router_key="webpush", channelID=chid,
-                    message_id=version, message_type="direct",
+                    message_id=version, message_source="direct",
                     message_size=size, uaid_hash=self.ps.uaid_hash,
                     user_agent=self.ps.user_agent)
             self.ps.direct_updates[chid].remove(msg)
@@ -1104,7 +1104,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             msg = found[0]
             size = len(msg.data) if msg.data else 0
             log.msg("Ack", router_key="webpush", channelID=chid,
-                    message_id=version, message_type="stored",
+                    message_id=version, message_source="stored",
                     message_size=size, uaid_hash=self.ps.uaid_hash,
                     user_agent=self.ps.user_agent)
             d = self.force_retry(self.ps.message.delete_message,
@@ -1137,12 +1137,12 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
            self.ps.direct_updates[chid] <= version:
             del self.ps.direct_updates[chid]
             log.msg("Ack", router_key="simplepush", channelID=chid,
-                    message_id=version, message_type="direct",
+                    message_id=version, message_source="direct",
                     uaid_hash=self.ps.uaid_hash,
                     user_agent=self.ps.user_agent)
             return
         log.msg("Ack", router_key="simplepush", channelID=chid,
-                message_id=version, message_type="stored",
+                message_id=version, message_source="stored",
                 uaid_hash=self.ps.uaid_hash,
                 user_agent=self.ps.user_agent)
         if chid in self.ps.updates_sent and \


### PR DESCRIPTION
Logging considers "message_type" to be a reserved term. This causes us
to lose some logging information.

@bbangert r?