### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ When submitting a PR:
   with the new relevant code.
 
 See the main
-[documentation](http://autopush.readthedocs.org/en/latest/install.html)
+[documentation](https://autopush.readthedocs.io/en/latest/install.html)
 for information on prerequisites, installing, running and testing.
 
 ## Code Review

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov.io](https://img.shields.io/codecov/c/github/mozilla-services/autopush/master.svg)](https://codecov.io/github/mozilla-services/autopush?branch=master) [![Build Status](https://travis-ci.org/mozilla-services/autopush.svg?branch=master)](https://travis-ci.org/mozilla-services/autopush) [![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](http://autopush.readthedocs.org/) [![Requirements Status](https://requires.io/github/mozilla-services/autopush/requirements.svg?branch=master)](https://requires.io/github/mozilla-services/autopush/requirements/?branch=master)
+[![codecov.io](https://img.shields.io/codecov/c/github/mozilla-services/autopush/master.svg)](https://codecov.io/github/mozilla-services/autopush?branch=master) [![Build Status](https://travis-ci.org/mozilla-services/autopush.svg?branch=master)](https://travis-ci.org/mozilla-services/autopush) [![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://autopush.readthedocs.io/) [![Requirements Status](https://requires.io/github/mozilla-services/autopush/requirements.svg?branch=master)](https://requires.io/github/mozilla-services/autopush/requirements/?branch=master)
 
 # Autopush
 
@@ -8,4 +8,4 @@ Mozilla Push server and Push Endpoint utilizing built with:
 - twisted
 - DynamoDB
 
-[Autopush Documentation on ReadThedocs](http://autopush.readthedocs.org/>)
+[Autopush Documentation on ReadThedocs](https://autopush.readthedocs.io/>)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ For instance, if installing on an Amazon EC2 machine:
     libncurses5-devel openssl-devel patch python-devel \
     python-virtualenv readline-devel -y
 
-Autopush uses the `Boto python library <http://boto.readthedocs.org/en/latest/>`_. Be sure to `properly set up <http://boto.readthedocs.org/en/latest/boto_config_tut.html>`_ your ``.boto`` configuration file.
+Autopush uses the `Boto python library <https://boto.readthedocs.io/en/latest/>`_. Be sure to `properly set up <https://boto.readthedocs.io/en/latest/boto_config_tut.html>`_ your ``.boto`` configuration file.
 
 Python 2.7.7+ w/virtualenv
 ==========================


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.