### PR TITLE
bug: do not try to JSON serialize log output

### DIFF
--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -1,6 +1,5 @@
 """GCM Router"""
 import gcmclient
-import json
 
 from twisted.internet.threads import deferToThread
 from twisted.logger import Logger
@@ -158,7 +157,7 @@ class GCMRouter(object):
             self.metrics.increment("updates.client.bridge.gcm.failed.failure",
                                    self._base_tags)
             self.log.info("GCM failures: {failed()}",
-                          failed=lambda: json.dumps(reply.failed.items()))
+                          failed=lambda: repr(reply.failed.items()))
             self.router_table.register_user(
                 {"uaid": uaid_data.get('uaid'),
                  "router_type": uaid_data.get("router_type", "gcm"),
@@ -173,7 +172,7 @@ class GCMRouter(object):
         # retries:
         if reply.needs_retry():
             self.log.warn("GCM retry requested: {failed()}",
-                          failed=lambda: json.dumps(reply.failed.items()))
+                          failed=lambda: repr(reply.failed.items()))
             self.metrics.increment("updates.client.bridge.gcm.failed.retry",
                                    self._base_tags)
             raise RouterException("GCM failure to deliver, retry",

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -65,7 +65,7 @@ class WebPushRouter(SimpleRouter):
         uaid = uaid_data["uaid"]
         if 'current_month' not in uaid_data:
             self.log.info("Record missing 'current_month' {record}",
-                          record=json.dumps(uaid_data))
+                          record=repr(uaid_data))
             yield deferToThread(self.ap_settings.router.drop_user, uaid)
             raise RouterException("No such subscription", status_code=410,
                                   log_exception=False, errno=106)
@@ -73,7 +73,7 @@ class WebPushRouter(SimpleRouter):
         month_table = uaid_data["current_month"]
         if month_table not in self.ap_settings.message_tables:
             self.log.info("'current_month' out of scope: {record}",
-                          record=json.dumps(uaid_data))
+                          record=repr(uaid_data))
             yield deferToThread(self.ap_settings.router.drop_user, uaid)
             raise RouterException("No such subscription", status_code=410,
                                   log_exception=False, errno=106)


### PR DESCRIPTION
Some info that needs to be logged is not JSON serializable. Use repr()
for now.

closes #631 
@bbangert @pjenvey r?