### PR TITLE
bug: limit valid months to acceptable range

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -58,10 +58,11 @@ def normalize_id(id):
     return '-'.join((raw[:8], raw[8:12], raw[12:16], raw[16:20], raw[20:]))
 
 
-def make_rotating_tablename(prefix, delta=0):
+def make_rotating_tablename(prefix, delta=0, date=None):
     """Creates a tablename for table rotation based on a prefix with a given
     month delta."""
-    date = get_month(delta=delta)
+    if not date:
+        date = get_month(delta=delta)
     return "{}_{}_{}".format(prefix, date.year, date.month)
 
 
@@ -77,11 +78,11 @@ def create_rotating_message_table(prefix="message", read_throughput=5,
                         )
 
 
-def get_rotating_message_table(prefix="message", delta=0):
+def get_rotating_message_table(prefix="message", delta=0, date=None):
     """Gets the message table for the current month."""
     db = DynamoDBConnection()
     dblist = db.list_tables()["TableNames"]
-    tablename = make_rotating_tablename(prefix, delta)
+    tablename = make_rotating_tablename(prefix, delta, date)
     if tablename not in dblist:
         return create_rotating_message_table(prefix=prefix, delta=delta)
     else:

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -70,6 +70,14 @@ class DbCheckTestCase(unittest.TestCase):
             'd8f614d06cdd592cb8470f31177c8331a')
         db.key_hash = ""
 
+    def test_normalize_id(self):
+        import autopush.db as db
+        abnormal = "deadbeef00000000decafbad00000000"
+        normal = "deadbeef-0000-0000-deca-fbad00000000"
+        eq_(db.normalize_id(abnormal), normal)
+        self.assertRaises(ValueError, db.normalize_id, "invalid")
+        eq_(db.normalize_id(abnormal.upper()), normal)
+
 
 class StorageTestCase(unittest.TestCase):
     def setUp(self):

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -776,9 +776,14 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         self.transport.pauseProducing()
         # Check for table rotation
         cur_month = previous.get("current_month")
+        # Previous month user or new user, flag for message rotation and
+        # set the message_month to the router month
         if cur_month != self.ps.message_month:
-            # Previous month user or new user, flag for message rotation and
-            # set the message_month to the router month
+            if cur_month not in self.ps.settings.message_tables:
+                # This UAID has expired. Force client to reregister.
+                self.ps.uaid = uuid.uuid4().hex
+                self._finish_webpush_hello()
+                return
             self.ps.message_month = cur_month
             self.ps.rotate_message_table = True
 


### PR DESCRIPTION
A user that tries to connect from a period longer than we currently
allow for could cause a "KeyError" on the server. Instead, we should
require that the user use a new UAID, which shoud cause the client to
re-register older connections.

Closes #350 

@bbangert r? 
