### PR TITLE
Feature/issue 509

### DIFF
--- a/autopush/diagnostic_cli.py
+++ b/autopush/diagnostic_cli.py
@@ -1,0 +1,82 @@
+from __future__ import print_function
+
+import pprint
+import re
+import sys
+
+import configargparse
+from twisted.logger import Logger
+
+from autopush.main import (
+    add_shared_args,
+    shared_config_files,
+)
+from autopush.settings import AutopushSettings
+
+
+PUSH_RE = re.compile(r"push/(?:(?P<api_ver>v\d+)\/)?(?P<token>[^\/]+)")
+
+
+class EndpointDiagnosticCLI(object):
+    log = Logger()
+
+    def __init__(self, sysargs, use_files=True):
+        args = self._load_args(sysargs, use_files)
+        self._settings = AutopushSettings(
+            crypto_key=args.crypto_key,
+            router_tablename=args.router_tablename,
+            storage_tablename=args.storage_tablename,
+            message_tablename=args.message_tablename,
+        )
+        self._endpoint = args.endpoint
+        self._pp = pprint.PrettyPrinter(indent=4)
+
+    def _load_args(self, sysargs, use_files):
+        if use_files:
+            config_files = [
+                '/etc/autopush_endpoint.ini',
+                '~/.autopush_endpoint.ini',
+                '.autopush_endpoint.ini'
+            ]
+        else:
+            config_files = []  # pragma: nocover
+
+        parser = configargparse.ArgumentParser(
+            description='Runs endpoint diagnostics.',
+            default_config_files=shared_config_files + config_files)
+        parser.add_argument('endpoint', help="Endpoint to parse")
+
+        add_shared_args(parser)
+        return parser.parse_args(sysargs)
+
+    def run(self):
+        match = PUSH_RE.search(self._endpoint)
+        if not match:
+            sys.exit("Not a valid endpoint")
+            return  # Included purely for testing purposes
+
+        md = match.groupdict()
+        api_ver, token = md.get("api_ver", "v0"), md["token"]
+
+        parsed = self._settings.parse_endpoint(
+            token=token,
+            version=api_ver,
+        )
+        uaid, chid = parsed["uaid"], parsed["chid"]
+
+        print("UAID: {}\nCHID: {}\n".format(uaid, chid))
+
+        rec = self._settings.router.get_uaid(uaid)
+        print("Router record:")
+        self._pp.pprint(rec._data)
+        print("\n")
+
+        mess_table = rec["current_month"]
+        chans = self._settings.message_tables[mess_table].all_channels(uaid)
+        print("Channels in message table:")
+        self._pp.pprint(chans)
+
+
+def run_endpoint_diagnostic_cli(sysargs=None, use_files=True):
+    cli = EndpointDiagnosticCLI(sysargs, use_files)
+    cli.run()

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -31,6 +31,7 @@ from autopush.websocket import (
     StatusResource,
 )
 from autopush.web.simplepush import SimplePushHandler
+from autopush.web.webpush import WebPushHandler
 
 
 shared_config_files = [
@@ -504,6 +505,8 @@ def endpoint_main(sysargs=None, use_files=True):
          dict(ap_settings=settings)),
         (r"/spush/(?:(?P<api_ver>v\d+)\/)?(?P<token>[^\/]+)",
          SimplePushHandler, dict(ap_settings=settings)),
+        (r"/wpush/(?:(?P<api_ver>v\d+)\/)?(?P<token>[^\/]+)",
+         WebPushHandler, dict(ap_settings=settings)),
         (r"/m/([^\/]+)", MessageHandler, dict(ap_settings=settings)),
         # PUT /register/ => connect info
         # GET /register/uaid => chid + endpoint

