### PR TITLE
Bug: Fix webpush to reject endpoints which have an invalid GCM senderid

### DIFF
--- a/autopush/diagnostic_cli.py
+++ b/autopush/diagnostic_cli.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import pprint
 import re
-import sys
 
 import configargparse
 from twisted.logger import Logger

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -53,6 +53,7 @@ from autopush.utils import (
     base64url_encode,
 )
 from autopush.web.base import DEFAULT_ERR_URL
+from autopush.websocket import ms_time
 
 
 # Our max TTL is 60 days realistically with table rotation, so we hard-code it
@@ -581,7 +582,7 @@ class EndpointHandler(AutoendpointHandler):
         # Were we told to update the router data?
         if response.router_data:
             uaid_data["router_data"] = response.router_data
-            uaid_data["connected_at"] = int(time.time() * 1000)
+            uaid_data["connected_at"] = ms_time()
             d = deferToThread(self.ap_settings.router.register_user,
                               uaid_data)
             response.router_data = None
@@ -766,7 +767,7 @@ class RegistrationHandler(AutoendpointHandler):
             uaid=self.uaid,
             router_type=router_type,
             router_data=router_data,
-            connected_at=int(time.time() * 1000),
+            connected_at=ms_time(),
             last_connect=generate_last_connect(),
         )
         return deferToThread(self.ap_settings.router.register_user, user_item)

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -1526,7 +1526,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.reg.ap_settings.routers["gcm"] = gcm
         self.reg.request.body = json.dumps(dict(
             channelID=dummy_chid,
-            token="token",
+            token="182931248179192",
         ))
         self.fernet_mock.configure_mock(**{
             'encrypt.return_value': 'abcd123',

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -248,9 +248,11 @@ class GCMRouterTestCase(unittest.TestCase):
                           {"senderIDs": {}})
 
     def test_register(self):
-        result = self.router.register("uaid", {"token": "connect_data"})
+        result = self.router.register(uaid="uaid",
+                                      router_data={"token": "test123"},
+                                      router_token="test123")
         # Check the information that will be recorded for this user
-        eq_(result, {"token": "connect_data",
+        eq_(result, {"token": "test123",
                      "creds": {"senderID": "test123",
                                "auth": "12345678abcdefg"}})
 
@@ -378,7 +380,7 @@ class GCMRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(fail):
-            self._check_error_call(fail.value, 503)
+            self._check_error_call(fail.value, 410)
         d.addBoth(check_results)
         return d
 
@@ -401,13 +403,20 @@ class GCMRouterTestCase(unittest.TestCase):
         d.addBoth(check_results)
         return d
 
-    def test_ammend(self):
-        self.router.register("uaid", {"token": "connect_data"})
+    def test_amend(self):
+        self.router.register(uaid="uaid",
+                             router_data={"token": "test123"},
+                             router_token="test123")
         resp = {"key": "value"}
         result = self.router.amend_msg(resp,
                                        self.router_data.get('router_data'))
         eq_({"key": "value", "senderid": "test123"},
             result)
+
+    def test_register_invalid_token(self):
+        self.assertRaises(RouterException, self.router.register,
+                          uaid="uaid", router_data={"token": "invalid"},
+                          router_token="invalid")
 
 
 class FCMRouterTestCase(unittest.TestCase):
@@ -462,9 +471,11 @@ class FCMRouterTestCase(unittest.TestCase):
         self.assertRaises(IOError, FCMRouter, settings, {})
 
     def test_register(self):
-        result = self.router.register("uaid", {"token": "connect_data"})
+        result = self.router.register(uaid="uaid",
+                                      router_data={"token": "test123"},
+                                      router_token="test123")
         # Check the information that will be recorded for this user
-        eq_(result, {"token": "connect_data",
+        eq_(result, {"token": "test123",
                      "creds": {"senderID": "test123",
                                "auth": "12345678abcdefg"}})
 

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -375,6 +375,23 @@ class TestWebPushRequestSchema(unittest.TestCase):
 
         eq_(cm.exception.errno, 103)
 
+    def test_critical_failure(self):
+        schema = self._makeFUT()
+        schema.context["settings"].parse_endpoint.return_value = dict(
+            uaid=dummy_uaid,
+            chid=dummy_chid,
+            public_key="",
+        )
+        schema.context["settings"].router.get_uaid.return_value = dict(
+            router_type="fcm",
+            critical_failure="Bad SenderID",
+        )
+
+        with assert_raises(InvalidRequest) as cm:
+            schema.load(self._make_test_data())
+
+        eq_(cm.exception.errno, 105)
+
     def test_invalid_header_combo(self):
         schema = self._makeFUT()
         schema.context["settings"].parse_endpoint.return_value = dict(

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -171,7 +171,8 @@ class BaseHandler(cyclone.web.RequestHandler):
                       status_code=exc.status_code,
                       errno=exc.errno)
         self._write_response(exc.status_code, exc.errno,
-                             message="Request did not validate",
+                             message="Request did not validate %s" %
+                                     (exc.message or ""),
                              headers=exc.headers)
 
     def _response_err(self, fail):

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -209,6 +209,11 @@ class WebPushSubscriptionSchema(Schema):
         if result.get("router_type") not in ["webpush", "gcm", "apns", "fcm"]:
             raise InvalidRequest("Wrong URL for user", errno=108)
 
+        if result.get("critical_failure"):
+            raise InvalidRequest("Critical Failure: %s" %
+                                 result.get("critical_failure"),
+                                 status_code=410,
+                                 errno=105)
         # Propagate the looked up user data back out
         d["user_data"] = result
 

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -11,6 +11,7 @@ from autopush.web.validation import (
     threaded_validate,
     WebPushRequestSchema,
 )
+from autopush.websocket import ms_time
 
 
 class WebPushHandler(BaseHandler):
@@ -62,7 +63,7 @@ class WebPushHandler(BaseHandler):
                 del uaid_data["router_type"]
             else:
                 uaid_data["router_data"] = response.router_data
-            uaid_data["connected_at"] = int(time.time() * 1000)
+            uaid_data["connected_at"] = ms_time()
             d = deferToThread(self.ap_settings.router.register_user,
                               uaid_data)
             response.router_data = None


### PR DESCRIPTION
Adds logic to fail endpoints with invalid SenderIDs so that they fail fast on
post. Reduced logging level of GCM SenderID errors, since there's going
to be a lot of those for a while.

Closes #556 

@bbangert @pjenvey r?