### PR TITLE
bug: Normalize padding handling for restricted subscriptions

### DIFF
--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -1301,7 +1301,6 @@ class TestWebPush(IntegrationBase):
         yield client.connect()
         yield client.hello()
         yield client.register(chid=chid, key=pk_hex)
-        # check that the client actually registered the key.
 
         # Send an update with a properly formatted key.
         yield client.send_notification(vapid=vapid)

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -64,6 +64,14 @@ def base64url_encode(string):
     return base64.urlsafe_b64encode(string).strip('=')
 
 
+def repad(string):
+    """Adds padding to strings for base64 decoding"""
+
+    if len(string) % 4:
+        string = string + '===='[len(string) % 4:]
+    return string
+
+
 def base64url_decode(string):
     """Decodes a Base64 URL-encoded string per RFC 7515.
 
@@ -71,9 +79,7 @@ def base64url_decode(string):
     encoded strings, but Python's ``urlsafe_b64decode`` only accepts padded
     strings.
     """
-    if len(string) % 4:
-        string = string + '===='[len(string) % 4:]
-    return base64.urlsafe_b64decode(string)
+    return base64.urlsafe_b64decode(repad(string))
 
 
 def decipher_public_key(key_data):


### PR DESCRIPTION
Since fernet passes it's content through base64 handling, it's just as
picky about padding as other base64 instances. For now, strip padding
from outbound endpoints and reapply it (if needed) to inbound endpoints.

Closes #466 

@bbangert r?