### PR TITLE
bug: enforce fail.value.message to string

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -306,8 +306,9 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
         message = fail.value.message or repr(fail.value)
         if isinstance(fail.value, AssertionError):
             message = "A decryption error occurred"
-        self.log.debug("Invalid bearer token: " + message, **self._client_info)
-        raise VapidAuthException("Invalid bearer token: " + message)
+        self.log.debug("Invalid bearer token: " + repr(message),
+                       **self._client_info)
+        raise VapidAuthException("Invalid bearer token: " + repr(message))
 
     def _process_auth(self, result):
         """Process the optional VAPID auth token.

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1212,8 +1212,17 @@ class EndpointTestCase(unittest.TestCase):
         self.status_mock.assert_called_with(500)
 
     def test_padding(self):
+        # Some values can't be padded and still decode.
+        eq_(utils.fix_padding("a"), "a===")
+        self.assertRaises(TypeError,
+                          base64.urlsafe_b64decode,
+                          utils.fix_padding("a"))
         eq_(utils.fix_padding("ab"), "ab==")
+        base64.urlsafe_b64decode(utils.fix_padding("ab"))
+        eq_(utils.fix_padding("abc"), "abc=")
+        base64.urlsafe_b64decode(utils.fix_padding("abc"))
         eq_(utils.fix_padding("abcd"), "abcd")
+        base64.urlsafe_b64decode(utils.fix_padding("abcd"))
 
     def test_parse_endpoint(self):
         v0_valid = dummy_uaid + ":" + dummy_chid


### PR DESCRIPTION
Two things: 
1) fail.value.message can sometimes return a class, which will cause the logging to break.
2) Be a lot more rigorous about padding tests. There are some values that all the padding in the world will fail to decode, but we should be certain that only those actually fail.

@bbangert r?