### PR TITLE
fix: fix dockerfile for automated builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@ html_coverage
 site-packages/*
 lib-python/*
 bin/*
+ddb
 include/*
 lib_pypy/*
 pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 python:
   - "pypy"
 install:
+  - wget https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2
+  - tar xjvf pypy-5.0.0-linux64.tar.bz2
+  - virtualenv -p pypy-5.0.0-linux64/bin/pypy pypy
+  - source pypy/bin/activate
   - make travis
 script: tox -- --with-coverage --cover-xml --cover-package=autopush
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,9 @@
 # VERSION    0.1
 
 # Extend base debian
-FROM stackbrew/debian:wheezy
+FROM stackbrew/debian:sid
 
 MAINTAINER Ben Bangert <bbangert@mozilla.com>
-
-# It's nice to have some newer packages
-RUN echo "deb http://ftp.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN mkdir -p /home/autopush
 ADD . /home/autopush/
@@ -17,12 +14,13 @@ WORKDIR /home/autopush
 
 RUN \
     apt-get update; \
-    apt-get install -y -qq make curl wget bzip2 libexpat1-dev gcc libssl-dev libffi-dev; \
+    apt-get install -y -qq make curl wget bzip2 libexpat1-dev gcc git-core libssl1.0.0 libssl-dev libffi-dev; \
     make clean; \
-    tar xjvf pypy-2.5.1-linux64.tar.bz2; \
-    mv pypy-2.5.1-linux64 pypy; \
+    wget https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2; \
+    tar xjvf pypy-5.0.0-linux64.tar.bz2; \
+    mv pypy-5.0.0-linux64 pypy; \
     make; \
-    apt-get remove -y -qq make curl wget bzip2 libexpat1-dev gcc libssl-dev libffi-dev; \
+    apt-get remove -y -qq make curl wget bzip2 libexpat1-dev gcc git-core libssl1.0.0 libssl-dev libffi-dev; \
     apt-get install -y -qq libexpat1 libssl1.0.0 libffi6; \
     apt-get autoremove -y -qq; \
     apt-get clean -y

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ SHELL := /bin/sh
 APPNAME = autopush
 DEPS =
 HERE = $(shell pwd)
-PTYPE=python
-BIN = $(HERE)/bin
+PTYPE=pypy
+BIN = $(HERE)/pypy/bin
 VIRTUALENV = virtualenv
 TESTS = $(APPNAME)/tests
 PYTHON = $(BIN)/$(PTYPE)
@@ -18,7 +18,7 @@ BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python\
 
 all:	build
 
-travis: $(HERE)/ddb
+travis: $(HERE)/ddb $(BIN)/tox
 	pip install coverage nose mock moto codecov tox
 
 $(HERE)/ddb:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ autobahn[twisted]==0.13.0
 boto==2.38.0
 cffi==1.1.2
 characteristic==14.3.0
-cryptography==0.9.1
+cryptography==1.2.3
 cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,7 +16,7 @@ autobahn[twisted]==0.13.0
 boto==2.38.0
 #cffi==1.1.2
 characteristic==14.3.0
-cryptography==0.9.1
+cryptography==1.2.3
 cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0


### PR DESCRIPTION
Dockerfile and Makefile were both broken. This fixes the Dockerfile
and uses the latest PyPy 5.0 for building the container.

Closes #414 

@jrconlin r?