### PR TITLE
bug: Stop splitting version info when logging for websocket

### DIFF
--- a/autopush/web/message.py
+++ b/autopush/web/message.py
@@ -9,7 +9,7 @@ from autopush.web.base import threaded_validate, BaseWebHandler
 
 class MessageSchema(Schema):
     uaid = fields.UUID()
-    channel_id = fields.UUID(allow_none=True)
+    channel_id = fields.UUID()
     topic = fields.Str(allow_none=True)
     message_id = fields.Str()
 

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -1243,8 +1243,6 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         if not version:
             return
 
-        version, updateid = version.split(":")
-
         self.log.info(format="Nack", uaid_hash=self.ps.uaid_hash,
                       user_agent=self.ps.user_agent, message_id=version,
                       code=code, **self.ps.raw_agent)


### PR DESCRIPTION
fixes: #693