### PR TITLE
feat: Code cleanup

### DIFF
--- a/autopush/crypto_key.py
+++ b/autopush/crypto_key.py
@@ -31,14 +31,14 @@ http://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00#section-4
         chunks = header.split(",")
         for chunk in chunks:
             bits = chunk.split(";")
-            hash = {}
+            ck_hash = {}
             for bit in bits:
                 try:
                     (key, value) = bit.split("=", 1)
                 except ValueError:
                     raise CryptoKeyException("Invalid Crypto Key value")
-                hash[key.strip()] = value.strip(' "')
-            self._values.append(hash)
+                ck_hash[key.strip()] = value.strip(' "')
+            self._values.append(ck_hash)
 
     def get_keyid(self, keyid):
         """Return the Crypto-Key hash referred to by a given keyid.

--- a/autopush/diagnostic_cli.py
+++ b/autopush/diagnostic_cli.py
@@ -13,7 +13,7 @@ from autopush.main import (
 from autopush.settings import AutopushSettings
 
 
-PUSH_RE = re.compile(r"push/(?:(?P<api_ver>v\d+)\/)?(?P<token>[^\/]+)")
+PUSH_RE = re.compile(r"push/(?:(?P<api_ver>v\d+)/)?(?P<token>[^/]+)")
 
 
 class EndpointDiagnosticCLI(object):

--- a/autopush/health.py
+++ b/autopush/health.py
@@ -1,5 +1,6 @@
 """Health Check HTTP Handler"""
 import cyclone.web
+from autopush.endpoint import AutoendpointHandler
 
 from boto.dynamodb2.exceptions import (
     InternalServerError,
@@ -16,9 +17,12 @@ class MissingTableException(Exception):
     pass
 
 
-class HealthHandler(cyclone.web.RequestHandler):
+class HealthHandler(AutoendpointHandler):
     """HTTP Health Handler"""
     log = Logger()
+
+    def initialize(self, ap_settings):
+        self.ap_settings = ap_settings
 
     @cyclone.web.asynchronous
     def get(self):

--- a/autopush/log_check.py
+++ b/autopush/log_check.py
@@ -17,26 +17,26 @@ class LogCheckHandler(AutoendpointHandler):
         self._client_info = self._init_info()
 
     @cyclone.web.asynchronous
-    def get(self, errType=None):
+    def get(self, err_type=None):
         """HTTP GET
 
         Generate a dummy error message for logging
 
         """
-        if not errType:
-            errType = "error"
+        if not err_type:
+            err_type = "error"
         else:
-            errType = errType.lower()
-        if 'error' in errType:
+            err_type = err_type.lower()
+        if 'error' in err_type:
             self.log.error(format="Test Error Message",
                            status_code=418, errno=0,
                            **self._client_info)
             self._write_response(418, 999, message="ERROR:Success",
                                  reason="Test Error")
-        if 'crit' in errType:
+        if 'crit' in err_type:
             try:
                 raise LogCheckError("LogCheck")
-            except:
+            except LogCheckError:
                 self.log.failure(format="Test Critical Message",
                                  status_code=418, errno=0,
                                  **self._client_info)

--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -70,7 +70,7 @@ class PushLogger(object):
             self._output = None
         else:
             self._filename = log_output
-            self._output = "file"
+            self._output = None
         if log_format == "json":
             self.format_event = self.json_format
         else:

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -321,7 +321,7 @@ def make_settings(args, **kwargs):
     if args.gcm_enabled:
         # Create a common gcmclient
         try:
-            senderIDs = json.loads(args.senderid_list)
+            sender_ids = json.loads(args.senderid_list)
         except (ValueError, TypeError):
             log.critical(format="Invalid JSON specified for senderid_list")
             return
@@ -329,7 +329,7 @@ def make_settings(args, **kwargs):
             # This is an init check to verify that things are configured
             # correctly. Otherwise errors may creep in later that go
             # unaccounted.
-            senderIDs[senderIDs.keys()[0]]
+            sender_ids[sender_ids.keys()[0]]
         except (IndexError, TypeError):
             log.critical(format="No GCM SenderIDs specified or found.")
             return
@@ -337,7 +337,7 @@ def make_settings(args, **kwargs):
                               "dryrun": args.gcm_dryrun,
                               "max_data": args.max_data,
                               "collapsekey": args.gcm_collapsekey,
-                              "senderIDs": senderIDs}
+                              "senderIDs": sender_ids}
     if args.fcm_enabled:
         # Create a common gcmclient
         if not args.fcm_auth:
@@ -471,26 +471,26 @@ def connection_main(sysargs=None, use_files=True):
     # other requests.
     resource = DefaultResource(WebSocketResource(factory))
     resource.putChild("status", StatusResource())
-    siteFactory = Site(resource)
+    site_factory = Site(resource)
 
     # Start the WebSocket listener.
     if args.ssl_key:
-        contextFactory = AutopushSSLContextFactory(args.ssl_key,
-                                                   args.ssl_cert)
+        context_factory = AutopushSSLContextFactory(args.ssl_key,
+                                                    args.ssl_cert)
         if args.ssl_dh_param:
-            contextFactory.getContext().load_tmp_dh(args.ssl_dh_param)
+            context_factory.getContext().load_tmp_dh(args.ssl_dh_param)
 
-        reactor.listenSSL(args.port, siteFactory, contextFactory)
+        reactor.listenSSL(args.port, site_factory, context_factory)
     else:
-        reactor.listenTCP(args.port, siteFactory)
+        reactor.listenTCP(args.port, site_factory)
 
     # Start the internal routing listener.
     if args.router_ssl_key:
-        contextFactory = AutopushSSLContextFactory(args.router_ssl_key,
-                                                   args.router_ssl_cert)
+        context_factory = AutopushSSLContextFactory(args.router_ssl_key,
+                                                    args.router_ssl_cert)
         if args.ssl_dh_param:
-            contextFactory.getContext().load_tmp_dh(args.ssl_dh_param)
-        reactor.listenSSL(args.router_port, site, contextFactory)
+            context_factory.getContext().load_tmp_dh(args.ssl_dh_param)
+        reactor.listenSSL(args.router_port, site, context_factory)
     else:
         reactor.listenTCP(args.router_port, site)
 
@@ -562,11 +562,11 @@ def endpoint_main(sysargs=None, use_files=True):
 
     # start the senderIDs refresh timer
     if args.ssl_key:
-        contextFactory = AutopushSSLContextFactory(args.ssl_key,
-                                                   args.ssl_cert)
+        context_factory = AutopushSSLContextFactory(args.ssl_key,
+                                                    args.ssl_cert)
         if args.ssl_dh_param:
-            contextFactory.getContext().load_tmp_dh(args.ssl_dh_param)
-        reactor.listenSSL(args.port, site, contextFactory)
+            context_factory.getContext().load_tmp_dh(args.ssl_dh_param)
+        reactor.listenSSL(args.port, site, context_factory)
     else:
         reactor.listenTCP(args.port, site)
 

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -162,7 +162,7 @@ class SimpleRouter(object):
             returnValue(self.delivered_response(notification))
         else:
             self.metrics.increment("router.broadcast.miss")
-            retVal = self.stored_response(notification)
+            ret_val = self.stored_response(notification)
             if self.udp is not None and "server" in self.conf:
                 # Attempt to send off the UDP wake request.
                 try:
@@ -175,7 +175,7 @@ class SimpleRouter(object):
                 except Exception as exc:
                     self.log.debug("Could not send UDP wake request: {exc}",
                                    exc=exc)
-            returnValue(retVal)
+            returnValue(ret_val)
 
     #############################################################
     #                    Blocking Helper Functions

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -163,7 +163,9 @@ class AutopushSettings(object):
             storage_read_throughput,
             storage_write_throughput)
         self.message_table = get_rotating_message_table(
-            message_tablename)
+            message_tablename,
+            message_read_throughput=message_read_throughput,
+            message_write_throughput=message_write_throughput)
         self._message_prefix = message_tablename
         self.storage = Storage(self.storage_table, self.metrics)
         self.router = Router(self.router_table, self.metrics)
@@ -188,7 +190,7 @@ class AutopushSettings(object):
         self.wake_timeout = wake_timeout
 
         # Setup the routers
-        self.routers = {}
+        self.routers = dict()
         self.routers["simplepush"] = SimpleRouter(
             self,
             router_conf.get("simplepush")
@@ -345,7 +347,7 @@ class AutopushSettings(object):
             label = crypto_key.get_label('p256ecdsa')
             try:
                 public_key = base64url_decode(label)
-            except:
+            except TypeError:
                 # Ignore missing and malformed app server keys.
                 pass
 

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -56,8 +56,8 @@ def tearDown():
 
 
 class FileConsumer(object):  # pragma: no cover
-    def __init__(self, file):
-        self.file = file
+    def __init__(self, fileObj):
+        self.file = fileObj
 
     def write(self, data):
         self.file.write(data)
@@ -1283,11 +1283,11 @@ class EndpointTestCase(unittest.TestCase):
         This is not code that is triggered within normal flow, but
         by the cyclone wrapper.
         """
