### PR TITLE
fix: overwrite existing messages instead of throwing an error

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -411,7 +411,7 @@ class Message(object):
         if data:
             item["headers"] = headers
             item["data"] = data
-        self.table.put_item(data=item)
+        self.table.put_item(data=item, overwrite=True)
         return True
 
     @track_provisioned


### PR DESCRIPTION
DynamoDB throws a condition check failure if you put_item and
it already exists. This can occur when we save a message that
may already exist when a user hops servers without ack'ing. We
should allow it since it consumes the same resources.

Closes #535 

@jrconlin r?