### PR TITLE
feat: refactor webpush endpoint for validation schemas

### DIFF
--- a/autopush/exceptions.py
+++ b/autopush/exceptions.py
@@ -12,7 +12,8 @@ class InvalidTokenException(Exception):
 class InvalidRequest(AutopushException):
     """Invalid request exception, may include custom status_code and message
     to write for the error"""
-    def __init__(self, message, status_code=400, errno=None):
+    def __init__(self, message, status_code=400, errno=None, headers={}):
         super(AutopushException, self).__init__(message)
         self.status_code = status_code
         self.errno = errno
+        self.headers = headers

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -307,7 +307,7 @@ class AutopushSettings(object):
         :returns: Push endpoint
 
         """
-        root = self.endpoint_url + '/push/'
+        root = self.endpoint_url + '/wpush/'
         base = (uaid.replace('-', '').decode("hex") +
                 chid.replace('-', '').decode("hex"))
 

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -325,6 +325,7 @@ class IntegrationBase(unittest.TestCase):
             StatusResource,
         )
         from autopush.web.simplepush import SimplePushHandler
+        from autopush.web.webpush import WebPushHandler
         from twisted.web.server import Site
 
         router_table = os.environ.get("ROUTER_TABLE", "router_int_test")
@@ -378,6 +379,9 @@ class IntegrationBase(unittest.TestCase):
             (r"/spush/(?:(?P<api_ver>v\d+)\/)?(?P<token>[^\/]+)",
              SimplePushHandler, dict(ap_settings=settings)),
             (r"/m/([^\/]+)", MessageHandler, dict(ap_settings=settings)),
+            (r"/wpush/(?:(?P<api_ver>v\d+)\/)?(?P<token>[^\/]+)",
+             WebPushHandler, dict(ap_settings=settings)),
+
             # PUT /register/ => connect info
             # GET /register/uaid => chid + endpoint
             (r"/register(?:/(.+))?", RegistrationHandler,

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -916,7 +916,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.ap_settings.message.register_channel = Mock()
         test_key = "SomeRandomCryptoKeyString"
         test_sha = sha256(test_key).hexdigest()
-        test_endpoint = ('http://localhost/push/v2/' +
+        test_endpoint = ('http://localhost/wpush/v2/' +
                          self.proto.ps.uaid.replace('-', '') +
                          chid.replace('-', '') +
                          test_sha)

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -165,7 +165,7 @@ class BaseHandler(cyclone.web.RequestHandler):
         self.log.info(format="Request validation error",
                       status_code=exc.status_code,
                       errno=exc.errno)
-        self._write_response(exc.status_code, exc.errno)
+        self._write_response(exc.status_code, exc.errno, headers=exc.headers)
 
     def _response_err(self, fail):
         """errBack for all exceptions that should be logged

--- a/autopush/web/simplepush.py
+++ b/autopush/web/simplepush.py
@@ -15,7 +15,7 @@ from autopush.web.validation import (
 class SimplePushHandler(BaseHandler):
     cors_methods = "PUT"
 
-    @threaded_validate(SimplePushRequestSchema())
+    @threaded_validate(SimplePushRequestSchema)
     def put(self, api_ver="v1", token=None):
         sub = self.valid_input["subscription"]
         user_data = sub["user_data"]

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -1,4 +1,5 @@
 """Validation handler and Schemas"""
+import re
 import time
 import urlparse
 from functools import wraps
@@ -10,6 +11,7 @@ from marshmallow import (
     Schema,
     fields,
     pre_load,
+    post_load,
     validates,
     validates_schema,
 )
@@ -20,6 +22,13 @@ from autopush.exceptions import (
     InvalidRequest,
     InvalidTokenException,
 )
+from autopush.utils import (
+    base64url_encode,
+    extract_jwt,
+)
+
+MAX_TTL = 60 * 60 * 24 * 60
+AUTH_SCHEME = "bearer"
 
 
 class ThreadedValidate(object):
@@ -43,9 +52,10 @@ class ThreadedValidate(object):
             "path_kwargs": request_handler.path_kwargs,
             "arguments": request_handler.request.arguments,
         }
-        self.schema.context["settings"] = request_handler.ap_settings
-        self.schema.context["log"] = self.log
-        return self.schema.load(data)
+        schema = self.schema()
+        schema.context["settings"] = request_handler.ap_settings
+        schema.context["log"] = self.log
+        return schema.load(data)
 
     def _call_func(self, result, func, request_handler, *args, **kwargs):
         output, errors = result
@@ -61,11 +71,11 @@ class ThreadedValidate(object):
             request_handler._auto_finish = False
 
             d = deferToThread(self._validate_request, request_handler)
+            d.addCallback(self._call_func, func, request_handler, *args,
+                          **kwargs)
             d.addErrback(request_handler._overload_err)
             d.addErrback(request_handler._validation_err)
             d.addErrback(request_handler._response_err)
