### PR TITLE
bug: Do not record the GCM data overflow error

### DIFF
--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -76,7 +76,7 @@ class GCMRouter(object):
                                   "to 3070 bytes. Converted buffer too " +
                                   "long by %d bytes" %
                                   (len(notification.data) - mdata),
-                                  413, errno=104)
+                                  413, errno=104, log_exception=False)
 
             data['body'] = notification.data
             data['con'] = notification.headers['content-encoding']


### PR DESCRIPTION
Return the GCM data overflow error to the subscription server, but
there's no need to record it into Sentry.

Closes #552 

@bbangert , @pjenvey r?