### PR TITLE
Feature/issue 433

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -168,6 +168,15 @@ def preflight_check(storage, router, uaid="deadbeef00000000deadbeef00000000"):
     Failure to run correctly will raise an exception.
 
     """
+    # Verify tables are ready for use if they just got created
+    ready = False
+    while not ready:
+        tbl_status = [x.describe()["Table"]["TableStatus"]
+                      for x in [storage.table, router.table]]
+        ready = all([status == "ACTIVE" for status in tbl_status])
+        if not ready:
+            time.sleep(1)
+
     # Use a distinct UAID so it doesn't interfere with metrics
     chid = uuid.uuid4().hex
     node_id = "mynode:2020"

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1690,9 +1690,11 @@ class WebsocketTestCase(unittest.TestCase):
 
         d = Deferred()
 
-        def wait_for_clear():
+        def wait_for_clear(count=0.0):
             if self.proto.ps.updates_sent:  # pragma: nocover
-                reactor.callLater(0.1, wait_for_clear)
+                if count > 5.0:
+                    raise Exception("Time-out waiting")
+                reactor.callLater(0.1, wait_for_clear, count+0.1)
                 return
 
             # Accepting again
@@ -1739,10 +1741,12 @@ class WebsocketTestCase(unittest.TestCase):
 
         d = Deferred()
 
-        def check_mock_call():
+        def check_mock_call(count=0.0):
             calls = self.proto.process_notifications.mock_calls
             if len(calls) < 1:
-                reactor.callLater(0.1, check_mock_call)
+                if count > 5.0:  # pragma: nocover
+                    raise Exception("Time-out waiting")
+                reactor.callLater(0.1, check_mock_call, count+0.1)
                 return
 
             eq_(len(calls), 1)


### PR DESCRIPTION
feat: wait for tables to be active in pre-flight check

On a fresh start, tables that are in the process of being created
may not be ready yet. We now wait for the tables to be active
and ready.

Includes a test commit fix for a time-out issue as well.

Closes #433

@jrconlin r?