### PR TITLE
Bug/issue 395

### DIFF
--- a/autopush/__init__.py
+++ b/autopush/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.13'  # pragma: nocover
+__version__ = '1.13.1'  # pragma: nocover

--- a/autopush/exceptions.py
+++ b/autopush/exceptions.py
@@ -3,3 +3,7 @@
 
 class AutopushException(Exception):
     """Parent Autopush Exception"""
+
+
+class InvalidTokenException(Exception):
+    """Invalid URL token Exception"""

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -24,6 +24,7 @@ from autopush.db import (
     Router,
     Message
 )
+from autopush.exceptions import InvalidTokenException
 from autopush.metrics import (
     DatadogMetrics,
     TwistedMetrics,
@@ -293,16 +294,16 @@ class AutopushSettings(object):
 
         if version == 'v0':
             if ':' not in token:
-                raise ValueError("Corrupted push token")
+                raise InvalidTokenException("Corrupted push token")
             return tuple(token.split(':'))
         if version == 'v1' and len(token) != 32:
-            raise ValueError("Corrupted push token")
+            raise InvalidTokenException("Corrupted push token")
         if version == 'v2':
             if len(token) != 64:
-                raise ValueError("Corrupted push token")
+                raise InvalidTokenException("Corrupted push token")
             if not public_key:
-                raise ValueError("Invalid key data")
+                raise InvalidTokenException("Invalid key data")
             if not constant_time.bytes_eq(sha256(public_key).digest(),
                                           token[32:]):
-                raise ValueError("Key mismatch")
+                raise InvalidTokenException("Key mismatch")
         return (token[:16].encode('hex'), token[16:32].encode('hex'))


### PR DESCRIPTION
Default the api_ver to v0 for the message endpoint. Previously a
value of None could pass in causing earlier endpoints to be incorrectly
parsed out. parse_endpoint now throws InvalidTokenExceptions to avoid
being caught on accident as a ValueError.

Closes #395 

@jrconlin r?