### PR TITLE
Update dev endpoint

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,8 +54,8 @@ Firefox/FirefoxOS.
 dev
 ---
 
-* Websocket: wss://autopush-dev.stage.mozaws.net/
-* Endpoint: https://updates-autopush-dev.stage.mozaws.net/
+* Websocket: wss://autopush.dev.mozaws.net/
+* Endpoint: https://updates-autopush.dev.mozaws.net/
 
 stage
 -----


### PR DESCRIPTION
Was this move documented somewhere? updates-autopush-dev.stage.mozaws.net doesn't resolve anymore.

URLs from this page work https://wiki.mozilla.org/QA/Push_Notifications