### PR TITLE
feat: validate v0 tokens more thoroughly

### DIFF
--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -1,5 +1,6 @@
 """Autopush Settings Object and Setup"""
 import datetime
+import re
 import socket
 
 from hashlib import sha256
@@ -38,6 +39,9 @@ from autopush.router import (
 )
 from autopush.utils import canonical_url, resolve_ip
 from autopush.senderids import SENDERID_EXPRY, DEFAULT_BUCKET
+
+
+VALID_V0_TOKEN = re.compile(r'[0-9A-Za-z-]{32,36}:[0-9A-Za-z-]{32,36}')
 
 
 class AutopushSettings(object):
@@ -293,7 +297,7 @@ class AutopushSettings(object):
         token = self.fernet.decrypt(token.encode('utf8'))
 
         if version == 'v0':
-            if ':' not in token:
+            if not VALID_V0_TOKEN.match(token):
                 raise InvalidTokenException("Corrupted push token")
             return tuple(token.split(':'))
         if version == 'v1' and len(token) != 32:

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -538,6 +538,17 @@ class EndpointTestCase(unittest.TestCase):
         self.endpoint.put(None, '')
         return self.finish_deferred
 
+    def test_put_v1_token_as_v0_token(self):
+        self.fernet_mock.decrypt.return_value = \
+            '\xcb\n<\x0c\xe6\xf3C4:\xa8\xaeO\xf5\xab\xfbb|'
+
+        def handle_finish(result):
+            self.status_mock.assert_called_with(400)
+        self.finish_deferred.addCallback(handle_finish)
+
+        self.endpoint.put(None, '')
+        return self.finish_deferred
+
     def test_put_token_invalid(self):
         self.fernet_mock.configure_mock(**{
             'decrypt.side_effect': InvalidToken})


### PR DESCRIPTION
Changes v0 token validation from simple check containing a : into
regex expecting valid uuid characters on either side of the : as
well.

Closes #406 

@jrconlin r?