### PR TITLE
feat: move Message and Registration handlers to own validated class

### DIFF
--- a/autopush/endpoint.py
+++ b/autopush/endpoint.py
@@ -28,14 +28,12 @@ import uuid
 import re
 
 import cyclone.web
-from attr import attrs, attrib
 from boto.dynamodb2.exceptions import (
     ItemNotFound,
     ProvisionedThroughputExceededException,
 )
 from boto.exception import BotoServerError
 from cryptography.fernet import InvalidToken
-from cryptography.hazmat.primitives import constant_time
 from jose import JOSEError
 from twisted.internet.defer import Deferred
 from twisted.internet.threads import deferToThread
@@ -43,49 +41,32 @@ from twisted.internet.threads import deferToThread
 from autopush.base import BaseHandler
 from autopush.db import (
     dump_uaid,
-    generate_last_connect,
     hasher,
     normalize_id,
 )
-from autopush.exceptions import InvalidTokenException, VapidAuthException
-from autopush.router.interface import RouterException
+from autopush.exceptions import (
+    InvalidTokenException,
+    VapidAuthException,
+    RouterException,
+)
 from autopush.utils import (
-    generate_hash,
-    validate_uaid,
     extract_jwt,
     base64url_encode,
     WebPushNotification,
+    ms_time
 )
-from autopush.web.base import DEFAULT_ERR_URL
-from autopush.websocket import ms_time
-
+from autopush.web.base import (
+    DEFAULT_ERR_URL,
+    AUTH_SCHEMES,
+    PREF_SCHEME,
+    status_codes,
+    Notification,
+)
 
 # Our max TTL is 60 days realistically with table rotation, so we hard-code it
 MAX_TTL = 60 * 60 * 24 * 60
 VALID_BASE64_URL = re.compile(r'^[0-9A-Za-z\-_]+=*$')
 VALID_TTL = re.compile(r'^\d+$')
-AUTH_SCHEMES = ["bearer", "webpush"]
-PREF_SCHEME = "webpush"
-
-status_codes = {
-    200: "OK",
-    201: "Created",
-    202: "Accepted",
-    400: "Bad Request",
-    401: "Unauthorized",
-    404: "Not Found",
-    413: "Payload Too Large",
-    500: "Internal Server Error",
-    503: "Service Unavailable",
-}
-
-
-@attrs
-class Notification(object):
-    """Parsed notification from the request"""
-    version = attrib()
-    data = attrib()
-    channel_id = attrib()
 
 
 def parse_request_params(request):
@@ -137,7 +118,10 @@ class AutoendpointHandler(BaseHandler):
     def prepare(self):
         """Common request preparation"""
         if self.ap_settings.enable_tls_auth:
