### PR TITLE
bug: fix up AWS conditional binding and assoc. conditions

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -18,6 +18,7 @@ from boto.dynamodb2.layer1 import DynamoDBConnection
 from boto.dynamodb2.table import Table
 from boto.dynamodb2.types import NUMBER
 
+from autopush.exceptions import AutopushException
 from autopush.utils import generate_hash
 
 key_hash = ""
@@ -582,6 +583,10 @@ class Router(object):
         conn = self.table.connection
         db_key = self.encode({"uaid": hasher(data["uaid"])})
         del data["uaid"]
+        if "router_type" not in data or "connected_at" not in data:
+            # Not specifying these values will generate an exception in AWS.
+            raise AutopushException("data is missing router_type"
+                                    "or connected_at")
         # Generate our update expression
         expr = "SET " + ", ".join(["%s=:%s" % (x, x) for x in data.keys()])
         expr_values = self.encode({":%s" % k: v for k, v in data.items()})

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -569,12 +569,8 @@ class EndpointHandler(AutoendpointHandler):
         # TODO: Add some custom wake logic here
 
         # Were we told to update the router data?
-        if response.router_data is not None:
-            if not response.router_data:
-                del uaid_data["router_data"]
-                del uaid_data["router_type"]
-            else:
-                uaid_data["router_data"] = response.router_data
+        if response.router_data:
+            uaid_data["router_data"] = response.router_data
             uaid_data["connected_at"] = int(time.time() * 1000)
             d = deferToThread(self.ap_settings.router.register_user,
                               uaid_data)

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -94,9 +94,9 @@ class GCMRouter(object):
         except KeyError:
             raise self._error("Server error, missing bridge credentials " +
                               "for %s" % creds.get("senderID"), 500)
-        except gcmclient.GCMAuthenticationError, e:
+        except gcmclient.GCMAuthenticationError as e:
             raise self._error("Authentication Error: %s" % e, 500)
-        except Exception, e:
+        except Exception as e:
             raise self._error("Unhandled exception in GCM Routing: %s" % e,
                               500)
         self.metrics.increment("updates.client.bridge.gcm.attempted",

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -624,7 +624,7 @@ class EndpointTestCase(unittest.TestCase):
         def handle_finish(result):
             self.assertTrue(result)
             self.endpoint.set_status.assert_called_with(500, None)
-            assert(self.router_mock.register_user.called)
+            ok_(not self.router_mock.register_user.called)
         self.finish_deferred.addCallback(handle_finish)
 
         self.endpoint.put(None, dummy_uaid)

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -435,6 +435,7 @@ class WebsocketTestCase(unittest.TestCase):
             uaid=orig_uaid,
             connected_at=ms_time(),
             current_month=msg_date,
+            router_type="webpush"
         ))
 
         def fake_msg(data):
@@ -1865,6 +1866,19 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.ps._register.addCallback(after_hello)
         self.proto.ps._register.addErrback(lambda x: d.errback(x))
         return d
+
+    def test_incomplete_uaid(self):
+        mm = self.proto.ap_settings.router = Mock()
+        fr = self.proto.force_retry = Mock()
+        uaid = uuid.uuid4().hex
+        mm.get_uaid.return_value = {
+            'uaid': uaid
+        }
+        self.proto.ps.uaid = uaid
+        reply = self.proto._verify_user_record()
+        eq_(reply, None)
+        assert(fr.called)
+        eq_(fr.call_args[0], (mm.drop_user, uaid))
 
 
 class RouterHandlerTestCase(unittest.TestCase):


### PR DESCRIPTION
AWS throws an exception if conditional args are not defined, this
impacted tests by failing, but throwing an exception and causing fun
havoc. register_user now fails if all conditionals are not met
(preserving previous behaviors). Added tests for older records that may
be incomplete.

Some formatting fixes included as well

@bbangert r?