### PR TITLE
bug: remove shared file inclusion for tests

### DIFF
--- a/autopush/diagnostic_cli.py
+++ b/autopush/diagnostic_cli.py
@@ -33,7 +33,7 @@ class EndpointDiagnosticCLI(object):
 
     def _load_args(self, sysargs, use_files):
         if use_files:
-            config_files = [
+            config_files = shared_config_files + [  # pragma: nocover
                 '/etc/autopush_endpoint.ini',
                 '~/.autopush_endpoint.ini',
                 '.autopush_endpoint.ini'
@@ -43,7 +43,7 @@ class EndpointDiagnosticCLI(object):
 
         parser = configargparse.ArgumentParser(
             description='Runs endpoint diagnostics.',
-            default_config_files=shared_config_files + config_files)
+            default_config_files=config_files)
         parser.add_argument('endpoint', help="Endpoint to parse")
 
         add_shared_args(parser)

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -196,7 +196,7 @@ def _parse_connection(sysargs, use_files=True):
     # For testing, do not use the configuration files since they can
     # produce unexpected results.
     if use_files:  # pragma: nocover
-        config_files = [
+        config_files = shared_config_files + [  # pragma: nocover
             '/etc/autopush_connection.ini',
             '~/.autopush_connection.ini',
             '.autopush_connection.ini'
@@ -205,7 +205,7 @@ def _parse_connection(sysargs, use_files=True):
         config_files = []  # pragma: nocover
     parser = configargparse.ArgumentParser(
         description='Runs a Connection Node.',
-        default_config_files=shared_config_files + config_files)
+        default_config_files=config_files)
     parser.add_argument('--config-connection',
                         help="Connection node configuration file path",
                         dest='config_file', is_config_file=True)
@@ -250,7 +250,7 @@ def _parse_connection(sysargs, use_files=True):
 def _parse_endpoint(sysargs, use_files=True):
     """Parses out endpoint arguments for an autoendpoint node"""
     if use_files:
-        config_files = [
+        config_files = shared_config_files + [
             '/etc/autopush_endpoint.ini',
             '~/.autopush_endpoint.ini',
             '.autopush_endpoint.ini'
@@ -259,7 +259,7 @@ def _parse_endpoint(sysargs, use_files=True):
         config_files = []  # pragma: nocover
     parser = configargparse.ArgumentParser(
         description='Runs an Endpoint Node.',
-        default_config_files=shared_config_files + config_files)
+        default_config_files=config_files)
     parser.add_argument('--config-endpoint',
                         help="Endpoint node configuration file path",
                         dest='config_file', is_config_file=True)

--- a/autopush/tests/test_diagnostic_cli.py
+++ b/autopush/tests/test_diagnostic_cli.py
@@ -23,7 +23,7 @@ class FakeDict(dict):
 class DiagnosticCLITestCase(unittest.TestCase):
     def _makeFUT(self, *args, **kwargs):
         from autopush.diagnostic_cli import EndpointDiagnosticCLI
-        return EndpointDiagnosticCLI(*args, **kwargs)
+        return EndpointDiagnosticCLI(*args, use_files=False, **kwargs)
 
     def test_basic_load(self):
         cli = self._makeFUT([
@@ -56,5 +56,5 @@ class DiagnosticCLITestCase(unittest.TestCase):
         run_endpoint_diagnostic_cli([
             "--router_tablename=fred",
             "http://something/wpush/v1/legit_endpoint",
-        ])
+        ], use_files=False)
         mock_message_table.all_channels.assert_called()

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -248,7 +248,7 @@ class EndpointMainTestCase(unittest.TestCase):
             "--ssl_dh_param=keys/dhparam.pem",
             "--ssl_cert=keys/server.crt",
             "--ssl_key=keys/server.key",
-        ])
+        ], False)
 
     def test_bad_senderidlist(self):
         endpoint_main([
@@ -277,7 +277,7 @@ class EndpointMainTestCase(unittest.TestCase):
             "--gcm_enabled",
             """--senderid_list={"123":{"auth":"abcd"}}""",
             "--s3_bucket=none",
-        ])
+        ], False)
 
     @patch("requests.get")
     def test_aws_ami_id(self, request_mock):


### PR DESCRIPTION
Parse-args can aggressively pull local config files. Tests are set to
exclude local files, but recent file changes added the shared_config
files back in causing local unit tests to fail.

Closes #515 

@bbangert r?