### PR TITLE
bug: Add metrics for connection errors, reduce level for other errors

### DIFF
--- a/autopush/router/apns2.py
+++ b/autopush/router/apns2.py
@@ -122,16 +122,13 @@ class APNSClient(object):
                 raise RouterException(
                     "APNS Transmit Error {}:{}".format(response.status,
                                                        reason),
-                    status_code=500,
+                    status_code=502,
                     response_body="APNS could not process "
-                                  "your message {}".format(reason))
-        except HTTP20Error as ex:
+                                  "your message {}".format(reason)
+                )
+        except HTTP20Error:
             connection.close()
-            raise RouterException(
-                "APNS Processing error: {}".format(repr(ex)),
-                status_code=503,
-                response_body="APNS returned an error processing request",
-            )
+            raise
         finally:
             # Returning a closed connection to the pool is ok.
             # hyper will reconnect on .request()


### PR DESCRIPTION
Previous bridge connection error severity has been reduced for
non-critical errors. In addition, a new metric set has been created for
connection specific errors. Ops should monitor
`updates.client.bridge.(fcm|gcm|apns).connection_err` for sudden spikes.

Closes #715