### PR TITLE
fix: update cffi dep and ensure test reqs matches reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ argparse==1.2.1
 autobahn[twisted]==0.13.0
 boto==2.38.0
 boto3==1.3.0
-cffi==1.1.2
+cffi==1.5.2
 characteristic==14.3.0
 cryptography==1.2.3
 cyclone==1.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,7 +15,7 @@ argparse==1.2.1
 autobahn[twisted]==0.13.0
 boto==2.38.0
 boto3==1.3.0
-#cffi==1.1.2
+cffi==1.5.2
 characteristic==14.3.0
 cryptography==1.2.3
 cyclone==1.1


### PR DESCRIPTION
A cffi dependency pinning was missed because test-requirements was
not matching requirements.txt. This caused build issues for ops.