-        class testX(Exception):
+        class TestX(Exception):
             pass
 
         try:
-            raise testX()
+            raise TestX()
         except:
             exc_info = sys.exc_info()
 

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -27,7 +27,7 @@ class HealthTestCase(unittest.TestCase):
         self.mock_dynamodb2 = mock_dynamodb2()
         self.mock_dynamodb2.start()
 
-        HealthHandler.ap_settings = self.settings = AutopushSettings(
+        ap_settings = self.settings = AutopushSettings(
             hostname="localhost",
             statsd_host=None,
         )
@@ -35,7 +35,9 @@ class HealthTestCase(unittest.TestCase):
         self.storage_table = self.settings.storage.table
 
         self.request_mock = Mock()
-        self.health = HealthHandler(Application(), self.request_mock)
+        self.health = HealthHandler(Application(),
+                                    self.request_mock,
+                                    ap_settings=ap_settings)
         self.health.log = self.log_mock = Mock(spec=Logger)
         self.status_mock = self.health.set_status = Mock()
         self.write_mock = self.health.write = Mock()

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -119,7 +119,7 @@ class PushLoggerTestCase(twisted.trial.unittest.TestCase):
     def test_file_output(self):
         try:
             os.unlink("testfile.txt")
-        except:  # pragma: nocover
+        except OSError:  # pragma: nocover
             pass
         obj = PushLogger.setup_logging("Autoput", log_output="testfile.txt")
         obj.start()

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -179,7 +179,7 @@ class ConnectionMainTestCase(unittest.TestCase):
 
 
 class EndpointMainTestCase(unittest.TestCase):
-    class test_arg:
+    class TestArg:
         # important stuff
         apns_enabled = True
         apns_cert_file = "cert.file"
@@ -257,33 +257,33 @@ class EndpointMainTestCase(unittest.TestCase):
         ], False)
 
     def test_ping_settings(self):