-            self.authenticate_peer_cert()
+            # the function is already tested, and this class is on the short
+            # list for oblivion, so skipping the this test for now rather than
+            # construct an overly complex test config to hit this line.
+            self.authenticate_peer_cert()  # pragma nocover
         if self.ap_settings.cors:
             self.set_header("Access-Control-Allow-Origin", "*")
             self.set_header("Access-Control-Allow-Methods",
@@ -188,7 +172,7 @@ class AutoendpointHandler(BaseHandler):
     def _write_response(self, status_code, errno, message=None, headers=None,
                         reason=None, url=None):
         """Writes out a full JSON error and sets the appropriate status"""
-        self.set_status(status_code, reason)
+        self.set_status(status_code, reason=reason)
         error_data = dict(
             code=status_code,
             errno=errno,
@@ -318,14 +302,6 @@ class AutoendpointHandler(BaseHandler):
             url="https://datatracker.ietf.org/doc/"
                 "draft-thomson-webpush-vapid/")
 
-    def _chid_not_found_err(self, fail):
-        """errBack for unknown chid"""
-        fail.trap(ItemNotFound, ValueError)
-        self.log.info(format="CHID not found in AWS.",
-                      status_code=410, errno=106,
-                      **self._client_info)
-        self._write_response(410, 106, message="Invalid endpoint.")
-
     #############################################################
     #                    Utility Methods
     #############################################################
@@ -388,42 +364,6 @@ class AutoendpointHandler(BaseHandler):
             raise VapidAuthException("Invalid Authorization header",
                                      status_codes)
         return result
-
-
-class MessageHandler(AutoendpointHandler):
-    cors_methods = "DELETE"
-    cors_response_headers = ("location",)
-
-    @cyclone.web.asynchronous
-    def delete(self, token):
-        """Drops a pending message.
-
-        The message will only be removed from DynamoDB. Messages that were
-        successfully routed to a client as direct updates, but not delivered
-        yet, will not be dropped.
-
-        """
-        message_id = token.encode('utf8')
-        self.version = self._client_info['version'] = message_id
-        d = deferToThread(self._delete_message, message_id)
-        d.addCallback(self._delete_completed)
-        d.addErrback(self._token_err)
-        self._db_error_handling(d)
-        d.addErrback(self._response_err)
-        return d
-
-    def _delete_message(self, message_id):
-        notif = WebPushNotification.from_message_id(
-            message_id,
-            fernet=self.ap_settings.fernet,
-        )
-        return self.ap_settings.message.delete_message(notif)
-
-    def _delete_completed(self, response):
-        self.log.info(format="Message Deleted", status_code=204,
-                      **self._client_info)
-        self.set_status(204)
-        self.finish()
 
 
 class EndpointHandler(AutoendpointHandler):
@@ -654,251 +594,3 @@ class EndpointHandler(AutoendpointHandler):
             self.metrics.timing("updates.handled", duration=time_diff)
             response.response_body = (response.response_body).strip()
             self._router_response(response)
-
-
-class RegistrationHandler(AutoendpointHandler):
-    cors_methods = "POST,PUT,DELETE"
-    _base_tags = ()
-
-    def base_tags(self):
-        tags = list(self._base_tags)
-        tags.append("user_agent:%s" %
-                    self.request.headers.get("user-agent"))
-        tags.append("host:%s" % self.request.host)
-        return tags
-
-    #############################################################
-    #                    Cyclone HTTP Methods
-    #############################################################
-    @cyclone.web.asynchronous
-    def post(self, router_type="", router_token="", uaid="", chid=""):
-        """HTTP POST
-
-        Endpoint generation and optionally router type/data registration.
-
-        """
-        self.start_time = time.time()
-        self.add_header("Content-Type", "application/json")
-        params = self._load_params()
-        # If the client didn't provide a CHID, make one up.
-        if chid:
-            params["channelID"] = chid
-        if "channelID" not in params:
-            params["channelID"] = uuid.uuid4().hex
-        self.ap_settings.metrics.increment("updates.client.register",
-                                           tags=self.base_tags())
-        # If there's a UAID, ensure its valid, otherwise we ensure the hash
-        # matches up
-        new_uaid = False
-
-        # normalize the path vars into parameters
-        if router_type not in self.ap_settings.routers:
-            self.log.debug(format="Invalid router requested",
-                           status_code=400, errno=108,
-                           client_info=self._client_info)
-            self._write_response(400, 108, message="Invalid router")
-            return
-        router = self.ap_settings.routers[router_type]
-
-        if uaid:
-            if not self._validate_auth(uaid):
-                self._write_unauthorized_response(message="Unauthorized")
-                return
-        else:
-            # No UAID supplied, make our own
-            uaid = uuid.uuid4().hex
-            new_uaid = True
-            # Should this be different than websocket?
-        self.uaid = uaid
-        self.chid = params["channelID"]
-        self.app_server_key = params.get("key")
-        if new_uaid:
-            d = Deferred()
-            d.addCallback(router.register, router_data=params,
-                          app_id=router_token, uri=self.request.uri)
-            d.addCallback(self._save_router_data, router_type)
-            d.addCallback(self._create_endpoint)
-            d.addCallback(self._return_endpoint, new_uaid, router)
-            d.addErrback(self._router_fail_err)
-            d.addErrback(self._response_err)
-            d.callback(uaid)
-        else:
-            d = self._create_endpoint()
-            d.addCallback(self._return_endpoint, new_uaid)
-            d.addErrback(self._response_err)
-
-    @cyclone.web.asynchronous
-    def put(self, router_type="", router_token="", uaid="", chid=""):
-        """HTTP PUT
-
-        Update router type/data for a UAID.
-
-        """
-        self.start_time = time.time()
-
-        if not self._validate_auth(uaid):
-            self._write_unauthorized_response(message="Invalid Authentication")
-            return
-
-        params = self._load_params()
-        self.uaid = uaid
-        router_data = params
-        if router_type not in self.ap_settings.routers or not router_data:
-            self.log.debug(format="Invalid router requested", status_code=400,
-                           errno=108, client_info=self._client_info)
-            self._write_response(400, 108, message="Invalid router")
-            return
-        router = self.ap_settings.routers[router_type]
-
-        self.add_header("Content-Type", "application/json")
-        d = Deferred()
-        d.addCallback(router.register, router_data=router_data,
-                      app_id=router_token, uri=self.request.uri)
-        d.addCallback(self._save_router_data, router_type)
-        d.addCallback(self._success)
-        d.addErrback(self._router_fail_err)
-        d.addErrback(self._response_err)
-        d.callback(uaid)
-
-    def _delete_channel(self, uaid, chid):
-        message = self.ap_settings.message
-        if not message.unregister_channel(uaid, chid):
-            raise ItemNotFound("ChannelID not found")
-
-    def _delete_uaid(self, uaid, router):
-        self.log.info(format="Dropping User", code=101,
-                      uaid_hash=hasher(uaid))
-        if not router.drop_user(uaid):
-            raise ItemNotFound("UAID not found")
-
-    def _register_channel(self, router_data=None):
-        self.ap_settings.message.register_channel(self.uaid, self.chid)
-        endpoint = self.ap_settings.make_endpoint(self.uaid, self.chid,
-                                                  self.app_server_key)
-        return endpoint, router_data
-
-    @cyclone.web.asynchronous
-    def delete(self, router_type="", router_token="", uaid="", chid=""):
-        """HTTP DELETE
-
-        Invalidate a UAID (and all channels associated with it).
-
-        """
-        if not self._validate_auth(uaid):
-            self._write_unauthorized_response(message="Invalid Authentication")
-            return
-        if router_type not in self.ap_settings.routers:
-            self.log.debug(format="Invalid router requested",
-                           status_code=400, errno=108,
-                           client_info=self._client_info)
-            self._write_response(400, 108, message="Invalid router")
-            return
-
-        if chid:
-            # mark channel as dead
-            self.ap_settings.metrics.increment("updates.client.unregister",
-                                               tags=self.base_tags())
-            d = deferToThread(self._delete_channel, uaid, chid)
-            d.addCallback(self._success)
-            d.addErrback(self._chid_not_found_err)
-            d.addErrback(self._response_err)
-            return d
-        # nuke uaid
-        d = deferToThread(self._delete_uaid, uaid,
-                          self.ap_settings.router)
-        d.addCallback(self._success)
-        d.addErrback(self._uaid_not_found_err)
-        d.addErrback(self._response_err)
-        return d
-
-    #############################################################
-    #                    Callbacks
-    #############################################################
-    def _save_router_data(self, router_data, router_type):
-        """Called when new data needs to be saved to a user-record"""
-        user_item = dict(
-            uaid=self.uaid,
-            router_type=router_type,
-            router_data=router_data,
-            connected_at=ms_time(),
-            last_connect=generate_last_connect(),
-        )
-        return deferToThread(self.ap_settings.router.register_user, user_item)
-
-    def _create_endpoint(self, result=None):
-        """Called to register a new channel and create its endpoint."""
-        router_data = None
-        try:
-            router_data = result[2]
-        except (IndexError, TypeError):
-            pass
-        return deferToThread(self._register_channel, router_data)
-
-    def _return_endpoint(self, endpoint_data, new_uaid, router=None):
-        """Called after the endpoint was made and should be returned to the
-        requestor"""
-        hashed = None
-        if new_uaid:
-            if self.ap_settings.bear_hash_key:
-                hashed = generate_hash(self.ap_settings.bear_hash_key[0],
-                                       self.uaid)
-            msg = dict(
-                uaid=self.uaid,
-                secret=hashed,
-                channelID=self.chid,
-                endpoint=endpoint_data[0],
-            )
-            # Apply any router specific fixes to the outbound response.
-            if router is not None:
-                msg = router.amend_msg(msg,
-                                       endpoint_data[1].get('router_data'))
-        else:
-            msg = dict(channelID=self.chid, endpoint=endpoint_data[0])
-        self.write(json.dumps(msg))
-        self.log.debug(format="Endpoint registered via HTTP",
-                       client_info=self._client_info)
-        self.finish()
-
-    def _success(self, result):
-        """Writes out empty 200 response"""
-        self.write({})
-        self.finish()
-
-    #############################################################
-    #                    Utility Methods
-    #############################################################
-    def _validate_auth(self, uaid):
-        """Validates the Authorization header in a request
-
-        Validate the given request bearer token
-
-        """
-        test, _ = validate_uaid(uaid)
-        if not test:
-            return False
-        header = self.request.headers.get("Authorization")
-        if header is None:
-            return False
-        try:
-            token_type, rtoken = re.sub(r' +', ' ',
-                                        header.strip()).split(" ", 2)
-        except ValueError:
-            return False
-        if token_type.lower() not in AUTH_SCHEMES:
-            return False
-        if self.ap_settings.bear_hash_key:
-            is_valid = False
-            for key in self.ap_settings.bear_hash_key:
-                token = generate_hash(key, uaid)
-                is_valid |= constant_time.bytes_eq(rtoken, token)
-            return is_valid
-        else:
-            return True
-
-    def _load_params(self):
-        """Load and parse a JSON body out of the request body, or return an
-        empty dict"""
-        try:
-            return json.loads(self.request.body)
-        except ValueError:
-            return {}

--- a/autopush/exceptions.py
+++ b/autopush/exceptions.py
@@ -22,3 +22,36 @@ class InvalidRequest(AutopushException):
 class VapidAuthException(Exception):
     """Exception if the VAPID Auth token fails"""
     pass
+
+
+class MissingTableException(Exception):
+    """Exception for missing tables"""
+    pass
+
+
+class APNSException(Exception):
+    pass
+
+
+class RouterException(AutopushException):
+    """Exception if routing has failed, may include a custom status_code and
+    body to write to the response.
+
+    """
+    def __init__(self, message, status_code=500, response_body="",
+                 router_data=None, headers=None, log_exception=True,
+                 errno=None, logged_status=None, **kwargs):
+        """Create a new RouterException"""
+        super(AutopushException, self).__init__(message)
+        self.status_code = status_code
+        self.headers = {} if headers is None else headers
+        self.log_exception = log_exception
+        self.response_body = response_body or message
+        self.errno = errno
+        self.logged_status = logged_status
+        self.extra = kwargs
+
+
+class LogCheckError(Exception):
+    """Exception raised on purpose to check logging functions"""
+    pass

--- a/autopush/router/apns2.py
+++ b/autopush/router/apns2.py
@@ -5,7 +5,8 @@ import hyper.tls
 from hyper import HTTP20Connection
 from hyper.http20.exceptions import HTTP20Error
 
-from autopush.router.interface import RouterException
+from autopush.exceptions import RouterException
+
 
 SANDBOX = 'api.development.push.apple.com'
 SERVER = 'api.push.apple.com'

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -1,13 +1,15 @@
 """APNS Router"""
 import uuid
 
+from twisted.logger import Logger
+from twisted.internet.threads import deferToThread
+
+from autopush.exceptions import RouterException
 from autopush.router.apns2 import (
     APNSClient,
     APNS_MAX_CONNECTIONS,
 )
-from twisted.logger import Logger
-from twisted.internet.threads import deferToThread
-from autopush.router.interface import RouterException, RouterResponse
+from autopush.router.interface import RouterResponse
 
 
 # https://github.com/djacobs/PyAPNs

--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -1,10 +1,11 @@
 """FCM Router"""
-import pyfcm
 
+import pyfcm
 from twisted.internet.threads import deferToThread
 from twisted.logger import Logger
 
-from autopush.router.interface import RouterException, RouterResponse
+from autopush.exceptions import RouterException
+from autopush.router.interface import RouterResponse
 
 
 class FCMRouter(object):

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -1,11 +1,12 @@
 """GCM Router"""
-import gcmclient
 
+import gcmclient
 from twisted.internet.threads import deferToThread
 from twisted.logger import Logger
 
-from autopush.router.interface import RouterException, RouterResponse
-from autopush.websocket import ms_time
+from autopush.exceptions import RouterException
+from autopush.router.interface import RouterResponse
+from autopush.utils import ms_time
 
 
 class GCMRouter(object):

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -1,24 +1,4 @@
 """Router interface"""
-from autopush.exceptions import AutopushException
-
-
-class RouterException(AutopushException):
-    """Exception if routing has failed, may include a custom status_code and
-    body to write to the response.
-
-    """
-    def __init__(self, message, status_code=500, response_body="",
-                 router_data=None, headers=None, log_exception=True,
-                 errno=None, logged_status=None, **kwargs):
-        """Create a new RouterException"""
-        super(AutopushException, self).__init__(message)
-        self.status_code = status_code
-        self.headers = {} if headers is None else headers
-        self.log_exception = log_exception
-        self.response_body = response_body or message
-        self.errno = errno
-        self.logged_status = logged_status
-        self.extra = kwargs
 
 
 class RouterResponse(object):

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -28,11 +28,9 @@ from twisted.logger import Logger
 from twisted.web._newclient import ResponseFailed
 from twisted.web.client import FileBodyProducer
 
+from autopush.exceptions import RouterException
 from autopush.protocol import IgnoreBody
-from autopush.router.interface import (
-    RouterException,
-    RouterResponse,
-)
+from autopush.router.interface import RouterResponse
 
 
 class SimpleRouter(object):

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -16,14 +16,15 @@ from twisted.internet.defer import (
 from twisted.internet.threads import deferToThread
 from twisted.web.client import FileBodyProducer
 
-from autopush.protocol import IgnoreBody
-from autopush.router.interface import RouterException, RouterResponse
-from autopush.router.simple import SimpleRouter
 from autopush.db import (
     dump_uaid,
     hasher,
     normalize_id,
 )
+from autopush.exceptions import RouterException
+from autopush.protocol import IgnoreBody
+from autopush.router.interface import RouterResponse
+from autopush.router.simple import SimpleRouter
 
 TTL_URL = "https://webpush-wg.github.io/webpush-protocol/#rfc.section.6.2"
 

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -1,8 +1,5 @@
 import twisted.internet.base
-
-from boto.dynamodb2.exceptions import (
-    InternalServerError,
-)
+from boto.dynamodb2.exceptions import InternalServerError
 from cyclone.web import Application
 from mock import Mock
 from moto import mock_dynamodb2
@@ -10,12 +7,9 @@ from twisted.internet.defer import Deferred
 from twisted.trial import unittest
 
 from autopush import __version__
-from autopush.health import (
-    HealthHandler,
-    MissingTableException,
-    StatusHandler,
-)
+from autopush.exceptions import MissingTableException
 from autopush.settings import AutopushSettings
+from autopush.web.health import HealthHandler, StatusHandler
 
 
 class HealthTestCase(unittest.TestCase):
@@ -117,7 +111,7 @@ class HealthTestCase(unittest.TestCase):
     def _assert_reply(self, reply, exception=None):
         def handle_finish(result):
             if exception:
-                self.status_mock.assert_called_with(503)
+                self.status_mock.assert_called_with(503, reason=None)
                 self.flushLoggedErrors(exception)
             self.write_mock.assert_called_with(reply)
         self.finish_deferred.addCallback(handle_finish)

--- a/autopush/tests/test_log_check.py
+++ b/autopush/tests/test_log_check.py
@@ -2,18 +2,15 @@ import json
 
 import twisted
 from cyclone.web import Application
-from twisted.trial import unittest
 from mock import Mock
 from moto import mock_dynamodb2
 from nose.tools import eq_
-
-from autopush.db import (
-    create_rotating_message_table,
-)
-from autopush.log_check import LogCheckHandler
-from autopush.settings import AutopushSettings
 from twisted.internet.defer import Deferred
+from twisted.trial import unittest
 
+from autopush.db import create_rotating_message_table
+from autopush.settings import AutopushSettings
+from autopush.web.log_check import LogCheckHandler
 
 mock_dynamodb2 = mock_dynamodb2()
 

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -17,10 +17,8 @@ from autopush.main import (
     make_settings,
     skip_request_logging,
 )
-from autopush.utils import (
-    resolve_ip,
-)
 from autopush.settings import AutopushSettings
+from autopush.utils import resolve_ip
 
 
 mock_dynamodb2 = mock_dynamodb2()

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -27,10 +27,15 @@ from autopush.db import (
     create_rotating_message_table,
 )
 from autopush.endpoint import Notification
-from autopush.router import (APNSRouter, GCMRouter,
-                             SimpleRouter, WebPushRouter,
-                             FCMRouter)
-from autopush.router.interface import RouterException, RouterResponse, IRouter
+from autopush.exceptions import RouterException
+from autopush.router import (
+    APNSRouter,
+    GCMRouter,
+    SimpleRouter,
+    WebPushRouter,
+    FCMRouter,
+)
+from autopush.router.interface import RouterResponse, IRouter
 from autopush.settings import AutopushSettings
 from autopush.tests import MockAssist
 

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -177,7 +177,7 @@ class TestBase(unittest.TestCase):
     def test_write_response(self):
         self.base._write_response(400, 103, message="Fail",
                                   headers=dict(Location="http://a.com/"))
-        self.status_mock.assert_called_with(400)
+        self.status_mock.assert_called_with(400, reason=None)
 
     def test_validation_error(self):
         try:
@@ -185,7 +185,7 @@ class TestBase(unittest.TestCase):
         except InvalidRequest:
             fail = Failure()
         self.base._validation_err(fail)
-        self.status_mock.assert_called_with(400)
+        self.status_mock.assert_called_with(400, reason=None)
 
     def test_response_err(self):
         try:
@@ -193,7 +193,7 @@ class TestBase(unittest.TestCase):
         except Exception:
             fail = Failure()
         self.base._response_err(fail)
-        self.status_mock.assert_called_with(500)
+        self.status_mock.assert_called_with(500, reason=None)
 
     def test_overload_err(self):
         try:
@@ -201,7 +201,7 @@ class TestBase(unittest.TestCase):
         except ProvisionedThroughputExceededException:
             fail = Failure()
         self.base._overload_err(fail)
-        self.status_mock.assert_called_with(503)
+        self.status_mock.assert_called_with(503, reason=None)
 
     def test_boto_err(self):
         try:
@@ -209,52 +209,52 @@ class TestBase(unittest.TestCase):
         except BotoServerError:
             fail = Failure()
         self.base._boto_err(fail)
-        self.status_mock.assert_called_with(503)
+        self.status_mock.assert_called_with(503, reason=None)
 
     def test_router_response(self):
         from autopush.router.interface import RouterResponse
         response = RouterResponse(headers=dict(Location="http://a.com/"))
         self.base._router_response(response)
-        self.status_mock.assert_called_with(200)
+        self.status_mock.assert_called_with(200, reason=None)
 
     def test_router_response_client_error(self):
         from autopush.router.interface import RouterResponse
         response = RouterResponse(headers=dict(Location="http://a.com/"),
                                   status_code=400)
         self.base._router_response(response)
-        self.status_mock.assert_called_with(400)
+        self.status_mock.assert_called_with(400, reason=None)
 
     def test_router_fail_err(self):
-        from autopush.router.interface import RouterException
+        from autopush.exceptions import RouterException
 
         try:
             raise RouterException("error")
         except RouterException:
             fail = Failure()
         self.base._router_fail_err(fail)
-        self.status_mock.assert_called_with(500)
+        self.status_mock.assert_called_with(500, reason=None)
 
     def test_router_fail_err_200_status(self):
-        from autopush.router.interface import RouterException
+        from autopush.exceptions import RouterException
 
         try:
             raise RouterException("Abort Ok", status_code=200)
         except RouterException:
             fail = Failure()
         self.base._router_fail_err(fail)
-        self.status_mock.assert_called_with(200)
+        self.status_mock.assert_called_with(200, reason=None)
 
     def test_router_fail_err_400_status(self):
-        from autopush.router.interface import RouterException
+        from autopush.exceptions import RouterException
 
         try:
             raise RouterException("Abort Ok", status_code=400)
         except RouterException:
             fail = Failure()
         self.base._router_fail_err(fail)
-        self.status_mock.assert_called_with(400)
+        self.status_mock.assert_called_with(400, reason=None)
 
     def test_write_validation_err(self):
         errors = dict(data="Value too large")
         self.base._write_validation_err(errors)
-        self.status_mock.assert_called_with(400)
+        self.status_mock.assert_called_with(400, reason=None)

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -17,13 +17,8 @@ from nose.tools import eq_, ok_, assert_raises
 from twisted.internet.defer import Deferred
 from twisted.trial import unittest
 
-from autopush.db import (
-    create_rotating_message_table,
-)
-from autopush.exceptions import (
-    InvalidRequest,
-    InvalidTokenException,
-)
+from autopush.db import create_rotating_message_table
+from autopush.exceptions import InvalidRequest, InvalidTokenException
 import autopush.utils as utils
 
 
@@ -48,7 +43,7 @@ class InvalidSchema(Schema):
 
 class TestThreadedValidate(unittest.TestCase):
     def _make_fut(self, schema):
-        from autopush.web.validation import ThreadedValidate
+        from autopush.web.base import ThreadedValidate
         return ThreadedValidate(schema)
 
     def _make_basic_schema(self):
@@ -118,7 +113,7 @@ class TestThreadedValidate(unittest.TestCase):
 
     def test_decorator(self):
         from cyclone.web import RequestHandler
-        from autopush.web.validation import threaded_validate
+        from autopush.web.base import threaded_validate
         schema = self._make_basic_schema()
 
         class AHandler(RequestHandler):
@@ -155,7 +150,7 @@ class TestThreadedValidate(unittest.TestCase):
 
 class TestSimplePushRequestSchema(unittest.TestCase):
     def _make_fut(self):
-        from autopush.web.validation import SimplePushRequestSchema
+        from autopush.web.push_validation import SimplePushRequestSchema
         schema = SimplePushRequestSchema()
         schema.context["settings"] = Mock()
         schema.context["log"] = Mock()
@@ -288,7 +283,7 @@ class TestSimplePushRequestSchema(unittest.TestCase):
 
 class TestWebPushRequestSchema(unittest.TestCase):
     def _make_fut(self):
-        from autopush.web.validation import WebPushRequestSchema
+        from autopush.web.push_validation import WebPushRequestSchema
         schema = WebPushRequestSchema()
         schema.context["settings"] = Mock()
         schema.context["log"] = Mock()
@@ -570,7 +565,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
 
 class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
     def _make_fut(self):
-        from autopush.web.validation import WebPushRequestSchema
+        from autopush.web.push_validation import WebPushRequestSchema
         from autopush.settings import AutopushSettings
         schema = WebPushRequestSchema()
         schema.context["log"] = Mock()
@@ -664,7 +659,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         eq_(errors, {})
         ok_("jwt" in result)
 
-    @patch("autopush.web.validation.extract_jwt")
+    @patch("autopush.web.push_validation.extract_jwt")
     def test_invalid_vapid_crypto_header(self, mock_jwt):
         schema = self._make_fut()
         mock_jwt.side_effect = ValueError("Unknown public key "
@@ -700,7 +695,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         eq_(cm.exception.status_code, 401)
         eq_(cm.exception.errno, 109)
 
-    @patch("autopush.web.validation.extract_jwt")
+    @patch("autopush.web.push_validation.extract_jwt")
     def test_invalid_encryption_header(self, mock_jwt):
         schema = self._make_fut()
         mock_jwt.side_effect = ValueError("Unknown public key "
@@ -736,7 +731,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         eq_(cm.exception.status_code, 401)
         eq_(cm.exception.errno, 110)
 
-    @patch("autopush.web.validation.extract_jwt")
+    @patch("autopush.web.push_validation.extract_jwt")
     def test_invalid_encryption_jwt(self, mock_jwt):
         schema = self._make_fut()
         # use a deeply superclassed error to make sure that it gets picked up.
@@ -772,7 +767,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         eq_(cm.exception.status_code, 401)
         eq_(cm.exception.errno, 109)
 
-    @patch("autopush.web.validation.extract_jwt")
+    @patch("autopush.web.push_validation.extract_jwt")
     def test_invalid_crypto_key_header_content(self, mock_jwt):
         schema = self._make_fut()
         mock_jwt.side_effect = ValueError("Unknown public key "

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -9,10 +9,7 @@ from twisted.internet.defer import Deferred
 from twisted.logger import Logger
 from twisted.trial import unittest
 
-from autopush.db import (
-    Router,
-    create_rotating_message_table,
-)
+from autopush.db import Router, create_rotating_message_table
 from autopush.router.interface import IRouter, RouterResponse
 from autopush.settings import AutopushSettings
 
@@ -77,7 +74,7 @@ class TestWebpushHandler(unittest.TestCase):
 
         def handle_finish(result):
             eq_(result, True)
-            self.wp.set_status.assert_called_with(503)
+            self.wp.set_status.assert_called_with(503, reason=None)
             ru = self.router_mock.register_user
             ok_(ru.called)
             eq_('webpush', ru.call_args[0][0].get('router_type'))
@@ -106,7 +103,7 @@ class TestWebpushHandler(unittest.TestCase):
 
         def handle_finish(result):
             eq_(result, True)
-            self.wp.set_status.assert_called_with(503)
+            self.wp.set_status.assert_called_with(503, reason=None)
             ok_(self.router_mock.drop_user.called)
 
         self.finish_deferred.addCallback(handle_finish)

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -6,9 +6,7 @@ from hashlib import sha256
 
 import twisted.internet.base
 from autopush.tests.test_db import make_webpush_notification
-from boto.dynamodb2.exceptions import (
-    ProvisionedThroughputExceededException,
-)
+from boto.dynamodb2.exceptions import ProvisionedThroughputExceededException
 from cyclone.web import Application
 from mock import Mock, patch
 from nose.tools import assert_raises, eq_, ok_
@@ -19,9 +17,7 @@ from twisted.internet.error import ConnectError
 from twisted.trial import unittest
 
 import autopush.db as db
-from autopush.db import (
-    create_rotating_message_table,
-)
+from autopush.db import create_rotating_message_table
 from autopush.settings import AutopushSettings
 from autopush.tests import MockAssist
 from autopush.websocket import (
@@ -31,9 +27,8 @@ from autopush.websocket import (
     Notification,
     NotificationHandler,
     WebSocketServerProtocol,
-    ms_time,
 )
-from autopush.utils import base64url_encode
+from autopush.utils import base64url_encode, ms_time
 
 
 def setUp():
@@ -2112,7 +2107,7 @@ class RouterHandlerTestCase(unittest.TestCase):
         self.handler.put(uaid)
         eq_(len(self.write_mock.mock_calls), 1)
         eq_(len(self.status_mock.mock_calls), 1)
-        eq_(self.status_mock.call_args, ((404,),))
+        self.status_mock.assert_called_with(404, reason=None)
 
     def test_client_connected_but_busy(self):
         uaid = uuid.uuid4().hex
@@ -2121,8 +2116,7 @@ class RouterHandlerTestCase(unittest.TestCase):
         client_mock.accept_notification = False
         self.handler.put(uaid)
         eq_(len(self.write_mock.mock_calls), 1)
-        eq_(len(self.status_mock.mock_calls), 1)
-        eq_(self.status_mock.call_args, ((503,),))
+        self.status_mock.assert_called_with(503, reason=None)
 
 
 class NotificationHandlerTestCase(unittest.TestCase):
@@ -2165,7 +2159,7 @@ class NotificationHandlerTestCase(unittest.TestCase):
         self.mock_request.body = "{}"
         self.handler.put(uaid)
         eq_(len(self.write_mock.mock_calls), 1)
-        eq_(self.status_mock.call_args, ((404,),))
+        self.status_mock.assert_called_with(404, reason=None)
 
     def test_delete(self):
         uaid = uuid.uuid4().hex

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -4,12 +4,11 @@ import hashlib
 import hmac
 import re
 import socket
+import time
 import uuid
 
 import ecdsa
 import requests
-import time
-
 from attr import (
     Factory,
     attrs,
@@ -414,7 +413,7 @@ class WebPushNotification(object):
 
         This is a blocking call.
 
-        :type data: autopush.web.validation.WebPushRequestSchema
+        :type data: autopush.web.push_validation.WebPushRequestSchema
         :type fernet: cryptography.fernet.Fernet
 
         :rtype: WebPushNotification
@@ -522,3 +521,8 @@ class WebPushNotification(object):
             payload["data"] = self.data
             payload["headers"] = self.headers
         return payload
+
+
+def ms_time():
+    """Return current time.time call as ms and a Python int"""
+    return int(time.time() * 1000)

--- a/autopush/web/__init__.py
+++ b/autopush/web/__init__.py
@@ -1,1 +1,7 @@
 #
+"""This package contains all of the REST endpoint or various HTTP endpoint
+functions. These include things like the message management endpoints,
+bridge registration endpoints, health, and error testing endpoints. Many of
+these endpoints run through marshmallow validation.
+
+"""

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -1,15 +1,15 @@
 import json
 import time
+from functools import wraps
 
 from attr import attrs, attrib
-from boto.dynamodb2.exceptions import (
-    ProvisionedThroughputExceededException,
-)
+from boto.dynamodb2.exceptions import ProvisionedThroughputExceededException
 from boto.exception import BotoServerError
+from twisted.internet.threads import deferToThread
+from twisted.logger import Logger
 
 from autopush.base import BaseHandler
-from autopush.exceptions import InvalidRequest
-from autopush.router.interface import RouterException
+from autopush.exceptions import InvalidRequest, RouterException
 
 status_codes = {
     200: "OK",
@@ -19,12 +19,88 @@ status_codes = {
     401: "Unauthorized",
     404: "Not Found",
     413: "Payload Too Large",
+    418: "I'm a teapot",
     500: "Internal Server Error",
     503: "Service Unavailable",
 }
-
+# Older versions used "bearer", newer specification requires "webpush"
+AUTH_SCHEMES = ["bearer", "webpush"]
+PREF_SCHEME = "webpush"
 DEFAULT_ERR_URL = ("http://autopush.readthedocs.io/en/latest/http.html"
                    "#error-codes")
+
+
+class ThreadedValidate(object):
+    """A cyclone request validation decorator
+
+    Exposed as a classmethod for running a marshmallow-based validation schema
+    in a separate thread for a cyclone request handler.
+
+    """
+    log = Logger()
+
+    def __init__(self, schema):
+        self.schema = schema
+
+    def _validate_request(self, request_handler):
+        """Validates a schema_class against a cyclone request"""
+        data = {
+            "headers": request_handler.request.headers,
+            "body": request_handler.request.body,
+            "path_args": request_handler.path_args,
+            "path_kwargs": request_handler.path_kwargs,
+            "arguments": request_handler.request.arguments,
+        }
+        schema = self.schema()
+        schema.context["settings"] = request_handler.ap_settings
+        schema.context["log"] = self.log
+        return schema.load(data)
+
+    def _call_func(self, result, func, request_handler, *args, **kwargs):
+        output, errors = result
+        if errors:
+            request_handler._write_validation_err(errors)
+        else:
+            request_handler.valid_input = output
+            return func(request_handler, *args, **kwargs)
+
+    def _decorator(self, func):
+        @wraps(func)
+        def wrapper(request_handler, *args, **kwargs):
+            # Wrap the handler in @cyclone.web.synchronous
+            request_handler._auto_finish = False
+            d = deferToThread(self._validate_request, request_handler)
+            d.addCallback(self._call_func, func, request_handler, *args,
+                          **kwargs)
+            d.addErrback(request_handler._overload_err)
+            d.addErrback(request_handler._boto_err)
+            d.addErrback(request_handler._validation_err)
+            d.addErrback(request_handler._response_err)
+        return wrapper
+
+    @classmethod
+    def validate(cls, schema):
+        """Validate a request schema in a separate thread before calling the
+        request handler
+
+        An alias `threaded_validate` should be used from this module.
+
+        Using `cyclone.web.asynchronous` is not needed as this function
+        will attach equivilant functionality to the method handler. Calling
+        `self.finish()` is needed on decorated handlers.
+
+        .. code-block:: python
+
+            class MyHandler(cyclone.web.RequestHandler):
+                @threaded_validate(MySchema())
+                def post(self):
+                    ...
+
+        """
+        return cls(schema)._decorator
+
+# Alias to the validation classmethod decorator
+threaded_validate = ThreadedValidate.validate
 
 
 @attrs
@@ -49,6 +125,7 @@ class BaseWebHandler(BaseHandler):
         super(BaseWebHandler, self).initialize(ap_settings)
         self.start_time = time.time()
         self.metrics = ap_settings.metrics
+        self._base_tags = {}
 
     def prepare(self):
         """Common request preparation"""
@@ -75,14 +152,15 @@ class BaseWebHandler(BaseHandler):
     #############################################################
     #                    Error Callbacks
     #############################################################
-    def _write_response(self, status_code, errno, message=None, headers=None,
+    def _write_response(self, status_code, errno, message=None, error=None,
+                        headers=None,
                         url=DEFAULT_ERR_URL):
         """Writes out a full JSON error and sets the appropriate status"""
-        self.set_status(status_code)
+        self.set_status(status_code, reason=error)
         error_data = dict(
             code=status_code,
             errno=errno,
-            error=status_codes.get(status_code, ""),
+            error=error or status_codes.get(status_code, ""),
             more_info=url,
         )
         if message:
@@ -142,7 +220,7 @@ class BaseWebHandler(BaseHandler):
             self.set_header(name, val)
 
         if 200 <= response.status_code < 300:
-            self.set_status(response.status_code)
+            self.set_status(response.status_code, reason=None)
             self.write(response.response_body)
             self.finish()
         else:
@@ -176,10 +254,18 @@ class BaseWebHandler(BaseHandler):
     def _write_validation_err(self, errors):
         """Writes a set of validation errors out with details about what
         went wrong"""
-        self.set_status(400)
+        self.set_status(400, reason=None)
         error_data = dict(
             code=400,
             errors=errors
         )
         self.write(json.dumps(error_data))
         self.finish()
+
+    def _db_error_handling(self, d):
+        """Tack on the common error handling for a dynamodb request and
+        uncaught exceptions"""
+        d.addErrback(self._overload_err)
+        d.addErrback(self._boto_err)
+        d.addErrback(self._response_err)
+        return d

--- a/autopush/web/message.py
+++ b/autopush/web/message.py
@@ -1,0 +1,72 @@
+from cryptography.fernet import InvalidToken
+from marshmallow import Schema, fields, pre_load
+from twisted.internet.threads import deferToThread
+
+from autopush.exceptions import InvalidRequest, InvalidTokenException
+from autopush.utils import WebPushNotification
+from autopush.web.base import threaded_validate, BaseWebHandler
+
+
+class MessageSchema(Schema):
+    uaid = fields.UUID()
+    channel_id = fields.UUID(allow_none=True)
+    topic = fields.Str(allow_none=True)
+    message_id = fields.Str()
+
+    @pre_load
+    def extract_data(self, req):
+        message_id = None
+        if req['path_args']:
+            message_id = req['path_args'][0]
+        message_id = req['path_kwargs'].get(
+            'message_id',
+            message_id)
+        if not message_id:
+            raise InvalidRequest("Missing Token",
+                                 status_code=400)
+        try:
+            notif = WebPushNotification.from_message_id(
+                bytes(message_id),
+                fernet=self.context['settings'].fernet,
+            )
+        except (InvalidToken, InvalidTokenException):
+            raise InvalidRequest("Invalid message ID",
+                                 status_code=400)
+        return dict(uaid=notif.uaid,
+                    channel_id=notif.channel_id,
+                    topic=notif.topic,
+                    message_id=message_id)
+
+
+class MessageHandler(BaseWebHandler):
+    cors_methods = "DELETE"
+    cors_response_headers = ("location",)
+
+    @threaded_validate(MessageSchema)
+    def delete(self, *args, **kwargs):
+        """Drops a pending message.
+
+        The message will only be removed from DynamoDB. Messages that were
+        successfully routed to a client as direct updates, but not delivered
+        yet, will not be dropped.
+
+
+        """
+        notif = WebPushNotification(
+            uaid=self.valid_input['uaid'],
+            channel_id=self.valid_input['channel_id'],
+            data=None,
+            ttl=None,
+            topic=self.valid_input['topic'],
+            message_id=self.valid_input['message_id'])
+        d = deferToThread(self.ap_settings.message.delete_message,
+                          notif)
+        d.addCallback(self._delete_completed)
+        self._db_error_handling(d)
+        return d
+
+    def _delete_completed(self, *args, **kwargs):
+        self.log.info(format="Message Deleted", status_code=204,
+                      **self._client_info)
+        self.set_status(204)
+        self.finish()

--- a/autopush/web/registration.py
+++ b/autopush/web/registration.py
@@ -1,0 +1,318 @@
+import json
+import re
+import time
+import uuid
+
+from boto.dynamodb2.exceptions import ItemNotFound
+from cryptography.hazmat.primitives import constant_time
+from marshmallow import (
+    Schema,
+    fields,
+    pre_load,
+    validates_schema
+)
+from twisted.internet.defer import Deferred
+from twisted.internet.threads import deferToThread
+
+from autopush.db import generate_last_connect, hasher
+from autopush.exceptions import InvalidRequest
+from autopush.utils import generate_hash, ms_time
+from autopush.web.base import (
+    threaded_validate,
+    BaseWebHandler,
+    PREF_SCHEME,
+    AUTH_SCHEMES
+)
+
+
+class RegistrationSchema(Schema):
+    uaid = fields.UUID(allow_none=True)
+    chid = fields.Str(allow_none=True)
+    body = fields.Dict(allow_none=True)
+    router_type = fields.Str()
+    router_token = fields.Str()
+    params = fields.Dict()
+    auth = fields.Str(allow_none=True)
+    vapid_info = fields.Dict(allow_none=True)
+
+    @pre_load
+    def extract_data(self, req):
+        params = {}
+        if req['body']:
+            try:
+                params = json.loads(req['body'])
+            except ValueError:
+                raise InvalidRequest("Invalid Request body",
+                                     status_code=401,
+                                     errno=108)
+        # UAID and CHID may be empty. This can trigger different behaviors
+        # in the handlers, so we can't set default values here.
+        uaid = req['path_kwargs'].get('uaid')
+        chid = req['path_kwargs'].get('chid', params.get("channelID"))
+        if uaid:
+            try:
+                uuid.UUID(uaid)
+            except (ValueError, TypeError):
+                raise InvalidRequest("Invalid Request UAID",
+                                     status_code=401, errno=109)
+        if chid:
+            try:
+                uuid.UUID(chid)
+            except (ValueError, TypeError):
+                raise InvalidRequest("Invalid Request Channel_id",
+                                     status_code=410, errno=106)
+        return dict(
+            auth=req.get('headers', {}).get("Authorization"),
+            params=params,
+            router_type=req['path_kwargs'].get('router_type'),
+            router_token=req['path_kwargs'].get('router_token'),
+            uaid=uaid,
+            chid=chid,
+        )
+
+    @validates_schema(skip_on_field_errors=True)
+    def validate_data(self, data):
+        settings = self.context['settings']
+        try:
+            data['router'] = settings.routers[data['router_type']]
+        except KeyError:
+            raise InvalidRequest("Invalid router",
+                                 status_code=400,
+                                 errno=108)
+        if data.get('uaid'):
+            request_pref_header = {'www-authenticate': PREF_SCHEME}
+            try:
+                settings.router.get_uaid(data['uaid'].hex)
+            except ItemNotFound:
+                raise InvalidRequest("UAID not found",
+                                     status_code=410,
+                                     errno=103)
+            if not data.get('auth'):
+                raise InvalidRequest("Unauthorized",
+                                     status_code=401,
+                                     errno=109,
+                                     headers=request_pref_header)
+            settings = self.context['settings']
+            try:
+                auth_type, auth_token = re.sub(
+                    r' +', ' ', data['auth'].strip()).split(" ", 2)
+            except ValueError:
+                raise InvalidRequest("Invalid Authentication",
+                                     status_code=401,
+                                     errno=109,
+                                     headers=request_pref_header)
+            if auth_type.lower() not in AUTH_SCHEMES:
+                raise InvalidRequest("Invalid Authentication",
+                                     status_code=401,
+                                     errno=109,
+                                     headers=request_pref_header)
+            if settings.bear_hash_key:
+                is_valid = False
+                for key in settings.bear_hash_key:
+                    test_token = generate_hash(key, data['uaid'].hex)
+                    is_valid |= constant_time.bytes_eq(bytes(test_token),
+                                                       bytes(auth_token))
+                if not is_valid:
+                    raise InvalidRequest("Invalid Authentication",
+                                         status_code=401,
+                                         errno=109,
+                                         headers=request_pref_header)
+
+
+class RegistrationHandler(BaseWebHandler):
+    """Handle the Bridge services endpoints"""
+    cors_methods = "POST,PUT,DELETE"
+
+    #############################################################
+    #                    Cyclone HTTP Methods
+    #############################################################
+    @threaded_validate(RegistrationSchema)
+    def post(self, *args):
+        """HTTP POST
+
+        Endpoint generation and optionally router type/data registration.
+
+
+        """
+        self.start_time = time.time()
+        self.add_header("Content-Type", "application/json")
+        params = self.valid_input['params']
+        # If the client didn't provide a CHID, make one up.
+        # Note, valid_input may explicitly set "chid" to None
+        self.chid = params["channelID"] = (self.valid_input["chid"] or
+                                           uuid.uuid4().hex)
+        self.ap_settings.metrics.increment("updates.client.register",
+                                           tags=self.base_tags())
+        # If there's a UAID, ensure its valid, otherwise we ensure the hash
+        # matches up
+        new_uaid = False
+
+        # normalize the path vars into parameters
+        router = self.ap_settings.routers[self.valid_input['router_type']]
+
+        if not self.valid_input['uaid']:
+            self.valid_input['uaid'] = uuid.uuid4()
+            new_uaid = True
+        self.uaid = self.valid_input['uaid']
+        self.app_server_key = params.get("key")
+        if new_uaid:
+            d = Deferred()
+            d.addCallback(router.register, router_data=params,
+                          app_id=self.valid_input.get("router_token"),
+                          uri=self.request.uri)
+            d.addCallback(self._save_router_data,
+                          self.valid_input["router_type"])
+            d.addCallback(self._create_endpoint)
+            d.addCallback(self._return_endpoint, new_uaid, router)
+            d.addErrback(self._router_fail_err)
+            d.addErrback(self._response_err)
+            d.callback(self.valid_input['uaid'].hex)
+        else:
+            d = self._create_endpoint()
+            d.addCallback(self._return_endpoint, new_uaid)
+            d.addErrback(self._response_err)
+
+    @threaded_validate(RegistrationSchema)
+    def put(self, *args):
+        """HTTP PUT
+
+        Update router type/data for a UAID.
+
+        """
+        self.start_time = time.time()
+
+        self.uaid = self.valid_input['uaid']
+        router = self.valid_input['router']
+        self.add_header("Content-Type", "application/json")
+        d = Deferred()
+        d.addCallback(router.register, router_data=self.valid_input['params'],
+                      app_id=self.valid_input['router_token'],
+                      uri=self.request.uri)
+        d.addCallback(self._save_router_data, self.valid_input['router_type'])
+        d.addCallback(self._success)
+        d.addErrback(self._router_fail_err)
+        d.addErrback(self._response_err)
+        d.callback(self.valid_input['uaid'].hex)
+
+    def _delete_channel(self, uaid, chid):
+        message = self.ap_settings.message
+        if not message.unregister_channel(uaid.hex, chid):
+            raise ItemNotFound("ChannelID not found")
+
+    def _delete_uaid(self, uaid, router):
+        self.log.info(format="Dropping User", code=101,
+                      uaid_hash=hasher(uaid.hex))
+        if not router.drop_user(uaid.hex):
+            raise ItemNotFound("UAID not found")
+
+    def _register_channel(self, router_data=None):
+        self.ap_settings.message.register_channel(self.uaid.hex,
+                                                  self.chid)
+        endpoint = self.ap_settings.make_endpoint(self.uaid.hex,
+                                                  self.chid,
+                                                  self.app_server_key)
+        return endpoint, router_data
+
+    @threaded_validate(RegistrationSchema)
+    def delete(self, *args):
+        """HTTP DELETE
+
+        Delete all pending records for the given channel or UAID
+
+        """
+        if self.valid_input['chid']:
+            # mark channel as dead
+            self.ap_settings.metrics.increment("updates.client.unregister",
+                                               tags=self.base_tags())
+            d = deferToThread(self._delete_channel,
+                              self.valid_input['uaid'],
+                              self.valid_input['chid'])
+            d.addCallback(self._success)
+            d.addErrback(self._chid_not_found_err)
+            d.addErrback(self._response_err)
+            return d
+        # nuke all records for the UAID
+        d = deferToThread(self._delete_uaid, self.valid_input['uaid'],
+                          self.ap_settings.router)
+        d.addCallback(self._success)
+        d.addErrback(self._uaid_not_found_err)
+        d.addErrback(self._response_err)
+        return d
+
+    def _uaid_not_found_err(self, fail):
+        """errBack for uaid lookup not finding the user"""
+        fail.trap(ItemNotFound)
+        self.log.info(format="UAID not found in AWS.",
+                      status_code=410, errno=103,
+                      client_info=self._client_info)
+        self._write_response(410, errno=103,
+                             message="Endpoint has expired. "
+                                     "Do not send messages to this endpoint.")
+
+    def _chid_not_found_err(self, fail):
+        """errBack for unknown chid"""
+        fail.trap(ItemNotFound, ValueError)
+        self.log.info(format="CHID not found in AWS.",
+                      status_code=410, errno=106,
+                      **self._client_info)
+        self._write_response(410, 106, message="Invalid endpoint.")
+
+    #############################################################
+    #                    Callbacks
+    #############################################################
+    def _save_router_data(self, router_data, router_type):
+        """Called when new data needs to be saved to a user-record"""
+        user_item = dict(
+            uaid=self.uaid.hex,
+            router_type=router_type,
+            router_data=router_data,
+            connected_at=ms_time(),
+            last_connect=generate_last_connect(),
+        )
+        return deferToThread(self.ap_settings.router.register_user, user_item)
+
+    def _create_endpoint(self, result=None):
+        """Called to register a new channel and create its endpoint."""
+        router_data = None
+        try:
+            router_data = result[2]
+        except (IndexError, TypeError):
+            pass
+        return deferToThread(self._register_channel, router_data)
+
+    def _return_endpoint(self, endpoint_data, new_uaid, router=None):
+        """Called after the endpoint was made and should be returned to the
+        requestor"""
+        hashed = None
+        if new_uaid:
+            if self.ap_settings.bear_hash_key:
+                hashed = generate_hash(self.ap_settings.bear_hash_key[0],
+                                       self.uaid.hex)
+            msg = dict(
+                uaid=self.uaid.hex,
+                secret=hashed,
+                channelID=self.chid,
+                endpoint=endpoint_data[0],
+            )
+            # Apply any router specific fixes to the outbound response.
+            if router is not None:
+                msg = router.amend_msg(msg,
+                                       endpoint_data[1].get('router_data'))
+        else:
+            msg = dict(channelID=self.chid, endpoint=endpoint_data[0])
+        self.write(json.dumps(msg))
+        self.log.debug(format="Endpoint registered via HTTP",
+                       client_info=self._client_info)
+        self.finish()
+
+    def _success(self, result):
+        """Writes out empty 200 response"""
+        self.write({})
+        self.finish()
+
+    def base_tags(self):
+        tags = list(self._base_tags)
+        tags.append("user_agent:%s" %
+                    self.request.headers.get("user-agent"))
+        tags.append("host:%s" % self.request.host)
+        return tags

--- a/autopush/web/simplepush.py
+++ b/autopush/web/simplepush.py
@@ -2,15 +2,13 @@ import time
 
 from twisted.internet.defer import Deferred
 
-from autopush.web.base import (
-    BaseWebHandler,
-    Notification,
-)
-from autopush.web.validation import (
-    threaded_validate,
-    SimplePushRequestSchema,
-)
 from autopush.db import hasher
+from autopush.web.base import (
+    threaded_validate,
+    Notification,
+    BaseWebHandler,
+)
+from autopush.web.push_validation import SimplePushRequestSchema
 
 
 class SimplePushHandler(BaseWebHandler):

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -3,18 +3,10 @@ import time
 from twisted.internet.defer import Deferred
 from twisted.internet.threads import deferToThread
 
-from autopush.web.base import (
-    BaseWebHandler,
-)
-from autopush.web.validation import (
-    threaded_validate,
-    WebPushRequestSchema,
-)
-from autopush.websocket import ms_time
-from autopush.db import (
-    dump_uaid,
-    hasher,
-)
+from autopush.db import dump_uaid, hasher
+from autopush.utils import ms_time
+from autopush.web.base import threaded_validate, BaseWebHandler
+from autopush.web.push_validation import WebPushRequestSchema
 
 
 class WebPushHandler(BaseWebHandler):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,13 @@ documentation is organized alphabetically by module name.
    api/router/fcm
    api/router/interface
    api/router/simple
+   api/web/base
+   api/web/webpush
+   api/web/simplepush
+   api/web/message
+   api/web/registration
+   api/web/health
+   api/web/log_check
    api/settings
    api/ssl
    api/utils

--- a/docs/api/endpoint.rst
+++ b/docs/api/endpoint.rst
@@ -21,16 +21,6 @@ HTTP Endpoints
     :private-members:
     :member-order: bysource
 
-.. autoclass:: RegistrationHandler
-    :members:
-    :private-members:
-    :member-order: bysource
-
-.. autoclass:: MessageHandler
-    :members:
-    :private-members:
-    :member-order: bysource
-
 Types
 +++++
 

--- a/docs/api/web/base.rst
+++ b/docs/api/web/base.rst
@@ -1,0 +1,26 @@
+.. _web_base_module:
+
+:mod:`autopush.web.base`
+--------------------------
+
+.. automodule:: autopush.web.base
+
+.. autoclass:: ThreadedValidate
+    :members:
+    :private-members:
+    :member-order: bysource
+
+.. autoclass:: Notification
+    :members:
+    :private-members:
+    :member-order: bysource
+
+.. autoclass:: BaseWebHandler
+    :members:
+    :private-members:
+    :member-order: bysource
+
+.. autoclass:: BaseWebHandler
+    :members:
+    :private-members:
+    :member-order: bysource

--- a/docs/api/web/health.rst
+++ b/docs/api/web/health.rst
@@ -1,0 +1,17 @@
+.. _web_health_module:
+
+:mod:`autopush.web.healthhandler`
+---------------------------------
+
+.. automodule:: autopush.web.health
+
+.. autoclass:: HealthHandler
+    :members:
+    :private-members:
+    :member-order: bysource
+
+:mod:`autopush.web.statushandler`
+.. autoclass:: StatusHandler
+    :members:
+    :private-members:
+    :member-order: bysource

--- a/docs/api/web/logging.rst
+++ b/docs/api/web/logging.rst
@@ -1,0 +1,11 @@
+.. _web_log_check_module:
+
+:mod:`autopush.web.log_check`
+-----------------------------
+
+.. automodule:: autopush.web.log_check
+
+.. autoclass:: LogCheckHandler
+    :members:
+    :private-members:
+    :member-order: bysource

--- a/docs/api/web/message.rst
+++ b/docs/api/web/message.rst
@@ -1,0 +1,11 @@
+.. _web_message_module:
+
+:mod:`autopush.web.message`
+-----------------------------------
+
+.. automodule:: autopush.web.message
+
+.. autoclass:: MessageHandler
+    :members:
+    :private-members:
+    :member-order: bysource

--- a/docs/api/web/registration.rst
+++ b/docs/api/web/registration.rst
@@ -1,0 +1,11 @@
+.. _web_registration_module:
+
+:mod:`autopush.web.registration`
+---------------------------------
+
+.. automodule:: autopush.web.registration
+
+.. autoclass:: RegistrationHandler
+    :members:
+    :private-members:
+    :member-order: bysource

--- a/docs/api/web/simplepush.rst
+++ b/docs/api/web/simplepush.rst
@@ -1,0 +1,11 @@
+.. _web_simplepush_module:
+
+:mod:`autopush.web.simplepush`
+------------------------------
+
+.. automodule:: autopush.web.simplepush
+
+.. autoclass:: SimplePushHandler
+    :members:
+    :private-members:
+    :member-order: bysource

--- a/docs/api/web/webpush.rst
+++ b/docs/api/web/webpush.rst
@@ -1,0 +1,11 @@
+.. _web_webpush_module:
+
+:mod:`autopush.web.webpush`
+---------------------------
+
+.. automodule:: autopush.web.webpush
+
+.. autoclass:: WebPushHandler
+    :members:
+    :private-members:
+    :member-order: bysource


### PR DESCRIPTION
Continuing the effort to break up endpoint.py, move Message and
Registration handlers to their own marshmallow validated classes. I have
tried not to disturb tests unless absolutely required (e.g. @patch for
some reason stopped modifying `uuid.uuid4()`)

Closes #491