### PR TITLE
feat: update logging for newstyle twisted and file output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 sudo: false
 python:
-  - "pypy"
+  - "2.7"
 install:
-  - wget https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2
-  - tar xjvf pypy-5.0.0-linux64.tar.bz2
-  - virtualenv -p pypy-5.0.0-linux64/bin/pypy pypy
+  - virtualenv pypy
+  - cd pypy/bin && ln -s python pypy && cd ../..
   - source pypy/bin/activate
   - make travis
 script: tox -- --with-coverage --cover-xml --cover-package=autopush

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 import datetime
-import logging
 import random
 import time
 import uuid
@@ -20,9 +19,6 @@ from boto.dynamodb2.table import Table
 from boto.dynamodb2.types import NUMBER
 
 from autopush.utils import generate_hash
-
-
-log = logging.getLogger(__file__)
 
 key_hash = ""
 TRACK_DB_CALLS = False
@@ -53,8 +49,6 @@ def hasher(uaid):
 
 
 def normalize_id(id):
-    if not id:
-        return id
     if (len(id) == 36 and
             id[8] == id[13] == id[18] == id[23] == '-'):
         return id.lower()
@@ -434,7 +428,6 @@ class Message(object):
             else:
                 expr += " REMOVE #dd, headers"
             expr_values = self.encode({":%s" % k: v for k, v in item.items()})
