### PR TITLE
bug: Handle URL arguments to OPTIONS and HEAD requests

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -145,10 +145,10 @@ class AutoendpointHandler(ErrorLogger, cyclone.web.RequestHandler):
     #############################################################
     #                    Cyclone HTTP Methods
     #############################################################
-    def options(self, *args):
+    def options(self, *args, **kwargs):
         """HTTP OPTIONS Handler"""
 
-    def head(self, *args):
+    def head(self, *args, **kwargs):
         """HTTP HEAD Handler"""
 
     #############################################################

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1198,7 +1198,8 @@ class EndpointTestCase(unittest.TestCase):
         endpoint = self.endpoint
         endpoint.ap_settings.cors = True
         endpoint.prepare()
-        endpoint.head(None)
+        args = {"api_ver": "v1", "token": "test"}
+        endpoint.head(args)
         eq_(endpoint._headers[ch1], "*")
         eq_(endpoint._headers[ch2], self.CORS_METHODS)
         eq_(endpoint._headers[ch3], self.CORS_HEADERS)
@@ -1212,7 +1213,8 @@ class EndpointTestCase(unittest.TestCase):
         endpoint = self.endpoint
         endpoint.ap_settings.cors = True
         endpoint.prepare()
-        endpoint.options(None)
+        args = {"api_ver": "v1", "token": "test"}
+        endpoint.options(args)
         eq_(endpoint._headers[ch1], "*")
         eq_(endpoint._headers[ch2], self.CORS_METHODS)
         eq_(endpoint._headers[ch3], self.CORS_HEADERS)

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -104,7 +104,8 @@ class TestBase(unittest.TestCase):
         base = self.base
         base.ap_settings.cors = True
         base.prepare()
-        base.head(None)
+        args = {"api_ver": "v1", "token": "test"}
+        base.head(args)
         eq_(base._headers[ch1], "*")
         eq_(base._headers[ch2], self.CORS_METHODS)
         eq_(base._headers[ch3], self.CORS_HEADERS)
@@ -115,10 +116,13 @@ class TestBase(unittest.TestCase):
         ch2 = "Access-Control-Allow-Methods"
         ch3 = "Access-Control-Allow-Headers"
         ch4 = "Access-Control-Expose-Headers"
+        # These should match the full endpoint arguments specified in
+        # autopush.main.endpoint_main
+        args = {"api_ver": "v1", "token": "test"}
         base = self.base
         base.ap_settings.cors = True
         base.prepare()
-        base.options(None)
+        base.options(args)
         eq_(base._headers[ch1], "*")
         eq_(base._headers[ch2], self.CORS_METHODS)
         eq_(base._headers[ch3], self.CORS_HEADERS)

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -95,10 +95,10 @@ class BaseHandler(cyclone.web.RequestHandler):
     #############################################################
     #                    Cyclone HTTP Methods
     #############################################################
-    def options(self, *args):
+    def options(self, *args, **kwargs):
         """HTTP OPTIONS Handler"""
 
-    def head(self, *args):
+    def head(self, *args, **kwargs):
         """HTTP HEAD Handler"""
 
     #############################################################


### PR DESCRIPTION
OPTIONS and HEAD requests are made by XHTTP and fetch calls in browsers.
These need to have tests that closely parallel the arguments being
generated in URL parsers in main.py.

closes #551 

@bbangert r?