-        ap = make_settings(self.test_arg)
+        ap = make_settings(self.TestArg)
         # verify that the hostname is what we said.
-        eq_(ap.hostname, self.test_arg.hostname)
+        eq_(ap.hostname, self.TestArg.hostname)
         # gcm isn't created until later since we may have to pull
         # config info from s3
-        eq_(ap.routers["apns"].apns.cert_file, self.test_arg.apns_cert_file)
-        eq_(ap.routers["apns"].apns.key_file, self.test_arg.apns_key_file)
+        eq_(ap.routers["apns"].apns.cert_file, self.TestArg.apns_cert_file)
+        eq_(ap.routers["apns"].apns.key_file, self.TestArg.apns_key_file)
         eq_(ap.wake_timeout, 10)
 
     def test_bad_senders(self):
-        oldList = self.test_arg.senderid_list
-        self.test_arg.senderid_list = "{}"
-        ap = make_settings(self.test_arg)
+        old_list = self.TestArg.senderid_list
+        self.TestArg.senderid_list = "{}"
+        ap = make_settings(self.TestArg)
         eq_(ap, None)
-        self.test_arg.senderid_list = oldList
+        self.TestArg.senderid_list = old_list
 
     def test_bad_fcm_senders(self):
-        old_auth = self.test_arg.fcm_auth
-        old_senderid = self.test_arg.fcm_senderid
-        self.test_arg.fcm_auth = ""
-        ap = make_settings(self.test_arg)
+        old_auth = self.TestArg.fcm_auth
+        old_senderid = self.TestArg.fcm_senderid
+        self.TestArg.fcm_auth = ""
+        ap = make_settings(self.TestArg)
         eq_(ap, None)
