### PR TITLE
bug: Update FCM handler to more accurately reflect API

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -41,6 +41,7 @@ pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycparser==2.14
 pycrypto==2.6.1
+pyfcm==1.0.2
 pyflakes==1.2.3
 python-dateutil==2.5.3
 python-jose==0.6.1

--- a/pypy-requirements.txt
+++ b/pypy-requirements.txt
@@ -40,6 +40,7 @@ pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycparser==2.14
 pycrypto==2.6.1
+pyfcm==1.0.2
 pyflakes==1.2.3
 python-dateutil==2.5.3
 python-jose==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycparser==2.14
 pycrypto==2.6.1
+pyfcm==1.0.2
 pyflakes==1.2.3
 python-dateutil==2.5.3
 python-jose==0.6.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -48,6 +48,7 @@ pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycparser==2.14
 pycrypto==2.6.1
+pyfcm==1.0.2
 pyflakes==1.2.3
 python-dateutil==2.5.3
 python-jose==0.6.1


### PR DESCRIPTION
FCM, while compatible with GCM, has a much richer error handler. We
should also use a fcm specific bridging library.

closes #589 

@pjenvey r?