### PR TITLE
bug: force header values to lowercase underscored values

### DIFF
--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -53,8 +53,9 @@ class WebPushRouter(SimpleRouter):
         # they're present to avoid empty strings.
         for name in ["encryption-key", "crypto-key"]:
             if name in headers:
-                # Normalize hyphens in header names.
-                data[name.replace("-", "_")] = headers[name]
+                # NOTE: The client code expects all header keys to be lower
+                # case and s/-/_/.
+                data[name.lower().replace("-", "_")] = headers[name]
         return data
 
     @inlineCallbacks


### PR DESCRIPTION
The client expects all header values transmitted to be lower case with
underbars. (e.g."Encryption-Key" would become "encryption-key") The
current code enforces this rule for the header data that is included
as part of the WebPush update.

Closes #373 

@bbangert 