### PR TITLE
fix: correct headers to use transcoded values

### DIFF
--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -115,13 +115,13 @@ class APNSRouter(object):
         }
         if notification.data:
             payload["body"] = notification.data
-            payload["con"] = notification.headers["content-encoding"]
+            payload["con"] = notification.headers["encoding"]
             payload["enc"] = notification.headers["encryption"]
 
-            if "crypto-key" in notification.headers:
-                payload["cryptokey"] = notification.headers["crypto-key"]
-            elif "encryption-key" in notification.headers:
-                payload["enckey"] = notification.headers["encryption-key"]
+            if "crypto_key" in notification.headers:
+                payload["cryptokey"] = notification.headers["crypto_key"]
+            elif "encryption_key" in notification.headers:
+                payload["enckey"] = notification.headers["encryption_key"]
             payload['aps'] = dict(
                 alert=router_data.get("title", config.get('default_title',
                                                           'Mozilla Push')),

--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -170,13 +170,13 @@ class FCMRouter(object):
                                   413, errno=104, log_exception=False)
 
             data['body'] = notification.data
-            data['con'] = notification.headers['content-encoding']
+            data['con'] = notification.headers['encoding']
             data['enc'] = notification.headers['encryption']
 
-            if 'crypto-key' in notification.headers:
-                data['cryptokey'] = notification.headers['crypto-key']
-            elif 'encryption-key' in notification.headers:
-                data['enckey'] = notification.headers['encryption-key']
+            if 'crypto_key' in notification.headers:
+                data['cryptokey'] = notification.headers['crypto_key']
+            elif 'encryption_key' in notification.headers:
+                data['enckey'] = notification.headers['encryption_key']
 
         # registration_ids are the FCM instance tokens (specified during
         # registration.

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -89,13 +89,13 @@ class GCMRouter(object):
                                   413, errno=104, log_exception=False)
 
             data['body'] = notification.data
-            data['con'] = notification.headers['content-encoding']
+            data['con'] = notification.headers['encoding']
             data['enc'] = notification.headers['encryption']
 
-            if 'crypto-key' in notification.headers:
-                data['cryptokey'] = notification.headers['crypto-key']
-            elif 'encryption-key' in notification.headers:
-                data['enckey'] = notification.headers['encryption-key']
+            if 'crypto_key' in notification.headers:
+                data['cryptokey'] = notification.headers['crypto_key']
+            elif 'encryption_key' in notification.headers:
+                data['enckey'] = notification.headers['encryption_key']
 
         # registration_ids are the GCM instance tokens (specified during
         # registration.

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -122,6 +122,7 @@ class APNSRouterTestCase(unittest.TestCase):
             ttl=200,
             message_id=10,
         )
+        self.notif.cleanup_headers()
         self.router_data = dict(router_data=dict(token="connect_data",
                                                  rel_channel="firefox"))
 
@@ -240,6 +241,7 @@ class APNSRouterTestCase(unittest.TestCase):
             ttl=200,
             message_id=10,
         )
+        self.notif.cleanup_headers()
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -280,6 +282,7 @@ class GCMRouterTestCase(unittest.TestCase):
             ttl=200,
             message_id=10,
         )
+        self.notif.cleanup_headers()
         self.router_data = dict(
             router_data=dict(
                 token="connect_data",
@@ -364,6 +367,7 @@ class GCMRouterTestCase(unittest.TestCase):
             headers=self.headers,
             ttl=None
         )
+        self.notif.cleanup_headers()
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -394,6 +398,7 @@ class GCMRouterTestCase(unittest.TestCase):
             headers=self.headers,
             ttl=5184000
         )
+        self.notif.cleanup_headers()
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -421,6 +426,7 @@ class GCMRouterTestCase(unittest.TestCase):
             headers=self.headers,
             ttl=200
         )
+
         d = self.router.route_notification(bad_notif, self.router_data)
 
         def check_results(result):
@@ -433,8 +439,8 @@ class GCMRouterTestCase(unittest.TestCase):
 
     def test_route_crypto_notification(self):
         self.router.gcm['test123'] = self.gcm
-        del(self.notif.headers['encryption-key'])
-        self.notif.headers['crypto-key'] = 'crypto'
+        del(self.notif.headers['encryption_key'])
+        self.notif.headers['crypto_key'] = 'crypto'
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -564,6 +570,7 @@ class FCMRouterTestCase(unittest.TestCase):
             headers=self.headers,
             ttl=200
         )
+        self.notif.cleanup_headers()
         self.router_data = dict(
             router_data=dict(
                 token="connect_data",
@@ -641,6 +648,7 @@ class FCMRouterTestCase(unittest.TestCase):
             headers=self.headers,
             ttl=None
         )
+        self.notif.cleanup_headers()
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -668,6 +676,7 @@ class FCMRouterTestCase(unittest.TestCase):
             headers=self.headers,
             ttl=5184000
         )
+        self.notif.cleanup_headers()
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -696,6 +705,7 @@ class FCMRouterTestCase(unittest.TestCase):
             ttl=200,
             message_id=10,
         )
+        self.notif.cleanup_headers()
         d = self.router.route_notification(bad_notif, self.router_data)
 
         def check_results(result):
@@ -708,8 +718,8 @@ class FCMRouterTestCase(unittest.TestCase):
 
     def test_route_crypto_notification(self):
         self.router.fcm = self.fcm
-        del(self.notif.headers['encryption-key'])
-        self.notif.headers['crypto-key'] = 'crypto'
+        del(self.notif.headers['encryption_key'])
+        self.notif.headers['crypto_key'] = 'crypto'
         d = self.router.route_notification(self.notif, self.router_data)
 
         def check_results(result):
@@ -1119,6 +1129,7 @@ class WebPushRouterTestCase(unittest.TestCase):
             ttl=0,
             message_id=uuid.uuid4().hex,
         )
+        self.notif.cleanup_headers()
         self.agent_mock.request.return_value = response_mock = Mock()
         response_mock.addCallback.return_value = response_mock
         type(response_mock).code = PropertyMock(

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1517,13 +1517,17 @@ class WebsocketTestCase(unittest.TestCase):
                    "timestamp": 0}
         self.proto.send_notifications(payload)
 
+        fixed_headers = dict()
+        for header in dummy_headers:
+            fixed_headers[header.replace("-", "_")] = dummy_headers[header]
+
         # Check the call result
         args = json.loads(self.send_mock.call_args[0][0])
         eq_(args, {"messageType": "notification",
                    "channelID": chid,
                    "data": dummy_data,
                    "version": "10",
-                   "headers": dummy_headers})
+                   "headers": fixed_headers})
 
     def test_notification_avoid_newer_delivery(self):
         self._connect()


### PR DESCRIPTION
Marshmallow converts "-" to "_", and some header values are stored with
slightly different names.

closes #702