-            log.debug(expr_values)
             conn.update_item(
                 self.table.table_name,
                 db_key,

--- a/autopush/health.py
+++ b/autopush/health.py
@@ -6,7 +6,7 @@ from boto.dynamodb2.exceptions import (
 )
 from twisted.internet.defer import DeferredList
 from twisted.internet.threads import deferToThread
-from twisted.python import log
+from twisted.logger import Logger
 
 from autopush import __version__
 
@@ -18,6 +18,8 @@ class MissingTableException(Exception):
 
 class HealthHandler(cyclone.web.RequestHandler):
     """HTTP Health Handler"""
+    log = Logger()
+
     @cyclone.web.asynchronous
     def get(self):
         """HTTP Get
@@ -54,7 +56,7 @@ class HealthHandler(cyclone.web.RequestHandler):
     def _check_error(self, failure, name):
         """Returns an error, and why"""
         self._healthy = False
-        log.err(failure, name)
+        self.log.failure(failure, name)
 
         cause = self._health_checks[name] = {"status": "NOT OK"}
         if failure.check(InternalServerError):

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -4,7 +4,7 @@ from boto.dynamodb2.exceptions import (
     InternalServerError,
 )
 from cyclone.web import Application
-from mock import (Mock, patch)
+from mock import Mock
 from moto import mock_dynamodb2
 from twisted.internet.defer import Deferred
 from twisted.trial import unittest
@@ -20,10 +20,10 @@ from autopush.settings import AutopushSettings
 
 class HealthTestCase(unittest.TestCase):
     def setUp(self):
+        from twisted.logger import Logger
         self.timeout = 0.5
         twisted.internet.base.DelayedCall.debug = True
 
-        self.log_mock = patch("autopush.health.log").start()
         self.mock_dynamodb2 = mock_dynamodb2()
         self.mock_dynamodb2.start()
 
@@ -36,6 +36,7 @@ class HealthTestCase(unittest.TestCase):
 
         self.request_mock = Mock()
         self.health = HealthHandler(Application(), self.request_mock)
+        self.health.log = self.log_mock = Mock(spec=Logger)
         self.status_mock = self.health.set_status = Mock()
         self.write_mock = self.health.write = Mock()
 
@@ -44,7 +45,6 @@ class HealthTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.mock_dynamodb2.stop()
-        self.log_mock.stop()
 
     def test_healthy(self):
         return self._assert_reply({

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -290,7 +290,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
     def disconnect(self):
         self.ws.close()
 
-    def sleep(self, duration):
+    def sleep(self, duration):  # pragma: nocover
         time.sleep(duration)
 
     def wait_for(self, func):

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -7,9 +7,12 @@ from mock import Mock, patch
 from nose.tools import eq_, ok_
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred
-from twisted.python import log, failure
+from twisted.logger import Logger
+from twisted.python import failure
 
-from autopush.logging import setup_logging
+from autopush.logging import PushLogger
+
+log = Logger()
 
 
 class SentryLogTestCase(twisted.trial.unittest.TestCase):
@@ -25,10 +28,10 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
 
     def test_sentry_logging(self):
         os.environ["SENTRY_DSN"] = "some_locale"
-        setup_logging("Autopush")
+        PushLogger.setup_logging("Autopush", sentry_dsn=True)
         eq_(len(self.mock_raven.mock_calls), 2)
 
-        log.err(failure.Failure(Exception("eek")))
+        log.failure("error", failure.Failure(Exception("eek")))
         self.flushLoggedErrors()
         d = Deferred()
 
@@ -43,21 +46,38 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
         return d
 
 
-class EliotLogTestCase(twisted.trial.unittest.TestCase):
+class PushLoggerTestCase(twisted.trial.unittest.TestCase):
     def test_custom_type(self):
-        setup_logging("Autopush")
-        with patch("sys.stdout") as mock_stdout:
-            log.msg("omg!", Type=7)
-            eq_(len(mock_stdout.mock_calls), 1)
-            kwargs = mock_stdout.mock_calls[0][1][0]
+        obj = PushLogger.setup_logging("Autopush")
+        obj._output = mock_stdout = Mock()
+        log.info("omg!", Type=7)
+        eq_(len(mock_stdout.mock_calls), 2)
+        kwargs = mock_stdout.mock_calls[0][1][0]
         ok_("Type" in kwargs)
 
     def test_human_logs(self):
-        setup_logging("Autopush", True)
-        with patch("sys.stdout") as mock_stdout:
-            mock_stdout.reset_mock()
-            log.msg("omg!", Type=7)
-            eq_(len(mock_stdout.mock_calls), 4)
-            mock_stdout.reset_mock()
-            log.err("wtf!", Type=7)
-            eq_(len(mock_stdout.mock_calls), 4)
+        obj = PushLogger.setup_logging("Autopush", log_format="text")
+        obj._output = mock_stdout = Mock()
+        log.info("omg!", Type=7)
+        eq_(len(mock_stdout.mock_calls), 2)
+        mock_stdout.reset_mock()
+        log.error("wtf!", Type=7)
+        eq_(len(mock_stdout.mock_calls), 2)
+
+    def test_start_stop(self):
+        obj = PushLogger.setup_logging("Autopush")
+        obj.start()
+        obj.stop()
+
+    def test_file_output(self):
+        try:
+            os.unlink("testfile.txt")
+        except:  # pragma: nocover
+            pass
+        obj = PushLogger.setup_logging("Autoput", log_output="testfile.txt")
+        obj.start()
+        log.info("wow")
+        obj.stop()
+        with open("testfile.txt") as f:
+            lines = f.readlines()
+        eq_(len(lines), 1)

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -8,7 +8,8 @@ import uuid
 import ecdsa
 from jose import jws
 
-from twisted.python import failure, log
+from twisted.logger import Logger
+from twisted.python import failure
 
 
 default_ports = {
@@ -102,7 +103,8 @@ def extract_jwt(token, crypto_key):
     return jws.verify(token, vk, algorithms=["ES256"])
 
 
-class ErrorLogger (object):
+class ErrorLogger(object):
+    log = Logger()
 
     def write_error(self, code, **kwargs):
         """Write the error (otherwise unhandled exception when dealing with
@@ -113,8 +115,9 @@ class ErrorLogger (object):
         """
         self.set_status(code)
         if "exc_info" in kwargs:
-            log.err(failure.Failure(*kwargs["exc_info"]),
-                    **self._client_info)
+            self.log.failure(failure.Failure(*kwargs["exc_info"]),
+                             **self._client_info)
         else:
-            log.err("Error in handler: %s" % code, **self._client_info)
+            self.log.failure("Error in handler: %s" % code,
+                             **self._client_info)
         self.finish()

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -17,7 +17,6 @@ cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0
 ecdsa==0.13
-eliot==0.7.1
 enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0
 ecdsa==0.13
-eliot==0.11.0
 enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -21,7 +21,6 @@ cyclone==1.1
 datadog==0.5.0
 decorator==4.0.0
 ecdsa==0.13
-eliot==0.11.0
 enum34==1.0.4
 funcsigs==0.4
 gcm-client==0.1.4


### PR DESCRIPTION
Updates all logging calls to use the newer logging utilities in
twisted. This obsoletes the use of eliot, as twisteds logger can
handle arbitrary keywords. The logging handling has been revamped
into a more easily testable class that implements twisteds IObserver
for easy logger observing.

log_level support has been re-added so that calls can be appropriately
scoped by logging type. Existing info/msg log calls now use appropriate
log levels, with delayed function calls to prevent unnecessary overhead
when formatting objects if the log message is ignored.

Closes #419 

@jrconlin r?