### PR TITLE
bug: pass TTL Header value to GCM

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -445,10 +445,10 @@ class EndpointHandler(AutoendpointHandler):
         try:
             self.router = self.ap_settings.routers[router_key]
         except KeyError:
-            log.msg("Client error", status_code=400, errno=108,
+            log.msg("Invalid router requested", status_code=400, errno=108,
                     **self._client_info)
             return self._write_response(400, 108,
-                                        message="Invalid router type")
+                                        message="Invalid router")
 
         # Only simplepush uses version/data out of body/query, GCM/APNS will
         # use data out of the request body 'WebPush' style.
@@ -598,9 +598,9 @@ class RegistrationHandler(AutoendpointHandler):
 
         # normalize the path vars into parameters
         if router_type not in self.ap_settings.routers:
-            log.msg("Invalid parameters", **self._client_info)
+            log.msg("Invalid router requested", **self._client_info)
             return self._write_response(
-                400, 108, message="Invalid arguments")
+                400, 108, message="Invalid router")
         router = self.ap_settings.routers[router_type]
         valid, router_token = router.check_token(router_token)
         if not valid:
@@ -651,9 +651,9 @@ class RegistrationHandler(AutoendpointHandler):
         self.uaid = uaid
         router_data = params
         if router_type not in self.ap_settings.routers or not router_data:
-            log.msg("Invalid parameters", **self._client_info)
+            log.msg("Invalid router requested", **self._client_info)
             return self._write_response(
-                400, 108, message="Invalid arguments")
+                400, 108, message="Invalid router")
         router = self.ap_settings.routers[router_type]
         valid, router_token = router.check_token(router_token)
         if not valid:
@@ -699,9 +699,9 @@ class RegistrationHandler(AutoendpointHandler):
             return self._write_unauthorized_response(
                 message="Invalid Authentication")
         if router_type not in self.ap_settings.routers:
-            log.msg("Invalid parameters", **self._client_info)
+            log.msg("Invalid router requested", **self._client_info)
             return self._write_response(
-                400, 108, message="Invalid arguments")
+                400, 108, message="Invalid router")
         router = self.ap_settings.routers[router_type]
         valid, router_token = router.check_token(router_token)
         if not valid:

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -13,14 +13,13 @@ from autopush.senderids import SenderIDs
 class GCMRouter(object):
     """GCM Router Implementation"""
     gcm = None
-    ttl = 60
     dryRun = 0
     collapseKey = "simplepush"
 
     def __init__(self, ap_settings, router_conf):
         """Create a new GCM router and connect to GCM"""
         self.config = router_conf
-        self.ttl = router_conf.get("ttl", 60)
+        self.min_ttl = router_conf.get("ttl", 60)
         self.dryRun = router_conf.get("dryrun", False)
         self.collapseKey = router_conf.get("collapseKey", "simplepush")
         self.senderIDs = router_conf.get("senderIDs")
@@ -100,10 +99,11 @@ class GCMRouter(object):
 
         # registration_ids are the GCM instance tokens (specified during
         # registration.
+        router_ttl = notification.ttl or 0
         payload = gcmclient.JSONMessage(
             registration_ids=[router_data.get("token")],
             collapse_key=self.collapseKey,
-            time_to_live=self.ttl,
+            time_to_live=max(self.min_ttl, router_ttl),
             dry_run=self.dryRun or ("dryrun" in router_data),
             data=data,
         )

--- a/configs/autopush_endpoint.ini
+++ b/configs/autopush_endpoint.ini
@@ -25,6 +25,10 @@ port = 8082
 ; GCM requires a API Auth key. It is STRONGLY recommended you use one specific to this app.
 #gcm_apikey = <API_KEY>
 
+; Minimum GCM Time To Live value. Set this in case of excessive loss of
+; TTL 0 messages across the GCM bridge
+#gcm_ttl = 0
+
 ; AuthKey are the keys to use for Bearer Auth tokens. It uses the same
 ; autokey generator as the crypto_key argument, and sorted [newest, oldest]
 #auth_key = [HJVPy4ZwF4Yz_JdvXTL8hRcwIhv742vC60Tg5Ycrvw8=]


### PR DESCRIPTION
The code was previously using the configuration option of gcm_ttl
instead of the user supplied TTL. Instead, use gcm_ttl as the minimum
TTL in case of message loss due to TTL 0.

closes #374 

@bbangert 