### PR TITLE
feat: Reduce CPU load via openssl for vapid

### DIFF
--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -108,7 +108,7 @@ def _get_vapid(key=None, payload=None):
     if not key:
         key = ecdsa.SigningKey.generate(curve=ecdsa.NIST256p)
     vk = key.get_verifying_key()
-    auth = jws.sign(payload, key, algorithm="ES256").strip('=')
+    auth = jws.sign(payload, key.to_pem(), algorithm="ES256").strip('=')
     crypto_key = base64url_encode('\4' + vk.to_string())
     return {"auth": auth,
             "crypto-key": crypto_key,

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -746,7 +746,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
     def _gen_jwt(self, header, payload):
         sk256p = ecdsa.SigningKey.generate(curve=ecdsa.NIST256p)
         vk = sk256p.get_verifying_key()
-        sig = jws.sign(payload, sk256p, algorithm="ES256").strip('=')
+        sig = jws.sign(payload, sk256p.to_pem(), algorithm="ES256").strip('=')
         crypto_key = utils.base64url_encode(vk.to_string()).strip('=')
         return sig, crypto_key
 

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -31,7 +31,10 @@ pycparser==2.14
 pycrypto==2.6.1
 pyfcm==1.0.4
 python-dateutil==2.5.3
-python-jose==1.3.2
+# use the following until https://github.com/mpdavis/python-jose/pull/39 lands
+-e git+https://github.com/jrconlin/python-jose.git#egg=python-jose
+-e git+https://github.com/jrconlin/pyelliptic.git@648ddf2b7eae196c5fc81c25bf13d858e1a048e7#egg=pyelliptic
+#python-jose==1.3.2
 raven==5.25.0
 requests==2.11.0
 service-identity==16.0.0


### PR DESCRIPTION
This patch is dependent on two other library patches landing.
* https://github.com/mpdavis/python-jose/pull/39
* https://github.com/yann2192/pyelliptic/pull/53

Temporarily pointing to personal forks with patches applied.

closes #753