### PR TITLE
bug: limit max TTL for GCM/FCM

### DIFF
--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -20,6 +20,7 @@ class FCMRouter(object):
     gcm = None
     dryRun = 0
     collapseKey = "simplepush"
+    MAX_TTL = 2419200
     reasonTable = {
         "MissingRegistration": {
             "msg": ("'to' or 'registration_id' is blank or"
@@ -174,7 +175,8 @@ class FCMRouter(object):
 
         # registration_ids are the FCM instance tokens (specified during
         # registration.
-        router_ttl = max(self.min_ttl, notification.ttl or 0)
+        router_ttl = min(self.MAX_TTL,
+                         max(self.min_ttl, notification.ttl or 0))
         try:
             result = self.fcm.notify_single_device(
                 collapse_key=self.collapseKey,

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -14,6 +14,7 @@ class GCMRouter(object):
     log = Logger()
     dryRun = 0
     collapseKey = "simplepush"
+    MAX_TTL = 2419200
 
     def __init__(self, ap_settings, router_conf):
         """Create a new GCM router and connect to GCM"""
@@ -94,11 +95,12 @@ class GCMRouter(object):
 
         # registration_ids are the GCM instance tokens (specified during
         # registration.
-        router_ttl = notification.ttl or 0
+        router_ttl = min(self.MAX_TTL,
+                         max(notification.ttl or 0, self.min_ttl))
         payload = gcmclient.JSONMessage(
             registration_ids=[router_data.get("token")],
             collapse_key=self.collapseKey,
-            time_to_live=max(self.min_ttl, router_ttl),
+            time_to_live=router_ttl,
             dry_run=self.dryRun or ("dryrun" in router_data),
             data=data,
         )


### PR DESCRIPTION
Since this value is hard coded by Google, we can hard code it into
our bridge.

closes #615

@bbangert, @pjenvey r?