### PR TITLE
feat: use gnureadline instead of readline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pyflakes==0.8.1
 Pympler==0.4.2
 python-jose==0.5.6
 raven==5.10.2
-readline==6.2.4.1
+gnureadline==6.3.3
 repoze.lru==0.6
 requests==2.7.0
 service-identity==14.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -42,7 +42,7 @@ pyflakes==0.8.1
 Pympler==0.4.2
 python-jose==0.5.6
 raven==5.3.1
-readline==6.2.4.1
+gnureadline==6.3.3
 repoze.lru==0.6
 requests==2.7.0
 service-identity==14.0.0


### PR DESCRIPTION
gnureadline is still maintained while readline has fallen behind and
has compile errors on some platforms.

@jrconlin r?