### PR TITLE
bug: decode and process crypto-key header correctly

### DIFF
--- a/autopush/crypto_key.py
+++ b/autopush/crypto_key.py
@@ -1,0 +1,93 @@
+"""Crypto-Key header parser and manager"""
+
+
+class CryptoKeyException(Exception):
+    """Invalid CryptoKey"""
+
+
+class CryptoKey(object):
+    """Parse the Crypto-Key header per
+http://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00#section-4
+
+    The Crypto-Key header is a data store that has it's own set of rules,
+    This class manages access to the Crypto-Key data. There are two ways that
+    data in the Crypto-Key can be used, one by the key-id (an optional
+    identifier that can be used to associate key data to other fields) and
+    the data label name.
+
+    There are a few additional functions that may be implemented. For
+    instance, removing a Crypto-Key component that may not need to be
+    passed on.
+
+    """
+    _values = []
+
+    def __init__(self, header):
+        """Parse the Crypto-Key header
+
+        :param header: Header content string.
+
+        """
+        chunks = header.split(",")
+        if self._values:
+            self._values = []
+        for chunk in chunks:
+            bits = chunk.split(";")
+            hash = {}
+            for bit in bits:
+                try:
+                    (key, value) = bit.split("=", 1)
+                except ValueError:
+                    raise CryptoKeyException("Invalid Crypto Key value")
+                hash[key.strip()] = value.strip(' "')
+            self._values.append(hash)
+
+    def get_keyid(self, keyid):
+        """Return the Crypto-Key hash referred to by a given keyid.
+
+        For example, for a CryptoKey specified as:
+        Crypto-Key: keyid="apple";foo="fruit",keyid="gorp";bar="snake"
+
+        get_keyid("apple") would return a hash of
+        {"keyid": "apple", "foo":"fruit"}
+
+        :param keyid: The keyid to reference
+        :returns: hash of the matching key data or None
+
+        """
+        for val in self._values:
+            if keyid == val.get('keyid'):
+                return val
+        return None
+
+    def get_label(self, label):
+        """Return the Crypto-Key value referred to by a given label.
+
+        For example, for a CryptoKey specified as:
+        Crypto-Key: keyid="apple";foo="fruit",keyid="gorp";bar="snake"
+
+        get_label("foo")
+        would return a value of "apple"
+
+        ..note:: This presumes that "label" is unique. Otherwise it will
+        only return the FIRST instance of "label". Use get_keyid() if
+        you know of multiple sections containing similar labels.
+
+        :param label: The label to reference.
+        :returns: Value associated with the key data or None
+
+        """
+        for val in self._values:
+            if label in val:
+                return val.get(label)
+        return None
+
+    def to_string(self):
+        """Return a reformulated Crypto-Key header string"""
+        chunks = []
+        for val in self._values:
+            bits = []
+            for key in val:
+                bits.append("{}=\"{}\"".format(key, val[key]))
+            chunks.append(';'.join(bits))
+        return ','.join(chunks)

--- a/autopush/tests/test_cryptokey.py
+++ b/autopush/tests/test_cryptokey.py
@@ -1,0 +1,42 @@
+import unittest
+
+from nose.tools import (eq_, ok_)
+
+from autopush.crypto_key import CryptoKey
+
+
+class CryptoKeyTestCase(unittest.TestCase):
+
+    valid_key = (
+        'keyid="p256dh";dh="BDw9T0eImd4ax818VcYqDK_DOhcuDswKero'
+        'YyNkdhYmygoLSDlSiWpuoWYUSSFxi25cyyNTR5k9Ny93DzZc0UI4",'
+        'p256ecdsa="BF92zdI_AKcH5Q31_Rr-04bPqOHU_Qg6lAawHbvfQrY'
+        'xV_vIsAsHSyaiuyfofvxT8ZVIXccykd4V2Z7iJVfreT8"')
+
+    def test_parse(self):
+        ckey = CryptoKey(self.valid_key)
+        eq_(ckey.get_keyid("p256dh"),
+            {"keyid": "p256dh",
+             "dh": "BDw9T0eImd4ax818VcYqDK_DOhcuDswKero"
+                   "YyNkdhYmygoLSDlSiWpuoWYUSSFxi25cyyNTR5k9Ny93DzZc0UI4"})
+        eq_(ckey.get_label("p256ecdsa"),
+            "BF92zdI_AKcH5Q31_Rr-04bPqOHU_Qg6lAawHbvfQrY"
+            "xV_vIsAsHSyaiuyfofvxT8ZVIXccykd4V2Z7iJVfreT8")
+        ok_(ckey.get_keyid("missing") is None)
+        ok_(ckey.get_label("missing") is None)
+
+    def test_parse_lenient(self):
+        ckey = CryptoKey(self.valid_key.replace('"', ''))
+        str = ckey.to_string()
+        ckey2 = CryptoKey(str)
+        ok_(ckey.get_keyid("p256dh"), ckey2.get_keyid("p256dh"))
+        ok_(ckey.get_label("p256ecdsa") is not None)
+        ok_(ckey.get_label("p256ecdsa"), ckey2.get_label("p256ecdsa"))
+
+    def test_string(self):
+        ckey = CryptoKey(self.valid_key)
+        str = ckey.to_string()
+        ckey2 = CryptoKey(str)
+        ok_(ckey.get_keyid("p256dh"), ckey2.get_keyid("p256dh"))
+        ok_(ckey.get_label("p256ecdsa") is not None)
+        ok_(ckey.get_label("p256ecdsa"), ckey2.get_label("p256ecdsa"))

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -58,49 +58,6 @@ def generate_hash(key, payload):
     return h.hexdigest()
 
 
-def parse_header(header, major=";", minor="="):
-    """Convert a multi-component header line (e.g. "a;b=c;d=e;...") to
-    a list.
-
-    For example, if the header content line is
-
-    `"a;c=1;b;d=2+3=5"`
-
-    and presuming default values for major and minor, then the
-    response would be:
-
-    `['a', 'b', {'c': '1', 'd': '2+3=5'}]`
-
-    items defined with values will always appear as a dictionary at the
-    end of the list. If no items are assigned values, then no dictionary
-    is appended.
-
-    :param header: Header content line to parse.
-    :param major: Major item separator.
-    :param minor: Minor item separator.
-
-    """
-    vals = dict()
-    items = []
-    if not header:
-        return items
-    for v in map(lambda x: x.strip().split(minor, 1),
-                 header.split(major)):
-        try:
-            val = v[1]
-            # Trim quotes equally off of start and end
-            # because ""this is "quoted""" is a thing.
-            while val[0] == val[-1] == '"':
-                val = val[1:-1]
-            vals[v[0].lower()] = val
-        except IndexError:
-            if len(v[0]):
-                items.append(v[0].strip('"'))
-    if vals:
-        items.append(vals)
-    return items
-
-
 def fix_padding(string):
     """ Some JWT fields may strip the end padding from base64 strings """
     if len(string) % 4:


### PR DESCRIPTION
The Crypto-Key header has a different format than what was first
understood. A valid Crypto-Key header may look like `keyid="foo";
key1="data",key2="data"`. This patch specialized Crypto-Key parsing
to a class.

Closes #410

@bbangert r?

*Note*: I'd love to have a full integration test where we can check that the VAPID data was recorded correctly, as well as the data passed through. test_integration's TestWebpush.test_basic_delivery_with_vapid contains most of what would be required, but I don't know how to get the _client_info to check that the JWT content matches what we're expecting.