### PR TITLE
 feat: Validate Encryption/C-Key headers in preflight

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -529,6 +529,17 @@ class EndpointHandler(AutoendpointHandler):
                     400, 110, message="Invalid crypto headers")
                 return
             self._client_info["message_size"] = len(data) if data else 0
+            if ("crypto-key" in self.request.headers and
+                    "dh=" not in self.request.headers['crypto-key']):
+                self._write_response(
+                    401, 110, message="Crypto-Key header missing public-key "
+                    "'dh' value")
+                return
+            if ("encryption" in self.request.headers and
+                    "salt=" not in self.request.headers['encryption']):
+                self._write_response(
+                    401, 110, message="Encryption header missing 'salt' value")
+                return
 
         if "ttl" not in self.request.headers:
             ttl = None

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -208,7 +208,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
                     "Content-Type": "application/octet-stream",
                     "Content-Encoding": "aesgcm-128",
                     "Encryption": self._crypto_key,
-                    "Crypto-Key": 'keyid="a1"; key="JcqK-OLkJZlJ3sJJWstJCA"',
+                    "Crypto-Key": 'keyid="a1"; dh="JcqK-OLkJZlJ3sJJWstJCA"',
                 })
             if vapid:
                 headers.update({

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -278,6 +278,18 @@ class WebPushRequestSchema(Schema):
         req_fields = ["content-encoding", "encryption"]
         if d["body"] and not all([x in d["headers"] for x in req_fields]):
             raise InvalidRequest("Client error", errno=110)
+        if (d["headers"].get("crypto-key") and
+                "dh=" not in d["headers"]["crypto-key"]):
+                raise InvalidRequest(
+                    "Crypto-Key header missing public-key 'dh' value",
+                    status_code=401,
+                    errno=110)
+        if (d["headers"].get("encryption") and
+                "salt=" not in d["headers"]["encryption"]):
+                raise InvalidRequest(
+                    "Encryption header missing 'salt' value",
+                    status_code=401,
+                    errno=110)
 
     @pre_load
     def token_prep(self, d):


### PR DESCRIPTION
Check the encryption headers to make sure they're roughly valid before
passing them on to the client.

Closes #456

@pjenvey r?