### PR TITLE
feat: skip timestamped messages instead of deleting

### DIFF
--- a/autopush/settings.py
+++ b/autopush/settings.py
@@ -211,6 +211,10 @@ class AutopushSettings(object):
 
         self.ami_id = ami_id
 
+        # Generate messages per legacy rules, only used for testing to
+        # generate legacy data.
+        self._notification_legacy = False
+
     @property
     def message(self):
         """Property that access the current message table"""

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -315,7 +315,8 @@ class MessageTestCase(unittest.TestCase):
         message.store_message(make_webpush_notification(self.uaid, chid))
         message.store_message(make_webpush_notification(self.uaid, chid))
 
-        all_messages = list(message.fetch_messages(uuid.UUID(self.uaid)))
+        _, all_messages = message.fetch_timestamp_messages(
+            uuid.UUID(self.uaid), " ")
         eq_(len(all_messages), 3)
 
     def test_message_storage_overwrite(self):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -139,6 +139,17 @@ class MessageTestCase(unittest.TestCase):
         self.message.delete(self._make_req('ignored'))
         return self.finish_deferred
 
+    def test_delete_invalid_timestamp_token(self):
+        tok = ":".join(["02", str(dummy_chid)])
+        self.fernet_mock.decrypt.return_value = tok
+
+        def handle_finish(result):
+            self.status_mock.assert_called_with(400, reason=None)
+        self.finish_deferred.addCallback(handle_finish)
+
+        self.message.delete(self._make_req('ignored'))
+        return self.finish_deferred
+
     def test_delete_success(self):
         tok = ":".join(["m", dummy_uaid.hex, str(dummy_chid)])
         self.fernet_mock.decrypt.return_value = tok

--- a/autopush/web/push_validation.py
+++ b/autopush/web/push_validation.py
@@ -289,6 +289,7 @@ class WebPushRequestSchema(Schema):
 
         # Set the notification based on the validated request schema data
         d["notification"] = WebPushNotification.from_webpush_request_schema(
-            data=d, fernet=self.context["settings"].fernet
+            data=d, fernet=self.context["settings"].fernet,
+            legacy=self.context["settings"]._notification_legacy,
         )
         return d


### PR DESCRIPTION
Alleviates heavy writes to remove messages by instead timestamping
messages and skipping through them. The first message record
retains the timestamp that was read up to for later use.

Closes #661