### PR TITLE
feat: Allow both "Bearer" and "WebPush" as Auth tokens

### DIFF
--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -793,7 +793,7 @@ class EndpointTestCase(unittest.TestCase):
                    "sub": "mailto:admin@example.com"}
 
         (token, crypto_key) = self._gen_jwt(header, payload)
-        auth = "Bearer %s" % token
+        auth = "WebPush %s" % token
         """ # to verify that the object is encoded correctly
 
             kd2 = utils.base64url_decode(crypto_key)
@@ -857,7 +857,7 @@ class EndpointTestCase(unittest.TestCase):
                    "sub": "mailto:admin@example.com"}
 
         (token, crypto_key) = self._gen_jwt(header, payload)
-        auth = "Bearer other_token"
+        auth = "WebPush other_token"
         self.request_mock.headers["crypto-key"] = "p256ecdsa=%s" % crypto_key
         self.request_mock.headers["authorization"] = auth
         self.router_mock.get_uaid.return_value = dict(
@@ -969,7 +969,7 @@ class EndpointTestCase(unittest.TestCase):
 
         (sig, crypto_key) = self._gen_jwt(header, payload)
         sigs = sig.split('.')
-        auth = "Bearer %s.%s.%s" % (sigs[0], sigs[1], "invalid")
+        auth = "WebPush %s.%s.%s" % (sigs[0], sigs[1], "invalid")
         self.request_mock.headers["crypto-key"] = "p256ecdsa=%s" % crypto_key
         self.request_mock.headers["authorization"] = auth
         self.router_mock.get_uaid.return_value = dict(
@@ -1003,7 +1003,7 @@ class EndpointTestCase(unittest.TestCase):
 
         (token, crypto_key) = self._gen_jwt(header, payload)
         self.request_mock.headers["crypto-key"] = "p256ecdsa=%s" % crypto_key
-        self.request_mock.headers["authorization"] = "Bearer %s" % token
+        self.request_mock.headers["authorization"] = "WebPush %s" % token
         self.router_mock.get_uaid.return_value = dict(
             router_type="webpush",
             router_data=dict(),
@@ -1391,7 +1391,7 @@ class RegistrationTestCase(unittest.TestCase):
 
         self.status_mock = self.reg.set_status = Mock()
         self.write_mock = self.reg.write = Mock()
-        self.auth = ("Bearer %s" %
+        self.auth = ("WebPush %s" %
                      generate_hash(self.reg.ap_settings.bear_hash_key[0],
                                    dummy_uaid))
 
@@ -1636,7 +1636,7 @@ class RegistrationTestCase(unittest.TestCase):
             self._check_error(401, 109, 'Unauthorized')
 
         self.finish_deferred.addCallback(handle_finish)
-        self.reg.request.headers["Authorization"] = "Bearer Invalid"
+        self.reg.request.headers["Authorization"] = "WebPush Invalid"
         self.reg.post(router_type="simplepush",
                       uaid=dummy_uaid, chid=dummy_chid)
         return self.finish_deferred

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -169,8 +169,10 @@ class TestBase(unittest.TestCase):
         eq_(d["message_ttl"], "0")
         eq_(d["authorization"], "bearer token fred")
         self.request_mock.headers["x-forwarded-for"] = "local2"
+        self.request_mock.headers["authorization"] = "webpush token barney"
         d = self.base._init_info()
         eq_(d["remote_ip"], "local2")
+        eq_(d["authorization"], "webpush token barney")
 
     def test_properties(self):
         eq_(self.base.uaid, "")

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -29,7 +29,9 @@ from autopush.utils import (
 )
 
 MAX_TTL = 60 * 60 * 24 * 60
-AUTH_SCHEME = "bearer"
+# Older versions used "bearer", newer specification requires "webpush"
+AUTH_SCHEMES = ["bearer", "webpush"]
+PREF_SCHEME = "webpush"
 
 
 class ThreadedValidate(object):
@@ -297,10 +299,10 @@ class WebPushRequestSchema(Schema):
         except ValueError:
             raise InvalidRequest("Invalid Authorization Header",
                                  status_code=401, errno=109,
-                                 headers={"www-authenticate": AUTH_SCHEME})
+                                 headers={"www-authenticate": PREF_SCHEME})
 
         # If its not a bearer token containing what may be JWT, stop
-        if auth_type.lower() != AUTH_SCHEME or '.' not in token:
+        if auth_type.lower() not in AUTH_SCHEMES or '.' not in token:
             return
 
         try:
@@ -308,11 +310,11 @@ class WebPushRequestSchema(Schema):
         except ValueError:
             raise InvalidRequest("Invalid Authorization Header",
                                  status_code=401, errno=109,
-                                 headers={"www-authenticate": AUTH_SCHEME})
+                                 headers={"www-authenticate": PREF_SCHEME})
         if jwt.get('exp', 0) < time.time():
             raise InvalidRequest("Invalid bearer token: Auth expired",
                                  status_code=401, errno=109,
-                                 headers={"www-authenticate": AUTH_SCHEME})
+                                 headers={"www-authenticate": PREF_SCHEME})
         jwt_crypto_key = base64url_encode(public_key)
         d["jwt"] = dict(jwt_crypto_key=jwt_crypto_key, jwt_data=jwt)
 

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -272,13 +272,13 @@ agent.
 
 Most calls to the HTTP interface require a Authorization header. The
 Authorization header is a bearer token, which has been provided by the
-**Registration** call and is preceded by the token type word "Bearer".
+**Registration** call and is preceded by the token type word "WebPush".
 
 An example of the Authorization header would be:
 
 ::
 
-    Authorization: Bearer 0123abcdef
+    Authorization: WebPush 0123abcdef
 
 Calls
 -----
@@ -347,7 +347,7 @@ Update the current bridge token value
 
 ::
 
-    Authorization: Bearer {auth_token}
+    Authorization: WebPush {auth_token}
 
 **Parameters:**
 
@@ -372,7 +372,7 @@ example:
 .. code-block:: http
 
     > PUT /v1/fcm/a1b2c3/registration/abcdef012345
-    > Authorization: Bearer 0123abcdef
+    > Authorization: WebPush 0123abcdef
     >
     > {"token": "5e6g7h8i"}
 
@@ -397,7 +397,7 @@ Acquire a new ChannelID for a given UAID.
 
 ::
 
-    Authorization: Bearer {auth_token}
+    Authorization: WebPush {auth_token}
 
 **Parameters:**
 
@@ -416,7 +416,7 @@ example:
 .. code-block:: http
 
     > POST /v1/fcm/a1b2c3/registration/abcdef012345/subscription
-    > Authorization: Bearer 0123abcdef
+    > Authorization: WebPush 0123abcdef
     >
     > {}
 
@@ -443,7 +443,7 @@ is no longer valid.
 
 ::
 
-    Authorization: Bearer {auth_token}
+    Authorization: WebPush {auth_token}
 
 **Parameters:**
 
@@ -471,7 +471,7 @@ Remove a given ChannelID subscription from a UAID.
 
 ::
 
-    Authorization: Bearer {auth_token}
+    Authorization: WebPush {auth_token}
 
 **Parameters:**
 


### PR DESCRIPTION
VAPID spec recently changed to specify "WebPush" as valid Authorization
token ID. Code allows either Bearer or WebPush while external code
transitions.

Closes #592 

@pjenvey, @kitcambridge r?