### PR TITLE
fix: improve handling of JSONResponseErrors

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -266,6 +266,9 @@ def track_provisioned(func):
         except ProvisionedThroughputExceededException:
             self.metrics.increment("error.provisioned.%s" % func.__name__)
             raise
+        except JSONResponseError:
+            self.metrics.increment("error.jsonresponse.%s" % func.__name__)
+            raise
         except BotoServerError:
             self.metrics.increment("error.botoserver.%s" % func.__name__)
             raise
@@ -535,9 +538,9 @@ class Message(object):
 
         """
         # Eagerly fetches all results in the result set.
-        results = list(self.table.query_2(uaid__eq=hasher(uaid.hex),
-                                          chidmessageid__gt=" ",
-                                          consistent=True, limit=limit))
+        results = self.table.query_2(uaid__eq=hasher(uaid.hex),
+                                     chidmessageid__gt=" ",
+                                     consistent=True, limit=limit)
         return [
             WebPushNotification.from_message_table(uaid, x) for x in results
         ]

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -41,6 +41,7 @@ from boto.dynamodb2.exceptions import (
     ProvisionedThroughputExceededException,
     ItemNotFound
 )
+from boto.exception import JSONResponseError
 from twisted.internet import reactor
 from twisted.internet.defer import (
     Deferred,
@@ -317,7 +318,11 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
 
     def log_failure(self, failure, **kwargs):
         """Log a twisted failure out through twisted's log.failure"""
-        self.log.failure(format="Unexpected error", failure=failure, **kwargs)
+        exc = failure.value
+        if isinstance(exc, JSONResponseError):
+            self.log.info("JSONResponseError: {exc}", exc=exc, **kwargs)
+        else:
+            self.log.failure(format="Unexpected error", failure=failure, **kwargs)
 
     @property
     def paused(self):


### PR DESCRIPTION
have websocket log them instead of passing along to sentry and give them
a metric

closes #703