### PR TITLE
bug: Use static UAIDs for preflight, clean up after.

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -161,14 +161,14 @@ def get_storage_table(tablename="storage", read_throughput=5,
                        write_throughput)
 
 
-def preflight_check(storage, router):
+def preflight_check(storage, router, uaid="deadbeef00000000deadbeef00000000"):
     """Performs a pre-flight check of the storage/router/message to ensure
     appropriate permissions for operation.
 
     Failure to run correctly will raise an exception.
 
     """
-    uaid = uuid.uuid4().hex
+    # Use a distinct UAID so it doesn't interfere with metrics
     chid = uuid.uuid4().hex
     node_id = "mynode:2020"
     connected_at = 0
@@ -186,7 +186,11 @@ def preflight_check(storage, router):
                               router_type="simplepush"))
     item = router.get_uaid(uaid)
     assert item.get("node_id") == node_id
+    # Clean up the preflight data.
     router.clear_node(item)
+    router.drop_user(uaid)
+    storage.table.delete_item(uaid=uaid, chid=chid)
+    storage.table.delete_item(uaid=uaid, chid=" ")
 
 
 def track_provisioned(func):

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -370,6 +370,8 @@ def connection_main(sysargs=None, use_files=True):
         sentry_dsn=sentry_dsn,
         firehose_delivery_stream=args.firehose_stream_name
     )
+    # Add some entropy to prevent potential conflicts.
+    postfix = os.urandom(4).encode('hex').ljust(8, '0')
     settings = make_settings(
         args,
         port=args.port,
@@ -381,6 +383,7 @@ def connection_main(sysargs=None, use_files=True):
         router_port=args.router_port,
         env=args.env,
         hello_timeout=args.hello_timeout,
+        preflight_uaid="deadbeef000000000deadbeef" + postfix,
     )
 
     r = RouterHandler
@@ -480,6 +483,8 @@ def endpoint_main(sysargs=None, use_files=True):
         firehose_delivery_stream=args.firehose_stream_name
     )
 
+    # Add some entropy to prevent potential conflicts.
+    postfix = os.urandom(4).encode('hex').ljust(8, '0')
     settings = make_settings(
         args,
         endpoint_scheme=args.endpoint_scheme,
@@ -490,6 +495,7 @@ def endpoint_main(sysargs=None, use_files=True):
         senderid_expry=args.senderid_expry,
         senderid_list=senderid_list,
         bear_hash_key=args.auth_key,
+        preflight_uaid="deadbeef000000000deadbeef" + postfix,
     )
 
     # Endpoint HTTP router

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -85,6 +85,7 @@ class AutopushSettings(object):
                  senderid_list={},
                  hello_timeout=0,
                  bear_hash_key=None,
+                 preflight_uaid="deadbeef00000000deadbeef000000000",
                  ):
         """Initialize the Settings object
 
@@ -172,7 +173,7 @@ class AutopushSettings(object):
         self.create_initial_message_tables()
 
         # Run preflight check
-        preflight_check(self.storage, self.router)
+        preflight_check(self.storage, self.router, preflight_uaid)
 
         # CORS
         self.cors = enable_cors


### PR DESCRIPTION
Preflight would create new accounts which could throw off metrics.
This patch solves this in two ways; It uses static UAIDs matching
"deadbeef00000000deadbeef\d{8}" and deletes the created data once
the preflight is done.

Closes #434 

@bbangert r?