--- a/autopush/tests/test_diagnostic_cli.py
+++ b/autopush/tests/test_diagnostic_cli.py
@@ -1,0 +1,60 @@
+import unittest
+
+from mock import Mock, patch
+from moto import mock_dynamodb2
+from nose.tools import eq_
+
+
+mock_dynamodb2 = mock_dynamodb2()
+
+
+def setUp():
+    mock_dynamodb2.start()
+
+
+def tearDown():
+    mock_dynamodb2.stop()
+
+
+class FakeDict(dict):
+    pass
+
+
+class DiagnosticCLITestCase(unittest.TestCase):
+    def _makeFUT(self, *args, **kwargs):
+        from autopush.diagnostic_cli import EndpointDiagnosticCLI
+        return EndpointDiagnosticCLI(*args, **kwargs)
+
+    def test_basic_load(self):
+        cli = self._makeFUT([
+            "--router_tablename=fred",
+            "http://someendpoint",
+        ])
+        eq_(cli._settings.router_table.table_name, "fred")
+
+    @patch("sys.exit")
+    def test_bad_endpoint(self, mock_exit):
+        cli = self._makeFUT([
+            "--router_tablename=fred",
+            "http://someendpoint",
+        ])
+        cli.run()
+        mock_exit.assert_called()
+
+    @patch("autopush.diagnostic_cli.AutopushSettings")
+    def test_successfull_lookup(self, mock_settings_class):
+        from autopush.diagnostic_cli import run_endpoint_diagnostic_cli
+        mock_settings_class.return_value = mock_settings = Mock()
+        mock_settings.parse_endpoint.return_value = dict(
+            uaid="asdf", chid="asdf")
+        mock_settings.router.get_uaid.return_value = mock_item = FakeDict()
+        mock_item._data = {}
+        mock_item["current_month"] = "201608120002"
+        mock_message_table = Mock()
+        mock_settings.message_tables = {"201608120002": mock_message_table}
+
+        run_endpoint_diagnostic_cli([
+            "--router_tablename=fred",
+            "http://something/wpush/v1/legit_endpoint",
+        ])
+        mock_message_table.all_channels.assert_called()

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1234,7 +1234,7 @@ class EndpointTestCase(unittest.TestCase):
 
         self.endpoint.write_error(999, exc_info=exc_info)
         self.status_mock.assert_called_with(999)
-        self.assertTrue(self.endpoint.log.called)
+        eq_(self.endpoint.log.failure.called, True)
 
     def test_write_error_no_exc(self):
         """ Write error is triggered by sending the app a request
@@ -1244,7 +1244,7 @@ class EndpointTestCase(unittest.TestCase):
         """
         self.endpoint.write_error(999)
         self.status_mock.assert_called_with(999)
-        self.assertTrue(self.endpoint.log.called)
+        eq_(self.endpoint.log.failure.called, True)
 
     def _assert_error_response(self, result):
         self.status_mock.assert_called_with(500, None)
@@ -1434,24 +1434,24 @@ class RegistrationTestCase(unittest.TestCase):
             type="test",
         ))
         result = self.reg._load_params()
-        self.assert_(isinstance(result, dict))
+        ok_(isinstance(result, dict))
         eq_(result["channelID"], dummy_chid)
 
     def test_load_params_invalid_body(self):
         self.reg.request.body = b'connect={"type":"test"}'
-        self.assertTrue(not self.reg._load_params())
+        ok_(not self.reg._load_params())
 
     @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_load_params_prefer_body(self, t):
         args = self.reg.request.arguments
         args['connect'] = ['{"type":"invalid"}']
         self.reg.request.body = b'connect={"type":"test"}'
-        self.assertTrue(self.reg._load_params())
+        eq_(self.reg._load_params(), {})
 
     @patch('uuid.uuid4', return_value=uuid.UUID(dummy_chid))
     def test_load_params_no_conn(self, t):
         self.reg.request.body = b'noconnect={"type":"test"}'
