### PR TITLE
bug: Clear corrupted router records

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -539,7 +539,12 @@ class Router(object):
 
         """
         try:
-            return self.table.get_item(consistent=True, uaid=hasher(uaid))
+            item = self.table.get_item(consistent=True, uaid=hasher(uaid))
+            if item.keys() == ['uaid']:
+                # Incomplete record, drop it.
+                self.drop_user(uaid)
+                raise ItemNotFound("uaid not found")
+            return item
         except ProvisionedThroughputExceededException:
             # We unfortunately have to catch this here, as track_provisioned
             # will not see this, since JSONResponseError is a subclass and

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -448,6 +448,15 @@ class RouterTestCase(unittest.TestCase):
         eq_(bool(result), True)
         eq_(result["node_id"], "me")
 
+    def test_incomplete_uaid(self):
+        uaid = str(uuid.uuid4())
+        r = get_router_table()
+        router = Router(r, SinkMetrics())
+        router.register_user(dict(uaid=uaid))
+        self.assertRaises(ItemNotFound, router.get_uaid, uaid)
+        self.assertRaises(ItemNotFound, router.table.get_item,
+                          consistent=True, uaid=uaid)
+
     def test_save_new(self):
         r = get_router_table()
         router = Router(r, SinkMetrics())


### PR DESCRIPTION
Records containing only a UAID are corrupt. Drop these records and
return a 410 to the server.

Closes #400 

@bbangert r?