### PR TITLE
feature: allow channels to register with public key

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -15,7 +15,8 @@ import socket
 import sys
 
 import raven
-from eliot import add_destination, fields, Logger, MessageType
+from eliot import (add_destination, fields,
+                   Logger, MessageType)
 from twisted.python.log import textFromEventDict, startLoggingWithObserver
 
 HOSTNAME = socket.getfqdn()

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -467,7 +467,8 @@ def endpoint_main(sysargs=None, use_files=True):
 
     # Endpoint HTTP router
     site = cyclone.web.Application([
-        (r"/push/([^\/]+)", EndpointHandler, dict(ap_settings=settings)),
+        (r"/push/(?:(v\d+)\/)?([^\/]+)", EndpointHandler,
+         dict(ap_settings=settings)),
         (r"/m/([^\/]+)", MessageHandler, dict(ap_settings=settings)),
         # PUT /register/ => connect info
         # GET /register/uaid => chid + endpoint

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -1000,7 +1000,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         self.transport.pauseProducing()
 
         d = self.deferToThread(self.ap_settings.make_endpoint, self.ps.uaid,
-                               chid)
+                               chid, data.get("key"))
         d.addCallback(self.finish_register, chid)
         d.addErrback(self.trap_cancel)
         d.addErrback(self.error_register)


### PR DESCRIPTION
Channels can include a public key when registering a new subscription
channel. This public key should match the public key used to send
subscription updates later.

NOTE: this patch changes the format of the endpoint URLs, & the content
of the endpoint URL token. This change also requires that ChannelIDs be
normalized to dashed format, (e.g. a lower case, dash delimited string
"deadbeef-0000-0000-deca-fbad11112222") This is the default mechanism
used by Firefox for UUID generation. It is STRONGLY urged that clients
normalize UUIDs used for ChannelIDs and User Agent IDs. While this
should not break existing clients, additional testing may be required.

Closes #326

@bbangert r?