-        self.test_arg.fcm_auth = old_auth
-        self.test_arg.fcm_senderid = ""
-        ap = make_settings(self.test_arg)
+        self.TestArg.fcm_auth = old_auth
+        self.TestArg.fcm_senderid = ""
+        ap = make_settings(self.TestArg)
         eq_(ap, None)
-        self.test_arg.fcm_senderid = old_senderid
+        self.TestArg.fcm_senderid = old_senderid
 
     def test_gcm_start(self):
         endpoint_main([
@@ -294,10 +294,10 @@ class EndpointMainTestCase(unittest.TestCase):
 
     @patch("requests.get")
     def test_aws_ami_id(self, request_mock):
-        class m_reply:
+        class MockReply:
             content = "ami_123"
 
-        request_mock.return_value = m_reply
-        self.test_arg.no_aws = False
-        ap = make_settings(self.test_arg)
+        request_mock.return_value = MockReply
+        self.TestArg.no_aws = False
+        ap = make_settings(self.TestArg)
         eq_(ap.ami_id, "ami_123")

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -338,10 +338,10 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_long_data(self):
         self.router.gcm['test123'] = self.gcm
-        badNotif = Notification(
+        bad_notif = Notification(
             10, "\x01abcdefghijklmnopqrstuvwxyz0123456789", dummy_chid,
             self.headers, 200)
-        d = self.router.route_notification(badNotif, self.router_data)
+        d = self.router.route_notification(bad_notif, self.router_data)
 
         def check_results(result):
             ok_(isinstance(result.value, RouterException))
@@ -589,10 +589,10 @@ class FCMRouterTestCase(unittest.TestCase):
 
     def test_long_data(self):
         self.router.fcm = self.fcm
-        badNotif = Notification(
+        bad_notif = Notification(
             10, "\x01abcdefghijklmnopqrstuvwxyz0123456789", dummy_chid,
             self.headers, 200)
-        d = self.router.route_notification(badNotif, self.router_data)
+        d = self.router.route_notification(bad_notif, self.router_data)
 
         def check_results(result):
             ok_(isinstance(result.value, RouterException))

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -135,11 +135,11 @@ class TestBase(unittest.TestCase):
         This is not code that is triggered within normal flow, but
         by the cyclone wrapper.
         """
-        class testX(Exception):
+        class TestX(Exception):
             pass
 
         try:
-            raise testX()
+            raise TestX()
         except:
             exc_info = sys.exc_info()
 
@@ -191,7 +191,7 @@ class TestBase(unittest.TestCase):
     def test_validation_error(self):
         try:
             raise InvalidRequest("oops", errno=110)
-        except:
+        except InvalidRequest:
             fail = Failure()
         self.base._validation_err(fail)
         self.status_mock.assert_called_with(400)
@@ -199,7 +199,7 @@ class TestBase(unittest.TestCase):
     def test_response_err(self):
         try:
             raise Exception("oops")
-        except:
+        except Exception:
             fail = Failure()
         self.base._response_err(fail)
         self.status_mock.assert_called_with(500)
@@ -207,7 +207,7 @@ class TestBase(unittest.TestCase):
     def test_overload_err(self):
         try:
             raise ProvisionedThroughputExceededException("error", None, None)
-        except:
+        except ProvisionedThroughputExceededException:
             fail = Failure()
         self.base._overload_err(fail)
         self.status_mock.assert_called_with(503)
@@ -215,7 +215,7 @@ class TestBase(unittest.TestCase):
     def test_boto_err(self):
         try:
             raise BotoServerError(503, "derp")
-        except:
+        except BotoServerError:
             fail = Failure()
         self.base._boto_err(fail)
         self.status_mock.assert_called_with(503)
@@ -238,7 +238,7 @@ class TestBase(unittest.TestCase):
 
         try:
             raise RouterException("error")
-        except:
+        except RouterException:
             fail = Failure()
         self.base._router_fail_err(fail)
         self.status_mock.assert_called_with(500)
@@ -248,7 +248,7 @@ class TestBase(unittest.TestCase):
 
         try:
             raise RouterException("Abort Ok", status_code=200)
-        except:
+        except RouterException:
             fail = Failure()
         self.base._router_fail_err(fail)
         self.status_mock.assert_called_with(200)
@@ -258,7 +258,7 @@ class TestBase(unittest.TestCase):
 
         try:
             raise RouterException("Abort Ok", status_code=400)
-        except:
+        except RouterException:
             fail = Failure()
         self.base._router_fail_err(fail)
         self.status_mock.assert_called_with(400)

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -45,24 +45,24 @@ class InvalidSchema(Schema):
 
 
 class TestThreadedValidate(unittest.TestCase):
-    def _makeFUT(self, schema):
+    def _make_fut(self, schema):
         from autopush.web.validation import ThreadedValidate
         return ThreadedValidate(schema)
 
-    def _makeBasicSchema(self):
+    def _make_basic_schema(self):
 
         class Basic(Schema):
             pass
 
         return Basic
 
-    def _makeDummyRequest(self, method="GET", uri="/", **kwargs):
+    def _make_dummy_request(self, method="GET", uri="/", **kwargs):
         from cyclone.httpserver import HTTPRequest
         req = HTTPRequest(method, uri, **kwargs)
         req.connection = Mock()
         return req
 
-    def _makeReqHandler(self, request):
+    def _make_req_handler(self, request):
         self._mock_errors = Mock()
         from cyclone.web import RequestHandler
 
@@ -78,37 +78,37 @@ class TestThreadedValidate(unittest.TestCase):
         vr.ap_settings = Mock()
         return vr
 
-    def _makeFull(self, schema=None):
-        req = self._makeDummyRequest()
+    def _make_full(self, schema=None):
+        req = self._make_dummy_request()
         if not schema:
-            schema = self._makeBasicSchema()
-        tv = self._makeFUT(schema)
-        rh = self._makeReqHandler(req)
+            schema = self._make_basic_schema()
+        tv = self._make_fut(schema)
+        rh = self._make_req_handler(req)
 
         return tv, rh
 
     def test_validate_load(self):
-        tv, rh = self._makeFull()
+        tv, rh = self._make_full()
         d, errors = tv._validate_request(rh)
         eq_(errors, {})
         eq_(d, {})
 
     def test_validate_invalid_schema(self):
-        tv, rh = self._makeFull(schema=InvalidSchema)
+        tv, rh = self._make_full(schema=InvalidSchema)
         d, errors = tv._validate_request(rh)
         ok_("afield" in errors)
         eq_(d, {})
 
     def test_call_func_no_error(self):
         mock_func = Mock()
-        tv, rh = self._makeFull()
+        tv, rh = self._make_full()
         result = tv._validate_request(rh)
         tv._call_func(result, mock_func, rh)
         mock_func.assert_called()
 
     def test_call_func_error(self):
         mock_func = Mock()
-        tv, rh = self._makeFull(schema=InvalidSchema)
+        tv, rh = self._make_full(schema=InvalidSchema)
         result = tv._validate_request(rh)
         tv._call_func(result, mock_func, rh)
         self._mock_errors.assert_called()
@@ -117,7 +117,7 @@ class TestThreadedValidate(unittest.TestCase):
     def test_decorator(self):
         from cyclone.web import RequestHandler
         from autopush.web.validation import threaded_validate
-        schema = self._makeBasicSchema()
+        schema = self._make_basic_schema()
 
         class AHandler(RequestHandler):
             @threaded_validate(schema)
@@ -125,7 +125,7 @@ class TestThreadedValidate(unittest.TestCase):
                 self.write("done")
                 self.finish()
 
-        req = self._makeDummyRequest()
+        req = self._make_dummy_request()
         app = Mock()
         app.ui_modules = dict()
         app.ui_methods = dict()
@@ -152,7 +152,7 @@ class TestThreadedValidate(unittest.TestCase):
 
 
 class TestSimplePushRequestSchema(unittest.TestCase):
-    def _makeFUT(self):
+    def _make_fut(self):
         from autopush.web.validation import SimplePushRequestSchema
         schema = SimplePushRequestSchema()
         schema.context["settings"] = Mock()
@@ -170,7 +170,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         )
 
     def test_valid_data(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -185,7 +185,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         eq_(str(result["subscription"]["uaid"]), dummy_uaid)
 
     def test_valid_data_in_body(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -202,7 +202,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         eq_(str(result["subscription"]["uaid"]), dummy_uaid)
 
     def test_valid_version(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -220,7 +220,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         eq_(str(result["subscription"]["uaid"]), dummy_uaid)
 
     def test_invalid_router_type(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -236,7 +236,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 108)
 
     def test_invalid_uaid_not_found(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -254,7 +254,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 103)
 
     def test_invalid_token(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
 
         def throw_item(*args, **kwargs):
             raise InvalidTokenException("Not found")
@@ -267,7 +267,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 102)
 
     def test_invalid_data_size(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -285,7 +285,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
 
 
 class TestWebPushRequestSchema(unittest.TestCase):
-    def _makeFUT(self):
+    def _make_fut(self):
         from autopush.web.validation import WebPushRequestSchema
         schema = WebPushRequestSchema()
         schema.context["settings"] = Mock()
@@ -303,7 +303,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
 
     def test_valid_data(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -318,7 +318,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(str(result["subscription"]["uaid"]), dummy_uaid)
 
     def test_no_headers(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -333,7 +333,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(errors, {'headers': {'ttl': [u'Not a valid integer.']}})
 
     def test_invalid_simplepush_user(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -349,7 +349,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 108)
 
     def test_invalid_token(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
 
         def throw_item(*args, **kwargs):
             raise InvalidTokenException("Not found")
@@ -362,7 +362,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 102)
 
     def test_invalid_fernet_token(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
 
         def throw_item(*args, **kwargs):
             raise InvalidToken
@@ -375,7 +375,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 102)
 
     def test_invalid_uaid_not_found(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -393,7 +393,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 103)
 
     def test_critical_failure(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -410,7 +410,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 105)
 
     def test_invalid_header_combo(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -442,7 +442,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 110)
 
     def test_invalid_data_size(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -459,7 +459,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 104)
 
     def test_invalid_data_must_have_crypto_headers(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -475,7 +475,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(cm.exception.errno, 110)
 
     def test_valid_data_crypto_padding_stripped(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -501,7 +501,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         eq_(result["headers"]["encryption"], "salt=asdfjiasljdf")
 
     def test_invalid_vapid_crypto_header(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         schema.context["settings"].parse_endpoint.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
@@ -528,7 +528,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
 
 
 class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
-    def _makeFUT(self):
+    def _make_fut(self):
         from autopush.web.validation import WebPushRequestSchema
         from autopush.settings import AutopushSettings
         schema = WebPushRequestSchema()
@@ -562,7 +562,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         return sig, crypto_key
 
     def test_valid_vapid_crypto_header(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
 
         header = {"typ": "JWT", "alg": "ES256"}
@@ -592,7 +592,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         ok_("jwt" in result)
 
     def test_valid_vapid_crypto_header_webpush(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
 
         header = {"typ": "JWT", "alg": "ES256"}
@@ -623,7 +623,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
 
     @patch("autopush.web.validation.extract_jwt")
     def test_invalid_vapid_crypto_header(self, mock_jwt):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
         mock_jwt.side_effect = ValueError("Unknown public key "
                                           "format specified")
@@ -658,7 +658,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
 
     @patch("autopush.web.validation.extract_jwt")
     def test_invalid_encryption_header(self, mock_jwt):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
         mock_jwt.side_effect = ValueError("Unknown public key "
                                           "format specified")
@@ -693,7 +693,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
 
     @patch("autopush.web.validation.extract_jwt")
     def test_invalid_encryption_jwt(self, mock_jwt):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
         # use a deeply superclassed error to make sure that it gets picked up.
         mock_jwt.side_effect = JWTClaimsError("invalid claim")
@@ -728,7 +728,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
 
     @patch("autopush.web.validation.extract_jwt")
     def test_invalid_crypto_key_header_content(self, mock_jwt):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
         mock_jwt.side_effect = ValueError("Unknown public key "
                                           "format specified")
@@ -762,7 +762,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         eq_(cm.exception.errno, 110)
 
     def test_expired_vapid_header(self):
-        schema = self._makeFUT()
+        schema = self._make_fut()
         self.fernet_mock.decrypt.return_value = dummy_token
 
         header = {"typ": "JWT", "alg": "ES256"}

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -194,7 +194,7 @@ class WebsocketTestCase(unittest.TestCase):
     def test_headers_locate(self):
         from autobahn.websocket.protocol import ConnectionRequest
         req = ConnectionRequest("localhost", {"user-agent": "Me"},
-                                "localhost", "/", {}, "1", "localhost",
+                                "localhost", "/", {}, 1, "localhost",
                                 [], [])
         self.proto.onConnect(req)
         eq_(self.proto.ps._user_agent, "Me")
@@ -818,9 +818,9 @@ class WebsocketTestCase(unittest.TestCase):
 
         def check_result(msg):
             eq_(msg["status"], 200)
-            routeData = self.proto.ap_settings.router.get_uaid(
+            route_data = self.proto.ap_settings.router.get_uaid(
                 msg["uaid"]).get('wake_data')
-            eq_(routeData, {
+            eq_(route_data, {
                 'data': {"ip": "127.0.0.1", "port": 9999, "mcc": "hammer",
                          "mnc": "banana", "netid": "gorp"}})
         return self._check_response(check_result)
@@ -905,14 +905,14 @@ class WebsocketTestCase(unittest.TestCase):
         ok_(self.proto.ps.ping_time_out, True)
         ok_(self.proto.dropConnection.called)
 
-    def test_deferToLater(self):
+    def test_defer_to_later(self):
         self._connect()
 
         def fail():
             raise twisted.internet.defer.CancelledError
 
-        def fail2(fail):
-            self.assertTrue(fail)
+        def fail2(failure):
+            self.assertTrue(failure)
 
         def check_result(result):  # pragma: nocover
             pass
@@ -922,7 +922,7 @@ class WebsocketTestCase(unittest.TestCase):
         d.addErrback(fail2)
         ok_(d is not None)
 
-    def test_deferToLater_cancel(self):
+    def test_defer_to_later_cancel(self):
         self._connect()
 
         f = Deferred()
@@ -1022,15 +1022,15 @@ class WebsocketTestCase(unittest.TestCase):
                          test_sha)
         self.proto.sendJSON = Mock()
 
-        def echo(str):
-            return str.encode('hex')
+        def echo(string):
+            return string.encode('hex')
 
         self.proto.ap_settings.fernet.encrypt = echo
 
         d = Deferred()
 
-        def check_register_result(msg, test_endpoint):
-            eq_(test_endpoint,
+        def check_register_result(msg, endpoint):
+            eq_(endpoint,
                 self.proto.sendJSON.call_args[0][0]['pushEndpoint'])
             assert self.proto.ap_settings.message.register_channel.called
             assert_called_included(self.proto.log.info, format="Register")
@@ -1158,26 +1158,26 @@ class WebsocketTestCase(unittest.TestCase):
         self._connect()
         mock_agent = Mock()
         self.proto.ap_settings.agent = mock_agent
-        nodeId = "http://otherhost"
+        node_id = "http://otherhost"
         uaid = "deadbeef000000000000000000000000"
         self.proto.ps.uaid = uaid
         connected = int(time.time())
-        res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
+        res = dict(node_id=node_id, connected_at=connected, uaid=uaid)
         self.proto._check_other_nodes((True, res, None))
         mock_agent.request.assert_called_with(
             "DELETE",
-            "%s/notif/%s/%s" % (nodeId, uaid, connected))
+            "%s/notif/%s/%s" % (node_id, uaid, connected))
 
     def test_register_kill_others_fail(self):
         self._connect()
 
         d = Deferred()
         self.proto.ap_settings.agent.request.return_value = d
-        nodeId = "http://otherhost"
+        node_id = "http://otherhost"
         uaid = "deadbeef000000000000000000000000"
         self.proto.ps.uaid = uaid
         connected = int(time.time())
-        res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
+        res = dict(node_id=node_id, connected_at=connected, uaid=uaid)
         self.proto._check_other_nodes((True, res, None))
         d.errback(ConnectError())
         return d
@@ -1186,7 +1186,7 @@ class WebsocketTestCase(unittest.TestCase):
         self._connect()
         mock_agent = Mock()
         self.proto.ap_settings.agent = mock_agent
-        nodeId = "http://localhost"
+        node_id = "http://localhost"
         uaid = "deadbeef000000000000000000000000"
         # Test that the 'existing' connection is newer than the current one.
         connected = int(time.time() * 1000)
@@ -1197,7 +1197,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.sendClose = Mock()
         self.proto.sendClose = Mock()
         self.proto.ps.uaid = uaid
-        res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
+        res = dict(node_id=node_id, connected_at=connected, uaid=uaid)
         self.proto._check_other_nodes((True, res, None))
         # the current one should be dropped.
         eq_(ff.sendClose.call_count, 0)
@@ -1207,7 +1207,7 @@ class WebsocketTestCase(unittest.TestCase):
         self._connect()
         mock_agent = Mock()
         self.proto.ap_settings.agent = mock_agent
-        nodeId = "http://localhost"
+        node_id = "http://localhost"
         uaid = "deadbeef000000000000000000000000"
         # Test that the 'existing' connection is older than the current one.
         connected = int(time.time() * 1000)
@@ -1217,7 +1217,7 @@ class WebsocketTestCase(unittest.TestCase):
         self.proto.ap_settings.clients = {uaid: ff}
         self.proto.sendClose = Mock()
         self.proto.ps.uaid = uaid
-        res = dict(node_id=nodeId, connected_at=connected, uaid=uaid)
+        res = dict(node_id=node_id, connected_at=connected, uaid=uaid)
         self.proto._check_other_nodes((True, res, None))
         # the existing one should be dropped.
         eq_(ff.sendClose.call_count, 1)

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -80,7 +80,7 @@ def repad(string):
     """Adds padding to strings for base64 decoding"""
 
     if len(string) % 4:
-        string = string + '===='[len(string) % 4:]
+        string += '===='[len(string) % 4:]
     return string
 
 
@@ -103,7 +103,7 @@ def get_amid():
             "http://169.254.169.254/latest/meta-data/ami-id",
             timeout=1)
         return resp.content
-    except:
+    except (requests.HTTPError, requests.ConnectionError):
         return "Unknown"
 
 

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -170,7 +170,6 @@ class SimplePushRequestSchema(Schema):
     @pre_load
     def extract_fields(self, d):
         body_string = d["body"]
-        version = data = None
         if len(body_string) > 0:
             body_args = urlparse.parse_qs(body_string, keep_blank_values=True)
             version = body_args.get("version")


### PR DESCRIPTION
* replaces python reserved word var names
* replaces mixed case var names
* fixes setting chain breaks (message_read/write_throughput)
* removes unneeded var instantiations
* normalize HealthHandler to base from AutoendpointHandler, so
ap_settings is known
* instantiate from dict() rather than {}
* limit except handlers to known exceptions

issue #612