### PR TITLE
bug: Do not remove router_type from UAID info

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -585,7 +585,7 @@ class Router(object):
         del data["uaid"]
         if "router_type" not in data or "connected_at" not in data:
             # Not specifying these values will generate an exception in AWS.
-            raise AutopushException("data is missing router_type"
+            raise AutopushException("data is missing router_type "
                                     "or connected_at")
         # Generate our update expression
         expr = "SET " + ", ".join(["%s=:%s" % (x, x) for x in data.keys()])

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -80,7 +80,10 @@ class TestWebpushHandler(unittest.TestCase):
         def handle_finish(result):
             eq_(result, True)
             self.wp.set_status.assert_called_with(503)
-            assert(self.router_mock.register_user.called)
+            ru = self.router_mock.register_user
+            assert(ru.called)
+            eq_('webpush', ru.call_args[0][0].get('router_type'))
+
         self.finish_deferred.addCallback(handle_finish)
 
         self.wp.post("v1", dummy_token)

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -60,7 +60,6 @@ class WebPushHandler(BaseHandler):
         if response.router_data is not None:
             if not response.router_data:
                 del uaid_data["router_data"]
-                del uaid_data["router_type"]
             else:
                 uaid_data["router_data"] = response.router_data
             uaid_data["connected_at"] = ms_time()


### PR DESCRIPTION
Webpush web handler should not remove router_type from UAID information.

Also fixed error message formatting and added appropriate test to ensure
that router_type persists.

closes #549 

@bbangert, @pjenvey r?