### PR TITLE
bug: normalize channelids to JSON encodable entities

### DIFF
--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -151,7 +151,7 @@ class FCMRouter(object):
 
     def _route(self, notification, router_data):
         """Blocking FCM call to route the notification"""
-        data = {"chid": notification.channel_id}
+        data = {"chid": str(notification.channel_id)}
         if not router_data.get("token"):
             raise self._error("No registration token found. "
                               "Rejecting message.",

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -75,7 +75,7 @@ class GCMRouter(object):
     def _route(self, notification, uaid_data):
         """Blocking GCM call to route the notification"""
         router_data = uaid_data["router_data"]
-        data = {"chid": notification.channel_id}
+        data = {"chid": str(notification.channel_id)}
         # Payload data is optional. The endpoint handler validates that the
         # correct encryption headers are included with the data.
         if notification.data:

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -56,7 +56,7 @@ class WebPushRouter(SimpleRouter):
         :type channel_id: uuid.UUID
 
         """
-        channel_id = normalize_id(channel_id.hex)
+        channel_id = normalize_id(channel_id)
         uaid = uaid_data["uaid"]
         if 'current_month' not in uaid_data:
             self.log.info(format="Dropping User", code=102,

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -347,6 +347,7 @@ class GCMRouterTestCase(unittest.TestCase):
             data = self.router.gcm['test123'].send.call_args[0][0].data
             eq_(data['body'], 'q60d6g')
             eq_(data['enc'], 'test')
+            eq_(data['chid'], dummy_chid)
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')
         d.addCallback(check_results)
@@ -374,6 +375,7 @@ class GCMRouterTestCase(unittest.TestCase):
             options = self.router.gcm['test123'].send.call_args[0][0].options
             eq_(data['body'], 'q60d6g')
             eq_(data['enc'], 'test')
+            eq_(data['chid'], dummy_chid)
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')
             # use the defined min TTL
@@ -400,6 +402,7 @@ class GCMRouterTestCase(unittest.TestCase):
             options = self.router.gcm['test123'].send.call_args[0][0].options
             eq_(data['body'], 'q60d6g')
             eq_(data['enc'], 'test')
+            eq_(data['chid'], dummy_chid)
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')
             # use the defined min TTL
@@ -620,6 +623,7 @@ class FCMRouterTestCase(unittest.TestCase):
             args = self.router.fcm.notify_single_device.call_args[1]
             data = args['data_message']
             eq_(data['body'], 'q60d6g')
+            eq_(data['chid'], dummy_chid)
             eq_(data['enc'], 'test')
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')
@@ -644,6 +648,7 @@ class FCMRouterTestCase(unittest.TestCase):
             args = self.router.fcm.notify_single_device.call_args[1]
             data = args['data_message']
             eq_(data['body'], 'q60d6g')
+            eq_(data['chid'], dummy_chid)
             eq_(data['enc'], 'test')
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')
@@ -670,6 +675,7 @@ class FCMRouterTestCase(unittest.TestCase):
             args = self.router.fcm.notify_single_device.call_args[1]
             data = args['data_message']
             eq_(data['body'], 'q60d6g')
+            eq_(data['chid'], dummy_chid)
             eq_(data['enc'], 'test')
             eq_(data['enckey'], 'test')
             eq_(data['con'], 'aesgcm')

--- a/autopush/web/message.py
+++ b/autopush/web/message.py
@@ -9,7 +9,7 @@ from autopush.web.base import threaded_validate, BaseWebHandler
 
 class MessageSchema(Schema):
     uaid = fields.UUID()
-    channel_id = fields.UUID(allow_none=True)
+    channel_id = fields.UUID()
     topic = fields.Str(allow_none=True)
     message_id = fields.Str()
 


### PR DESCRIPTION
While moving to UUIDs is noble, they're not fully JSON encodable.
Normalize ChannelIDs to strings where possible.

closes #691