### PR TITLE
fix: return 404 for invalid URL's for consistency

### DIFF
--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -5,7 +5,6 @@ from txstatsd.metrics.metrics import Metrics
 
 import datadog
 from datadog import ThreadStats
-from datadog.util.hostname import get_hostname
 
 
 class IMetrics(object):
@@ -70,13 +69,14 @@ class TwistedMetrics(object):
 
 class DatadogMetrics(object):
     """DataDog Metric backend"""
-    def __init__(self, api_key, app_key, flush_interval=10,
+    def __init__(self, api_key, app_key, hostname, flush_interval=10,
                  namespace="autopush"):
 
-        datadog.initialize(api_key=api_key, app_key=app_key)
+        datadog.initialize(api_key=api_key, app_key=app_key,
+                           host_name=hostname)
         self._client = ThreadStats()
         self._flush_interval = flush_interval
-        self._host = get_hostname()
+        self._host = hostname
         self._namespace = namespace
 
     def _prefix_name(self, name):

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -100,17 +100,6 @@ class AutopushSettings(object):
         pool = HTTPConnectionPool(reactor)
         self.agent = Agent(reactor, connectTimeout=5, pool=pool)
 
-        # Metrics setup
-        if datadog_api_key:
-            self.metrics = DatadogMetrics(
-                api_key=datadog_api_key,
-                app_key=datadog_app_key,
-                flush_interval=datadog_flush_interval
-            )
-        elif statsd_host:
-            self.metrics = TwistedMetrics(statsd_host, statsd_port)
-        else:
-            self.metrics = SinkMetrics()
         if not crypto_key:
             crypto_key = [Fernet.generate_key()]
         if not isinstance(crypto_key, list):
@@ -132,6 +121,19 @@ class AutopushSettings(object):
         self.hostname = hostname or default_hostname
         if resolve_hostname:
             self.hostname = resolve_ip(self.hostname)
+
+        # Metrics setup
+        if datadog_api_key:
+            self.metrics = DatadogMetrics(
+                hostname=self.hostname,
+                api_key=datadog_api_key,
+                app_key=datadog_app_key,
+                flush_interval=datadog_flush_interval,
+            )
+        elif statsd_host:
+            self.metrics = TwistedMetrics(statsd_host, statsd_port)
+        else:
+            self.metrics = SinkMetrics()
 
         self.port = port
         self.endpoint_hostname = endpoint_hostname or self.hostname

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -1318,7 +1318,7 @@ class TestWebPush(IntegrationBase):
 
         yield client.send_notification(
             vapid=vapid,
-            status=400)
+            status=404)
 
         yield self.shut_down(client)
 

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -5,8 +5,6 @@ import twisted.internet.base
 from nose.tools import ok_, eq_
 from mock import Mock, patch
 
-from datadog.util.hostname import get_hostname
-
 from autopush.metrics import (
     IMetrics,
     DatadogMetrics,
@@ -52,9 +50,10 @@ class TwistedMetricsTestCase(unittest.TestCase):
 class DatadogMetricsTestCase(unittest.TestCase):
     @patch("autopush.metrics.datadog")
     def test_basic(self, mock_dog):
-        hostname = get_hostname()
+        hostname = "localhost"
 
-        m = DatadogMetrics("someapikey", "someappkey", namespace="testpush")
+        m = DatadogMetrics("someapikey", "someappkey", namespace="testpush",
+                           hostname="localhost")
         ok_(len(mock_dog.mock_calls) > 0)
         m._client = Mock()
         m.start()

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -199,7 +199,7 @@ class WebPushSubscriptionSchema(Schema):
                 ckey_header=d["ckey_header"],
             )
         except (InvalidTokenException, InvalidToken):
-            raise InvalidRequest("invalid token", errno=102)
+            raise InvalidRequest("invalid token", status_code=404, errno=102)
         return result
 
     @validates_schema(skip_on_field_errors=True)

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -89,7 +89,6 @@ Unless otherwise specified, all calls return the following error codes:
 -  400 - Bad Parameters
 
    - errno 101 - Missing neccessary crypto keys
-   - errno 102 - Invalid URL endpoint
    - errno 108 - Router type is invalid
    - errno 110 - Invalid crypto keys specified
    - errno 111 - Missing Required Header
@@ -102,6 +101,10 @@ Unless otherwise specified, all calls return the following error codes:
 -  401 - Bad Authorization
 
    - errno 109 - Invalid authentication
+
+- 404 - Not Found
+
+   - errno 102 - Invalid URL endpoint
 
 -  410 - `{UAID}` or `{CHID}` not found
 


### PR DESCRIPTION
URL's that are invalid should return a 404, just like any other
invalid URL.

Closes #578