### PR TITLE
fix: Add a default handler that returns a 404 in JSON format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ PYTHON = $(BIN)/$(PTYPE)
 INSTALL = $(BIN)/pip install
 PATH := $(BIN):$(PATH)
 
-BUILD_DIRS = bin build deps include lib lib64 lib_pypy lib-python\
-	src site-packages .tox .eggs .coverage
-
-
 .PHONY: all build test coverage lint clean clean-env travis
 
 all:	build
@@ -50,9 +46,10 @@ $(PYTHON):
 
 clean-env:
 	rm -rf *.egg-info
-	rm -rf $(BUILD_DIRS)
+	rm -rf $(HERE)/$(PTYPE)
 
-clean:	clean-env
+clean: clean-env
+	rm -rf $(HERE)/ddb
 
 build: $(BIN)/pip
 	$(INSTALL) -r $(REQS)

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -12,6 +12,7 @@ from twisted.web.server import Site
 
 import autopush.db as db
 import autopush.utils as utils
+from autopush.base import DefaultHandler
 from autopush.logging import PushLogger
 from autopush.settings import AutopushSettings
 from autopush.ssl import AutopushSSLContextFactory
@@ -587,6 +588,7 @@ def endpoint_main(sysargs=None, use_files=True):
         (endpoint_paths['message'], MessageHandler, h_kwargs),
         (endpoint_paths['registration'], RegistrationHandler, h_kwargs),
         (endpoint_paths['logcheck'], LogCheckHandler, h_kwargs),
+        (r".*", DefaultHandler, h_kwargs),
     ],
         default_host=settings.hostname, debug=args.debug,
         log_function=skip_request_logging

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -30,6 +30,7 @@ from twisted.web.http_headers import Headers
 
 import autopush.db as db
 from autopush import __version__
+from autopush.base import DefaultHandler
 from autopush.db import (
     create_rotating_message_table,
     get_month,
@@ -397,6 +398,8 @@ class IntegrationBase(unittest.TestCase):
             # GET /register/uaid => chid + endpoint
             (endpoint_paths['registration'], RegistrationHandler, h_kwargs),
             (endpoint_paths['logcheck'], LogCheckHandler, h_kwargs),
+
+            (r".*", DefaultHandler, h_kwargs),
         ],
             default_host=settings.hostname,
             log_function=skip_request_logging,

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -175,7 +175,7 @@ class TestBase(unittest.TestCase):
         eq_(d["authorization"], "webpush token barney")
 
     def test_write_response(self):
-        self.base._write_response(400, 103, message="Fail",
+        self.base._write_response(400, errno=103, message="Fail",
                                   headers=dict(Location="http://a.com/"))
         self.status_mock.assert_called_with(400, reason=None)
 

--- a/autopush/web/log_check.py
+++ b/autopush/web/log_check.py
@@ -35,7 +35,7 @@ class LogCheckHandler(BaseWebHandler):
             self.log.error(format="Test Error Message",
                            status_code=418, errno=0,
                            client_info=self._client_info)
-            self._write_response(418, 999, message="ERROR:Success",
+            self._write_response(418, errno=999, message="ERROR:Success",
                                  error="Test Error")
         if 'crit' in err_type:
             try:
@@ -44,5 +44,6 @@ class LogCheckHandler(BaseWebHandler):
                 self.log.failure(format="Test Critical Message",
                                  status_code=418, errno=0,
                                  client_info=self._client_info)
-                self._write_response(418, 999, message="FAILURE:Success",
+                self._write_response(418, errno=999,
+                                     message="FAILURE:Success",
                                      error="Test Failure")

--- a/autopush/web/registration.py
+++ b/autopush/web/registration.py
@@ -257,7 +257,7 @@ class RegistrationHandler(BaseWebHandler):
         self.log.info(format="CHID not found in AWS.",
                       status_code=410, errno=106,
                       **self._client_info)
-        self._write_response(410, 106, message="Invalid endpoint.")
+        self._write_response(410, errno=106, message="Invalid endpoint.")
 
     #############################################################
     #                    Callbacks


### PR DESCRIPTION
Tip-of-tree Cyclone supports custom error handlers via an `error_handler` argument to `cyclone.web.Application` (fiorix/cyclone#125), but that hasn't been published to PyPI yet. We work around this by registering a catch-all handler that returns a 404 instead.