### PR TITLE
chore: remove the wsaccel dependency on pypy

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -57,7 +57,6 @@ typing==3.5.2.2
 txaio==2.5.1
 ua_parser==0.7.1
 virtualenv==15.0.3
-wsaccel==0.6.2
 xmltodict==0.10.2
 zope.deprecation==4.1.2
 zope.interface==4.3.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
--r base-requirements.txt
+-r requirements.txt
 nose
 coverage
 mock>=1.0.1


### PR DESCRIPTION
keep it in test-requirements (implying cpython for now)

issue #560 

I might shuffle the requirements around a bit soon so keeping this simple for now (i.e. no pypy-test-requirements.txt yet)