### PR TITLE
bug: Add ValueError trap for extract_jwt

### DIFF
--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -73,7 +73,7 @@ class FCMRouter(object):
                                   "to 3070 bytes. Converted buffer too " +
                                   "long by %d bytes" %
                                   (len(notification.data) - mdata),
-                                  413, errno=104)
+                                  413, errno=104, log_exception=False)
 
             data['body'] = notification.data
             data['con'] = notification.headers['content-encoding']

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -147,6 +147,7 @@ class SimpleRouter(object):
             raise RouterException("User was deleted",
                                   status_code=410,
                                   response_body="Invalid UAID",
+                                  log_exception=False,
                                   errno=105)
 
         # Verify there's a node_id in here, if not we're done

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -73,7 +73,7 @@ class WebPushRouter(SimpleRouter):
         month_table = uaid_data["current_month"]
         if month_table not in self.ap_settings.message_tables:
             self.log.info("'current_month' out of scope: {record}",
-                          records=json.dumps(uaid_data))
+                          record=json.dumps(uaid_data))
             yield deferToThread(self.ap_settings.router.drop_user, uaid)
             raise RouterException("No such subscription", status_code=410,
                                   log_exception=False, errno=106)
@@ -84,7 +84,7 @@ class WebPushRouter(SimpleRouter):
         if (not exists or channel_id.lower() not
                 in map(lambda x: normalize_id(x), chans)):
             self.log.info("Unknown subscription: {channel_id}",
-                          channelid=channel_id)
+                          channel_id=channel_id)
             raise RouterException("No such subscription", status_code=410,
                                   log_exception=False, errno=106)
         returnValue(month_table)

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -302,7 +302,12 @@ class WebPushRequestSchema(Schema):
         if auth_type.lower() != AUTH_SCHEME or '.' not in token:
             return
 
-        jwt = extract_jwt(token, public_key)
+        try:
+            jwt = extract_jwt(token, public_key)
+        except ValueError:
+            raise InvalidRequest("Invalid Authorization Header",
+                                 status_code=401, errno=109,
+                                 headers={"www-authenticate": AUTH_SCHEME})
         if jwt.get('exp', 0) < time.time():
             raise InvalidRequest("Invalid bearer token: Auth expired",
                                  status_code=401, errno=109,


### PR DESCRIPTION
A bad or improperly formatted VAPID object may generate a ValueError.
While important, and notable to the originator, this does not need to go
into Sentry.

Also fixes some logging formatting errors

closes #562 

@bbangert, @pjenvey r?