### PR TITLE
feat: Log naks from bridged connections via REST API

### DIFF
--- a/autopush/main.py
+++ b/autopush/main.py
@@ -15,6 +15,7 @@ from autopush.endpoint import (
     EndpointHandler,
     MessageHandler,
     RegistrationHandler,
+    BridgeMessageHandler,
 )
 from autopush.health import (HealthHandler, StatusHandler)
 from autopush.logging import PushLogger
@@ -201,7 +202,7 @@ def _parse_connection(sysargs, use_files=True):
             '.autopush_connection.ini'
         ]
     else:
-        config_files = []  # pragma: nocover
+        config_files = shared_config_files = []  # pragma: nocover
     parser = configargparse.ArgumentParser(
         description='Runs a Connection Node.',
         default_config_files=shared_config_files + config_files)
@@ -508,6 +509,9 @@ def endpoint_main(sysargs=None, use_files=True):
         (r"/v1/([^\/]+)/([^\/]+)/registration(?:/([^\/]+))"
             "?(?:/subscription)?(?:/([^\/]+))?",
          RegistrationHandler,
+         dict(ap_settings=settings)),
+        (r"/v1/naks/([^\/]+)",
+         BridgeMessageHandler,
          dict(ap_settings=settings)),
     ],
         default_host=settings.hostname, debug=args.debug,

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -75,6 +75,7 @@ class GCMRouter(object):
             data['body'] = notification.data
             data['con'] = notification.headers['content-encoding']
             data['enc'] = notification.headers['encryption']
+            data['id'] = notification.version
 
             if 'crypto-key' in notification.headers:
                 data['cryptokey'] = notification.headers['crypto-key']

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -235,10 +235,14 @@ class EndpointMainTestCase(unittest.TestCase):
             "--s3_bucket=none",
         ])
 
-    def test_bad_senderidlist(self):
+    @patch('autopush.main._parse_endpoint')
+    def test_bad_senderidlist(self, parse):
+        ff = Mock()
+        ff.senderid_list = "[Invalid"
+        parse.return_value = (ff, Mock())
         endpoint_main([
             "--senderid_list='[Invalid'"
-        ])
+        ], False)
 
     def test_ping_settings(self):
         ap = make_settings(self.test_arg)

--- a/docs/api/endpoint.rst
+++ b/docs/api/endpoint.rst
@@ -26,6 +26,11 @@ HTTP Endpoints
     :private-members:
     :member-order: bysource
 
+.. autoclass:: BridgeMessageHandler
+    :members:
+    :private-members:
+    :member-order: bysource
+
 .. autoclass:: MessageHandler
     :members:
     :private-members:


### PR DESCRIPTION
Bridged devices do not use the websocket connection, so NAKs can be
lost. Our system generally ACKs messages when they're handed off to the
bridge system, but clients can 'retro-actively' NAK a packet.

Since connections should be limited to the minimum possible, and NAKs
are (hopefully) more rare and meaningful than ACKs, only need to log
NAKs.

Also fix up missing coverage for bad senderid JSON.

Closes #469

@bbangert r?