### PR TITLE
bug: Require auth header for endpoints with v2

### DIFF
--- a/autopush/crypto_key.py
+++ b/autopush/crypto_key.py
@@ -34,7 +34,7 @@ http://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00#section-4
             ck_hash = {}
             for bit in bits:
                 try:
-                    (key, value) = bit.split("=", 1)
+                    key, value = bit.split("=", 1)
                 except ValueError:
                     raise CryptoKeyException("Invalid Crypto Key value")
                 ck_hash[key.strip()] = value.strip(' "')

--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -350,7 +350,7 @@ class AutoendpointHandler(BaseHandler):
                        **self._client_info)
         raise VapidAuthException("Invalid bearer token: " + repr(message))
 
-    def _process_auth(self, result):
+    def _process_auth(self, result, require_auth=False):
         """Process the optional VAPID auth token.
 
         VAPID requires two headers to be present;
@@ -361,12 +361,12 @@ class AutoendpointHandler(BaseHandler):
         """
         authorization = self.request.headers.get('authorization')
         # No auth present, so it's not a VAPID call.
-        if not authorization:
+        if not authorization and not require_auth:
             return result
 
         public_key = result.get("public_key")
         try:
-            (auth_type, token) = authorization.split(' ', 1)
+            auth_type, token = authorization.split(' ', 1)
         except ValueError:
             raise VapidAuthException("Invalid Authorization header")
         # if it's a bearer token containing what may be a JWT
@@ -376,7 +376,10 @@ class AutoendpointHandler(BaseHandler):
             d.addErrback(self._jws_err)
             d.addErrback(self._invalid_auth)
             return d
-        # otherwise, it's not, so ignore the VAPID data.
+        # otherwise, it's not, so ignore the VAPID data if we're supposed to
+        if require_auth:
+            raise VapidAuthException("Invalid Authorization header",
+                                     status_codes)
         return result
 
 
@@ -451,6 +454,7 @@ class EndpointHandler(AutoendpointHandler):
         api_ver = api_ver or "v0"
         self.start_time = time.time()
         crypto_key_header = self.request.headers.get('crypto-key')
+        auth_header = self.request.headers.get('authorization')
         content_encoding = self.request.headers.get('content-encoding', "")
         if content_encoding.lower() == 'aesgcm128' and crypto_key_header:
             self.log.debug(
@@ -466,10 +470,11 @@ class EndpointHandler(AutoendpointHandler):
             return
 
         d = deferToThread(self.ap_settings.parse_endpoint,
-                          token,
-                          api_ver,
-                          crypto_key_header)
-        d.addCallback(self._process_auth)
+                          token=token,
+                          version=api_ver,
+                          ckey_header=crypto_key_header,
+                          auth_header=auth_header)
+        d.addCallback(self._process_auth, require_auth=(api_ver == "v2"))
         d.addCallback(self._token_valid)
         d.addErrback(self._jws_err)
         d.addErrback(self._auth_err)

--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -333,6 +333,7 @@ class AutopushSettings(object):
         :param version: This is the API version of the token.
         :param ckey_header: the Crypto-Key header bearing the public key
         (from Crypto-Key: p256ecdsa=)
+        :param auth_header: The Authorization header bearing the VAPID info
 
         :raises ValueError: In the case of a malformed endpoint.
 

--- a/autopush/web/validation.py
+++ b/autopush/web/validation.py
@@ -318,7 +318,7 @@ class WebPushRequestSchema(Schema):
 
         public_key = d["subscription"].get("public_key")
         try:
-            (auth_type, token) = auth.split(' ', 1)
+            auth_type, token = auth.split(' ', 1)
         except ValueError:
             raise InvalidRequest("Invalid Authorization Header",
                                  status_code=401, errno=109,


### PR DESCRIPTION
closes #646 

Also took the opportunity to fix the `(tuple) = function()` returns. 

@bbangert, @pjenvey r?