### PR TITLE
fix: Canonicalize Base64 URL-encoded values per RFC 7515

### DIFF
--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -94,7 +94,7 @@ class APNSRouterTestCase(unittest.TestCase):
         self.headers = {"content-encoding": "aesgcm",
                         "encryption": "test",
                         "encryption-key": "test"}
-        self.notif = Notification(10, "q60d6g==", dummy_chid, self.headers,
+        self.notif = Notification(10, "q60d6g", dummy_chid, self.headers,
                                   200)
         self.router_data = dict(router_data=dict(token="connect_data"))
 
@@ -176,7 +176,7 @@ class APNSRouterTestCase(unittest.TestCase):
         headers = {"content-encoding": "aesgcm",
                    "encryption": "test",
                    "crypto-key": "test"}
-        self.notif = Notification(10, "q60d6g==", dummy_chid, headers, 200)
+        self.notif = Notification(10, "q60d6g", dummy_chid, headers, 200)
         now = int(time.time())
         self.router.messages = {now: {'token': 'dump', 'payload': {}},
                                 now-60: {'token': 'dump', 'payload': {}}}
@@ -222,7 +222,7 @@ class GCMRouterTestCase(unittest.TestCase):
                         "encryption": "test",
                         "encryption-key": "test"}
         # Payloads are Base64-encoded.
-        self.notif = Notification(10, "q60d6g==", dummy_chid, self.headers,
+        self.notif = Notification(10, "q60d6g", dummy_chid, self.headers,
                                   200)
         self.router_data = dict(
             router_data=dict(
@@ -284,7 +284,7 @@ class GCMRouterTestCase(unittest.TestCase):
             assert(self.router.gcm.send.called)
             # Make sure the data was encoded as base64
             data = self.router.gcm.send.call_args[0][0].data
-            eq_(data['body'], 'q60d6g==')
+            eq_(data['body'], 'q60d6g')
             eq_(data['enc'], 'test')
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')
@@ -294,7 +294,7 @@ class GCMRouterTestCase(unittest.TestCase):
     def test_ttl_none(self):
         self.router.gcm = self.gcm
         self.notif = Notification(version=10,
-                                  data="q60d6g==",
+                                  data="q60d6g",
                                   channel_id=dummy_chid,
                                   headers=self.headers,
                                   ttl=None)
@@ -306,7 +306,7 @@ class GCMRouterTestCase(unittest.TestCase):
             # Make sure the data was encoded as base64
             data = self.router.gcm.send.call_args[0][0].data
             options = self.router.gcm.send.call_args[0][0].options
-            eq_(data['body'], 'q60d6g==')
+            eq_(data['body'], 'q60d6g')
             eq_(data['enc'], 'test')
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -32,6 +32,7 @@ from autopush.websocket import (
     WebSocketServerProtocol,
     ms_time,
 )
+from autopush.utils import base64url_encode
 
 from .test_router import MockAssist
 
@@ -960,7 +961,7 @@ class WebsocketTestCase(unittest.TestCase):
 
         res = self.proto.process_register(
             dict(channelID=chid,
-                 key=test_key))
+                 key=base64url_encode(test_key)))
         res.addCallback(check_register_result, test_endpoint)
         return d
 


### PR DESCRIPTION
For restricted subscriptions with an app server key, we include the SHA-256 hash of the *encoded* form in the endpoint URL. This can be a problem if one side uses padded input, and the other uses unpadded. Another complication is, while RFC 7515 forbids padding, Python's Base64 decoder requires it. As we discussed on IRC a few days ago, keeping track of these different forms is error-prone.

This PR adds two helper functions to encode and decode unpadded Base64. It also normalizes VAPID keys to the unpadded form, regardless of whether the sender included padding.

Finally, I noticed `self.assertRaises` can silence failures, so I switched to using Nose's `assert_raises` instead.

@bbangert r?