### PR TITLE
feat: add metrics to bridge protocols

### DIFF
--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -252,7 +252,12 @@ class GCMRouterTestCase(unittest.TestCase):
             raise AttributeError
         fsenderids = Mock()
         fsenderids.choose_ID.side_effect = throw_ex
-        self.assertRaises(IOError, GCMRouter, {}, {"senderIDs": fsenderids})
+        settings = AutopushSettings(
+            hostname="localhost",
+            statsd_host=None,
+        )
+        self.assertRaises(IOError, GCMRouter, settings,
+                          {"senderIDs": fsenderids})
 
     def test_register(self):
         result = self.router.register("uaid", {"token": "connect_data"})


### PR DESCRIPTION
This adds metric calls for attempted and successful bridge sends.
format:
        updates.client.bridge.[apns|gcm].[attempted|succeeded]
Errors are already logged.

closes #497

@bbangert r?