### PR TITLE
bug: provide better logging and fix UAID misreference

### DIFF
--- a/autopush/base.py
+++ b/autopush/base.py
@@ -24,6 +24,7 @@ class BaseHandler(cyclone.web.RequestHandler):
                                                self.request.remote_ip),
             authorization=self.request.headers.get('authorization', ""),
             message_ttl=self.request.headers.get('ttl', ""),
+            uri=self.request.uri,
         )
 
     def write_error(self, code, **kwargs):
@@ -39,8 +40,8 @@ class BaseHandler(cyclone.web.RequestHandler):
             self.log.failure(
                 format=kwargs.get('format', "Exception"),
                 failure=failure.Failure(*kwargs['exc_info']),
-                **self._client_info)
+                client_info=self._client_info)
         else:
             self.log.failure("Error in handler: %s" % code,
-                             **self._client_info)
+                             client_info=self._client_info)
         self.finish()

--- a/autopush/log_check.py
+++ b/autopush/log_check.py
@@ -27,7 +27,7 @@ class LogCheckHandler(AutoendpointHandler):
         if 'error' in err_type:
             self.log.error(format="Test Error Message",
                            status_code=418, errno=0,
-                           **self._client_info)
+                           client_info=self._client_info)
             self._write_response(418, 999, message="ERROR:Success",
                                  reason="Test Error")
         if 'crit' in err_type:
@@ -36,6 +36,6 @@ class LogCheckHandler(AutoendpointHandler):
             except LogCheckError:
                 self.log.failure(format="Test Critical Message",
                                  status_code=418, errno=0,
-                                 **self._client_info)
+                                 client_info=self._client_info)
                 self._write_response(418, 999, message="FAILURE:Success",
                                      reason="Test Failure")

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -13,7 +13,6 @@ from twisted.trial import unittest
 
 from autopush.db import (
     create_rotating_message_table,
-    hasher,
     ProvisionedThroughputExceededException,
 )
 from autopush.exceptions import InvalidRequest
@@ -174,14 +173,6 @@ class TestBase(unittest.TestCase):
         d = self.base._init_info()
         eq_(d["remote_ip"], "local2")
         eq_(d["authorization"], "webpush token barney")
-
-    def test_properties(self):
-        eq_(self.base.uaid, "")
-        eq_(self.base.chid, "")
-        self.base.uaid = dummy_uaid
-        eq_(self.base._client_info["uaid_hash"], hasher(dummy_uaid))
-        self.base.chid = dummy_chid
-        eq_(self.base._client_info['channelID'], dummy_chid)
 
     def test_write_response(self):
         self.base._write_response(400, 103, message="Fail",

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -96,7 +96,7 @@ class TestWebpushHandler(unittest.TestCase):
         self.fernet_mock.decrypt.return_value = dummy_token
         self.router_mock.get_uaid.return_value = dict(
             router_type="webpush",
-            router_data=dict(),
+            router_data=dict(uaid="uaid"),
         )
         self.wp_router_mock.route_notification.return_value = RouterResponse(
             status_code=503,

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -74,7 +74,6 @@ class ThreadedValidate(object):
         def wrapper(request_handler, *args, **kwargs):
             # Wrap the handler in @cyclone.web.synchronous
             request_handler._auto_finish = False
-
             d = deferToThread(self._validate_request, request_handler)
             d.addCallback(self._call_func, func, request_handler, *args,
                           **kwargs)
@@ -279,7 +278,8 @@ class WebPushRequestSchema(Schema):
         req_fields = ["content-encoding", "encryption"]
         if d.get("body"):
             if not all([x in d["headers"] for x in req_fields]):
-                raise InvalidRequest("Client error", errno=110)
+                raise InvalidRequest("Client error", status_code=400,
+                                     errno=110)
             if (d["headers"].get("crypto-key") and
                     "dh=" not in d["headers"]["crypto-key"]):
                     raise InvalidRequest(


### PR DESCRIPTION
* when calling drop_user and the response.router_data is empty, fetch
the current UAID from known uaid_data
* make the logging far more verbose by adding _client_info to raven
calls

closes #629
@bbangert @pjenvey r?