### PR TITLE
fix: avoid uaid error in webpush preflight

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -773,12 +773,12 @@ class RegistrationHandler(AutoendpointHandler):
         return deferToThread(self.ap_settings.router.register_user, user_item)
 
     def _create_endpoint(self, result=None):
+        """Called to register a new channel and create its endpoint."""
         router_data = None
         try:
             router_data = result[2]
         except (IndexError, TypeError):
             pass
-        """Called to register a new channel and create its endpoint."""
         return deferToThread(self._register_channel, router_data)
 
     def _return_endpoint(self, endpoint_data, new_uaid, router=None):

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -64,7 +64,7 @@ class SimpleRouter(object):
     def amend_msg(self, msg, router_data=None):
         return msg
 
-    def preflight_check(self, uaid, channel_id):
+    def preflight_check(self, uaid_data, channel_id):
         """Verifies this routing call can be done successfully"""
         return True
 
@@ -87,7 +87,7 @@ class SimpleRouter(object):
 
         # Preflight check, hook used by webpush to verify channel id, extra
         # stores any additional data to pass to storing the message
-        extra = yield self.preflight_check(uaid, notification.channel_id)
+        extra = yield self.preflight_check(uaid_data, notification.channel_id)
 
         # Node_id is present, attempt delivery.
         # - Send Notification to node

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -214,6 +214,7 @@ class WebPushSubscriptionSchema(Schema):
                                  result.get("critical_failure"),
                                  status_code=410,
                                  errno=105)
+
         # Propagate the looked up user data back out
         d["user_data"] = result
 


### PR DESCRIPTION
Avoids the uaid error on fetch in the preflight by re-using the existing fetched
data. If the current_month doesn't exist, this is an invalid record so the uaid
is removed as it should've been.

closes #542, #553 

@jrconlin, @pjenvey r?