-        self.assertTrue(not self.reg._load_params())
+        ok_(not self.reg._load_params())
 
     def test_cors(self):
         ch1 = "Access-Control-Allow-Origin"

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -1,0 +1,112 @@
+import uuid
+
+from cryptography.fernet import Fernet
+from cyclone.web import Application
+from mock import Mock, patch
+from moto import mock_dynamodb2
+from nose.tools import eq_
+from twisted.internet.defer import Deferred
+from twisted.logger import Logger
+from twisted.trial import unittest
+
+from autopush.db import (
+    Router,
+    create_rotating_message_table,
+)
+from autopush.router.interface import IRouter, RouterResponse
+from autopush.settings import AutopushSettings
+
+dummy_request_id = "11111111-1234-1234-1234-567812345678"
+dummy_uaid = str(uuid.UUID("abad1dea00000000aabbccdd00000000"))
+dummy_chid = str(uuid.UUID("deadbeef00000000decafbad00000000"))
+dummy_token = dummy_uaid + ":" + dummy_chid
+mock_dynamodb2 = mock_dynamodb2()
+
+
+def setUp():
+    mock_dynamodb2.start()
+    create_rotating_message_table()
+
+
+def tearDown():
+    mock_dynamodb2.stop()
+
+
+class TestWebpushHandler(unittest.TestCase):
+    @patch('uuid.uuid4', return_value=uuid.UUID(dummy_request_id))
+    def setUp(self, t):
+        from autopush.web.webpush import WebPushHandler
+
+        settings = AutopushSettings(
+            hostname="localhost",
+            statsd_host=None,
+        )
+        self.fernet_mock = settings.fernet = Mock(spec=Fernet)
+        self.ap_settings = settings
+
+        self.router_mock = settings.router = Mock(spec=Router)
+        self.request_mock = Mock(body=b'', arguments={},
+                                 headers={"ttl": "0"},
+                                 host='example.com:8080')
+
+        self.wp = WebPushHandler(Application(),
+                                 self.request_mock,
+                                 ap_settings=settings)
+        self.wp.path_kwargs = {}
+        self.status_mock = self.wp.set_status = Mock()
+        self.write_mock = self.wp.write = Mock()
+        self.wp.log = Mock(spec=Logger)
+        d = self.finish_deferred = Deferred()
+        self.wp.finish = lambda: d.callback(True)
+        settings.routers["webpush"] = Mock(spec=IRouter)
+        self.wp_router_mock = settings.routers["webpush"]
+
+    def test_router_needs_update(self):
+        self.ap_settings.parse_endpoint = Mock(return_value=dict(
+            uaid=dummy_uaid,
+            chid=dummy_chid,
+            public_key="asdfasdf",
+        ))
+        self.fernet_mock.decrypt.return_value = dummy_token
+        self.router_mock.get_uaid.return_value = dict(
+            router_type="webpush",
+            router_data=dict(),
+        )
+        self.wp_router_mock.route_notification.return_value = RouterResponse(
+            status_code=503,
+            router_data=dict(token="new_connect"),
+        )
+
+        def handle_finish(result):
+            eq_(result, True)
+            self.wp.set_status.assert_called_with(503)
+            assert(self.router_mock.register_user.called)
+        self.finish_deferred.addCallback(handle_finish)
+
+        self.wp.post("v1", dummy_token)
+        return self.finish_deferred
+
+    def test_router_returns_data_without_detail(self):
+        self.ap_settings.parse_endpoint = Mock(return_value=dict(
+            uaid=dummy_uaid,
+            chid=dummy_chid,
+            public_key="asdfasdf",
+        ))
+        self.fernet_mock.decrypt.return_value = dummy_token
+        self.router_mock.get_uaid.return_value = dict(
+            router_type="webpush",
+            router_data=dict(),
+        )
+        self.wp_router_mock.route_notification.return_value = RouterResponse(
+            status_code=503,
+            router_data=dict(),
+        )
+
+        def handle_finish(result):
+            eq_(result, True)
+            self.wp.set_status.assert_called_with(503)
+            assert(self.router_mock.register_user.called)
+        self.finish_deferred.addCallback(handle_finish)
+
+        self.wp.post("v1", dummy_token)
+        return self.finish_deferred

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -11,7 +11,7 @@ from boto.dynamodb2.exceptions import (
 from cyclone.web import Application
 from mock import Mock, patch
 from moto import mock_dynamodb2
-from nose.tools import (eq_, ok_)
+from nose.tools import eq_, ok_
 from txstatsd.metrics.metrics import Metrics
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred
@@ -118,8 +118,8 @@ class WebsocketTestCase(unittest.TestCase):
 
         req.headers.get.side_effect = raise_error
 
-        with self.assertRaises(Exception):
-            self.proto.onConnect(req)
+        self.proto.onConnect(req)
+        self.proto.log.failure.assert_called()
 
     @patch("autopush.websocket.reactor")
     def test_autoping_no_uaid(self, mock_reactor):

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name="AutoPush",
       autopush = autopush.main:connection_main
       autoendpoint = autopush.main:endpoint_main
       autokey = autokey:main
+      endpoint_diagnostic = autopush.diagnostic_cli:run_endpoint_diagnostic_cli
       [nose.plugins]
       object-tracker = autopush.noseplugin:ObjectTracker
       """,


### PR DESCRIPTION
Fixes a few bugs in existing tests that were using self.assert which failed to verify the value.

Fixes issue with the wpush endpoint not being registered in main.py for autoendpoint.

Add's the test_web_webpush which should've been included with the prior webpush endpoint refactor.

The last commit add's a endpoint_diagnostic CLI that will resolve an endpoint to its
UAID/CHID and router record info along with applicable valid channels.

Closes #509

@jrconlin r?