-            d.addCallback(self._call_func, func, request_handler, *args,
-                          **kwargs)
         return wrapper
 
     @classmethod
@@ -92,6 +102,11 @@ class ThreadedValidate(object):
 
 # Alias to the validation classmethod decorator
 threaded_validate = ThreadedValidate.validate
+
+
+# Remove trailing padding characters from complex header items like
+# Crypto-Key and Encryption
+strip_padding = re.compile('=+(?=[,;]|$)')
 
 
 class SimplePushSubscriptionSchema(Schema):
@@ -163,4 +178,151 @@ class SimplePushRequestSchema(Schema):
             d["version"] = version
         if data:
             d["data"] = data
+        return d
+
+
+class WebPushSubscriptionSchema(Schema):
+    uaid = fields.UUID(required=True)
+    chid = fields.UUID(required=True)
+    public_key = fields.Raw(missing=None)
+
+    @pre_load
+    def extract_subscription(self, d):
+        try:
+            result = self.context["settings"].parse_endpoint(
+                token=d["token"],
+                version=d["api_ver"],
+                ckey_header=d["ckey_header"],
+            )
+        except InvalidTokenException:
+            raise InvalidRequest("invalid token", errno=102)
+        return result
+
+    @validates_schema
+    def validate_uaid(self, d):
+        try:
+            result = self.context["settings"].router.get_uaid(d["uaid"].hex)
+        except ItemNotFound:
+            raise InvalidRequest("UAID not found", status_code=410, errno=103)
+
+        if result.get("router_type") not in ["webpush", "gcm", "apns"]:
+            raise InvalidRequest("Wrong URL for user", errno=108)
+
+        # Propagate the looked up user data back out
+        d["user_data"] = result
+
+
+class WebPushHeaderSchema(Schema):
+    authorization = fields.String()
+    crypto_key = fields.String(load_from="crypto-key")
+    content_encoding = fields.String(load_from="content-encoding")
+    encryption = fields.String()
+    encryption_key = fields.String(load_from="encryption-key")
+    ttl = fields.Integer(required=False, missing=None)
+
+    @validates_schema
+    def validate_cypto_headers(self, d):
+        # Not allowed to use aesgcm128 + a crypto_key
+        if (d.get("content_encoding", "").lower() == "aesgcm128" and
+                d.get("crypto_key")):
+            wpe_url = ("https://developers.google.com/web/updates/2016/03/"
+                       "web-push-encryption")
+            raise InvalidRequest(
+                message="You're using outdated encryption; "
+                "Please update to the format described in " + wpe_url,
+                errno=110,
+            )
+
+        # These both can't be present
+        if "encryption_key" in d and "crypto_key" in d:
+            raise InvalidRequest("Invalid crypto headers", errno=110)
+
+        # Cap TTL
+        if 'ttl' in d:
+            d["ttl"] = min(d["ttl"], MAX_TTL)
+
+    @post_load
+    def fixup_headers(self, d):
+        return {k.replace("_", "-"): v for k, v in d.items()}
+
+
+class WebPushRequestSchema(Schema):
+    subscription = fields.Nested(WebPushSubscriptionSchema,
+                                 load_from="token_info")
+    headers = fields.Nested(WebPushHeaderSchema)
+    body = fields.Raw()
+
+    @validates('body')
+    def validate_data(self, value):
+        max_data = self.context["settings"].max_data
+        if value and len(value) > max_data:
+            raise InvalidRequest(
+                "Data payload must be smaller than {}".format(max_data),
+                errno=104,
+            )
+
+    @validates_schema
+    def ensure_encoding_with_data(self, d):
+        # This runs before nested schemas, so we use the - separated
+        # field name
+        req_fields = ["content-encoding", "encryption"]
+        if d["body"] and not all([x in d["headers"] for x in req_fields]):
+            raise InvalidRequest("Client error", errno=110)
+
+    @pre_load
+    def token_prep(self, d):
+        d["token_info"] = dict(
+            api_ver=d["path_kwargs"].get("api_ver"),
+            token=d["path_kwargs"].get("token"),
+            ckey_header=d["headers"].get("crypto-key", ""),
+        )
+        return d
+
+    def validate_auth(self, d):
+        auth = d["headers"].get("authorization")
+        if not auth:
+            return
+
+        public_key = d["subscription"].get("public_key")
+        try:
+            (auth_type, token) = auth.split(' ', 1)
+        except ValueError:
+            raise InvalidRequest("Invalid Authorization Header",
+                                 status_code=401, errno=109,
+                                 headers={"www-authenticate": AUTH_SCHEME})
+
+        # If its not a bearer token containing what may be JWT, stop
+        if auth_type.lower() != AUTH_SCHEME or '.' not in token:
+            return
+
+        jwt = extract_jwt(token, public_key)
+        if jwt.get('exp', 0) < time.time():
+            raise InvalidRequest("Invalid bearer token: Auth expired",
+                                 status_code=401, errno=109,
+                                 headers={"www-authenticate": AUTH_SCHEME})
+        jwt_crypto_key = base64url_encode(public_key)
+        d["jwt"] = dict(jwt_crypto_key=jwt_crypto_key, jwt_data=jwt)
+
+    @post_load
+    def fixup_output(self, d):
+        # Verify authorization
+        # Note: This has to be done here, since schema validation takes place
+        #       before nested schemas, and in this case we need all the nested
+        #       schema logic to run first.
+        self.validate_auth(d)
+
+        # Add a message_id
+        sub = d["subscription"]
+        d["message_id"] = self.context["settings"].fernet.encrypt(
+            ":".join(["m", sub["uaid"].hex, sub["chid"].hex]).encode('utf8')
+        )
+
+        # Strip crypto/encryption headers down
+        for hdr in ["crypto-key", "encryption"]:
+            if strip_padding.search(d["headers"].get(hdr, "")):
+                head = d["headers"][hdr].replace('"', '')
+                d["headers"][hdr] = strip_padding.sub("", head)
+
+        # Base64-encode data for Web Push
+        d["body"] = base64url_encode(d["body"])
         return d

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -1,1 +1,84 @@
-#
+import time
+
+from twisted.internet.defer import Deferred
+from twisted.internet.threads import deferToThread
+
+from autopush.web.base import (
+    BaseHandler,
+    Notification,
+)
+from autopush.web.validation import (
+    threaded_validate,
+    WebPushRequestSchema,
+)
+
+
+class WebPushHandler(BaseHandler):
+    cors_methods = "POST"
+    cors_request_headers = ["content-encoding", "encryption",
+                            "crypto-key", "ttl",
+                            "encryption-key", "content-type",
+                            "authorization"]
+    cors_response_headers = ["location", "www-authenticate"]
+
+    @threaded_validate(WebPushRequestSchema)
+    def post(self, api_ver="v1", token=None):
+        # Store Vapid info if present
+        jwt = self.valid_input.get("jwt")
+        if jwt:
+            self._client_info["jwt_crypto_key"] = jwt["jwt_crypto_key"]
+            for i in jwt["jwt_data"]:
+                self._client_info["jwt_" + i] = jwt["jwt_data"][i]
+
+        sub = self.valid_input["subscription"]
+        user_data = sub["user_data"]
+        router = self.ap_settings.routers[user_data["router_type"]]
+        self._client_info["message_id"] = self.valid_input["message_id"]
+
+        notification = Notification(
+            version=self.valid_input["message_id"],
+            data=self.valid_input["body"],
+            channel_id=str(sub["chid"]),
+            headers=self.valid_input["headers"],
+            ttl=self.valid_input["headers"]["ttl"]
+        )
+
+        d = Deferred()
+        d.addCallback(router.route_notification, user_data)
+        d.addCallback(self._router_completed, user_data, "")
+        d.addErrback(self._router_fail_err)
+        d.addErrback(self._response_err)
+
+        # Call the prepared router
+        d.callback(notification)
+
+    def _router_completed(self, response, uaid_data, warning=""):
+        """Called after router has completed successfully"""
+        # Were we told to update the router data?
+        # GCM/APNS bridges can result in data updates
+        if response.router_data is not None:
+            if not response.router_data:
+                del uaid_data["router_data"]
+                del uaid_data["router_type"]
+            else:
+                uaid_data["router_data"] = response.router_data
+            uaid_data["connected_at"] = int(time.time() * 1000)
+            d = deferToThread(self.ap_settings.router.register_user,
+                              uaid_data)
+            response.router_data = None
+            d.addCallback(lambda x: self._router_completed(response,
+                                                           uaid_data,
+                                                           warning))
+            return d
+        else:
+            if response.status_code == 200 or response.logged_status == 200:
+                self.log.info(format="Successful delivery",
+                              **self._client_info)
+            elif response.status_code == 202 or response.logged_status == 202:
+                self.log.info(format="Router miss, message stored.",
+                              **self._client_info)
+            time_diff = time.time() - self.start_time
+            self.metrics.timing("updates.handled", duration=time_diff)
+            response.response_body = (
+                response.response_body + " " + warning).strip()
+            self._router_response(response)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage
 mock>=1.0.1
 -e git+https://github.com/habnabit/txstatsd.git@master#egg=txStatsD
 -e git+https://github.com/bbangert/moto.git@3bdb75a961148ea5aa526f0e88d9e7835a30df3a#egg=moto
-flake8
+flake8==2.5.4
 psutil
 websocket-client
 ConfigArgParse==0.10.0


### PR DESCRIPTION
This refactor splits out the webpush endpoint to a new URL path
and uses the marshmallow schema to validate requests.

The webpush endpoints are issued under a new URL endpoint to
avoid conflicts with the existing.

Closes #379 

@jrconlin r?