### PR TITLE
bug: flatten JWT for logging.

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -296,8 +296,10 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
     def _store_auth(self, jwt, crypto_key, token, result):
         if jwt.get('exp', 0) < time.time():
             raise VapidAuthException("Invalid bearer token: Auth expired")
-        jwt['crypto_key'] = crypto_key
-        self._client_info['jwt'] = jwt
+        # flatten the jwt into the _client_info record
+        self._client_info["jwt_crypto_key"] = crypto_key
+        for i in jwt:
+            self._client_info["jwt_" + i] = jwt[i]
         return result
 
     def _invalid_auth(self, fail):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -806,7 +806,9 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result, crypto_key, token):
             self.endpoint.set_status.assert_called_with(201)
             payload.update({'crypto_key': crypto_key})
-            eq_(self.endpoint._client_info.get('jwt'), payload)
+            for i in payload:
+                n = 'jwt_' + i
+                eq_(self.endpoint._client_info.get(n), payload[i])
             self.assertTrue(result)
 
         self.finish_deferred.addCallback(handle_finish, crypto_key, token)


### PR DESCRIPTION
Logging does not handle object exports well. Flattening JWT by prefixing
"jwt_" to the names of values to prevent potential conflicts

@bbangert r?.