### PR TITLE
refactor: Remove duplicate validation logic in the GCM and APNs routers

### DIFF
--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -65,12 +65,24 @@ class APNSRouter(object):
     def _route(self, notification, router_data):
         """Blocking APNS call to route the notification"""
         token = router_data["token"]
+        custom = {
+          "Chid": notification.channel_id,
+          "Ver": notification.version,
+        }
+        if notification.data:
+            custom["Msg"] = notification.data
+            custom["Con"] = notification.headers["content-encoding"]
+            custom["Enc"] = notification.headers["encryption"]
+
+            if "crypto-key" in notification.headers:
+                custom["Cryptokey"] = notification.headers["crypto-key"]
+            elif "encryption-key" in notification.headers:
+                custom["Enckey"] = notification.headers["encryption-key"]
+
         payload = apns.Payload(alert=router_data.get("title",
                                                      self.default_title),
                                content_available=1,
-                               custom={"Msg": notification.data,
-                                       "Chid": notification.channel_id,
-                                       "Ver": notification.version})
+                               custom=custom)
         now = int(time.time())
         self.messages[now] = {"token": token, "payload": payload}
         # TODO: Add listener for error handling.

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -392,27 +392,6 @@ class EndpointTestCase(unittest.TestCase):
         self.finish_deferred.addCallback(handle_finish)
         return self.finish_deferred
 
-    def test_other_payload_encoding(self):
-        fresult = dict(router_type="test")
-        frouter = Mock(spec=Router)
-        frouter.route_notification = Mock()
-        frouter.route_notification.return_value = RouterResponse()
-        self.endpoint.chid = dummy_chid
-        self.endpoint.ap_settings.routers["test"] = frouter
-
-        self.request_mock.body = b"stuff"
-        self.endpoint._uaid_lookup_results(fresult)
-
-        def handle_finish(value):
-            calls = frouter.route_notification.mock_calls
-            eq_(len(calls), 1)
-            (_, (notification, _), _) = calls[0]
-            eq_(notification.channel_id, dummy_chid)
-            eq_(notification.data, b"stuff")
-
-        self.finish_deferred.addCallback(handle_finish)
-        return self.finish_deferred
-
     def test_init_info(self):
         d = self.endpoint._init_info()
         eq_(d["request_id"], dummy_request_id)


### PR DESCRIPTION
I cleaned this up a bit, since we already validate the headers and encode the payload in `EndpointHandler`. While I was here, I also updated the APNs router to forward the crypto headers (even though we don't have any active consumers at the moment).

@jrconlin r?