### PR TITLE
bug: capture ValueError for empty notifications arrays

### DIFF
--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1258,6 +1258,14 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.ps.updates_sent[chid] = None
         self.proto._handle_webpush_update_remove(None, chid, notif)
 
+    def test_ack_remove_missing(self):
+        self._connect()
+        chid = str(uuid.uuid4())
+        notif = Notification(version="bleh", headers={}, data="meh",
+                             channel_id=chid, ttl=200, timestamp=0)
+        self.proto.ps.updates_sent[chid] = []
+        self.proto._handle_webpush_update_remove(None, chid, notif)
+
     def test_ack_fails_first_time(self):
         self._connect()
         self.proto.ps.uaid = str(uuid.uuid4())

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -1148,7 +1148,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         """
         try:
             self.ps.updates_sent[chid].remove(notif)
-        except AttributeError:
+        except (AttributeError, ValueError):
             pass
 
     def _handle_simple_ack(self, chid, version, code):


### PR DESCRIPTION
Empty pending notification arrays may be returned. Removing a value can
trigger a ValueError that can be safely ignored.

Closes #385 

@bbangert r?