### PR TITLE
chore: fix travis' virtualenv giving us an older python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ dist: precise
 python:
 - '2.7'
 install:
+- pip install virtualenv
 - virtualenv pypy
 - cd pypy/bin && ln -s python pypy && cd ../..
 - source pypy/bin/activate
+- python --version
 - make travis
 script: tox -- --with-coverage --cover-xml --cover-package=autopush
 after_success:


### PR DESCRIPTION
quickest solution is to install virtualenv on its system python, so we
avoid the old virtualenv it has

travis sets up a virtualenv for us so our use of virtualenv here is redundant, at some point in the future we should probably stop doing it. I think we can use some of its caching features for pip/dynamodb too..