### PR TITLE
bug: Fix up FCM library to reject enpdoints with invalid FCM senderids

### DIFF
--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -50,6 +50,14 @@ class FCMRouter(object):
         if "token" not in router_data:
             raise self._error("connect info missing FCM Instance 'token'",
                               status=401)
+        # router_token and router_data['token'] are semi-legacy from when
+        # we were considering having multiple senderids for outbound
+        # GCM support. That was abandoned, but it is still useful to
+        # ensure that the client's senderid value matches what we need
+        # it to be. (If the client has an unexpected or invalid SenderID,
+        # it is impossible for us to reach them.
+        if not (router_token == router_data['token'] == self.senderID):
+            raise self._error("Invalid SenderID", status=410, errno=105)
         # Assign a senderid
         router_data["creds"] = {"senderID": self.senderID, "auth": self.auth}
         return router_data

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -626,13 +626,20 @@ class FCMRouterTestCase(unittest.TestCase):
         d.addBoth(check_results)
         return d
 
-    def test_ammend(self):
-        self.router.register("uaid", {"token": "connect_data"})
+    def test_amend(self):
+        self.router.register(uaid="uaid",
+                             router_data={"token": "test123"},
+                             router_token="test123")
         resp = {"key": "value"}
         result = self.router.amend_msg(resp,
                                        self.router_data.get('router_data'))
         eq_({"key": "value", "senderid": "test123"},
             result)
+
+    def test_register_invalid_token(self):
+        self.assertRaises(RouterException, self.router.register,
+                          uaid="uaid", router_data={"token": "invalid"},
+                          router_token="invalid")
 
 
 class SimplePushRouterTestCase(unittest.TestCase):


### PR DESCRIPTION
Closes #556 

(picks up spare from https://github.com/mozilla-services/autopush/pull/561)

@bbangert @pjenvey r?