### PR TITLE
feat: normalize user-agent for datadog and parse for raw logging

### DIFF
--- a/autopush/tests/test_utils.py
+++ b/autopush/tests/test_utils.py
@@ -1,0 +1,31 @@
+import unittest
+
+from nose.tools import eq_
+
+
+class TestUserAgentParser(unittest.TestCase):
+    def _makeFUT(self, *args):
+        from autopush.utils import parse_user_agent
+        return parse_user_agent(*args)
+
+    def test_linux_extraction(self):
+        dd, raw = self._makeFUT('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.2) Gecko/20090807 Mandriva Linux/1.9.1.2-1.1mud2009.1 (2009.1) Firefox/3.5.2 FirePHP/0.3,gzip(gfe),gzip(gfe)')  # NOQA
+        eq_(dd["ua_os_family"], "Linux")
+        eq_(raw["ua_os_family"], "Mandriva")
+
+    def test_windows_extraction(self):
+        dd, raw = self._makeFUT('Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 (.NET CLR 3.5.30729)')  # NOQA
+        eq_(dd["ua_os_family"], "Windows")
+        eq_(raw["ua_os_family"], "Windows 7")
+
+    def test_valid_os(self):
+        dd, raw = self._makeFUT('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.5; rv:2.1.1) Gecko/ Firefox/5.0.1')  # NOQA
+        eq_(dd["ua_os_family"], "Mac OS X")
+        eq_(raw["ua_os_family"], "Mac OS X")
+
+    def test_other_os_and_browser(self):
+        dd, raw = self._makeFUT('BlackBerry9000/4.6.0.167 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/102')  # NOQA
+        eq_(dd["ua_os_family"], "Other")
+        eq_(raw["ua_os_family"], "BlackBerry OS")
+        eq_(dd["ua_browser_family"], "Other")
+        eq_(raw["ua_browser_family"], "BlackBerry")

--- a/pypy-requirements.txt
+++ b/pypy-requirements.txt
@@ -53,6 +53,7 @@ six==1.10.0
 translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 txaio==2.5.1
+ua_parser==0.7.1
 virtualenv==15.0.1
 wsaccel==0.6.2
 xmltodict==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ six==1.10.0
 translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 txaio==2.5.1
+ua_parser==0.7.1
 virtualenv==15.0.1
 wsaccel==0.6.2
 xmltodict==0.10.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -61,6 +61,7 @@ six==1.10.0
 translationstring==1.3
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 txaio==2.5.1
+ua_parser==0.7.1
 virtualenv==15.0.1
 wsaccel==0.6.2
 xmltodict==0.10.1


### PR DESCRIPTION
The user-agent string is now parsed and normalized to fewer values for DataDog. The
raw parsed version is also included in all websocket.py logging statements for easier
filtering in our logging. Existing raw user_agent string will remain so that existing log
parsing systems using it can function as normal.

Closes #487 

@jrconlin, @pjenvey r?