### PR TITLE
feat: Add request timing w/validation breakdown.

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -165,8 +165,15 @@ class PushLogger(object):
         if ci and isinstance(ci, dict):
             msg['Fields'].update(
                 to_fields(ci.iteritems()))
-        # Add the nicely formatted message
 
+        # flatten timings into Fields
+        ti = event.get('timings')
+        if ti and isinstance(ti, dict):
+            msg["Fields"].update(
+                to_fields(ti.iteritems())
+            )
+
+        # Add the nicely formatted message
         msg["Fields"]["message"] = formatEvent(event)
         return json.dumps(msg, skipkeys=True) + "\n"
 

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -6,10 +6,10 @@ based channel ID's (only newest version is stored, no data stored).
 
 """
 import json
-import requests
 from urllib import urlencode
 from StringIO import StringIO
 
+import requests
 from boto.dynamodb2.exceptions import (
     ItemNotFound,
     ProvisionedThroughputExceededException,

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -50,10 +50,12 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
         pl = PushLogger.setup_logging("Autopush", sentry_dsn=True)
         pl._output = out
         _client_info = dict(key='value')
+        _timings = dict(key2='value')
 
         log.failure(format="error",
                     failure=failure.Failure(Exception("eek")),
-                    client_info=_client_info)
+                    client_info=_client_info,
+                    timings=_timings)
         self.flushLoggedErrors()
         d = Deferred()
 
@@ -70,7 +72,9 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
             # Check that the json written actually contains the client info
             # collapsed up into 'Fields'.
             out.seek(0)
-            eq_(json.loads(out.readline())['Fields']['key'], 'value')
+            payload = json.loads(out.readline())
+            eq_(payload['Fields']['key'], 'value')
+            eq_(payload['Fields']['key2'], 'value')
             self._port.stopListening()
             pl.stop()
             d.callback(True)

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -72,6 +72,7 @@ class TestThreadedValidate(unittest.TestCase):
         app.ui_modules = dict()
         app.ui_methods = dict()
         vr = ValidateRequest(app, request)
+        vr._timings = dict()
         vr.ap_settings = Mock()
         return vr
 
@@ -97,17 +98,19 @@ class TestThreadedValidate(unittest.TestCase):
         eq_(d, {})
 
     def test_call_func_no_error(self):
+        start_time = time.time()
         mock_func = Mock()
         tv, rh = self._make_full()
         result = tv._validate_request(rh)
-        tv._call_func(result, mock_func, rh)
+        tv._call_func(result, mock_func, rh, start_time)
         mock_func.assert_called()
 
     def test_call_func_error(self):
+        start_time = time.time()
         mock_func = Mock()
         tv, rh = self._make_full(schema=InvalidSchema)
         result = tv._validate_request(rh)
-        tv._call_func(result, mock_func, rh)
+        tv._call_func(result, mock_func, rh, start_time)
         self._mock_errors.assert_called()
         eq_(len(mock_func.mock_calls), 0)
 
@@ -127,6 +130,7 @@ class TestThreadedValidate(unittest.TestCase):
         app.ui_modules = dict()
         app.ui_methods = dict()
         vr = AHandler(app, req)
+        vr._timings = dict()
         d = Deferred()
         vr.finish = lambda: d.callback(True)
         vr.write = Mock()

--- a/autopush/web/simplepush.py
+++ b/autopush/web/simplepush.py
@@ -131,7 +131,7 @@ class SimplePushHandler(BaseWebHandler):
         elif response.status_code == 202 or response.logged_status == 202:
             self.log.info(format="Router miss, message stored.",
                           client_info=self._client_info)
-        time_diff = time.time() - self.start_time
+        time_diff = time.time() - self._start_time
         self.metrics.timing("updates.handled", duration=time_diff)
         response.response_body = (
             response.response_body + " " + warning).strip()

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -348,6 +348,7 @@ class WebPushHandler(BaseWebHandler):
         self._client_info["message_size"] = len(notification.data or "")
         self._client_info["ttl"] = notification.ttl
         self._client_info["version"] = notification.version
+        self._router_time = time.time()
         d = Deferred()
         d.addCallback(router.route_notification, user_data)
         d.addCallback(self._router_completed, user_data, "")
@@ -359,9 +360,10 @@ class WebPushHandler(BaseWebHandler):
 
     def _router_completed(self, response, uaid_data, warning=""):
         """Called after router has completed successfully"""
+        # Log the time taken for routing
+        self._timings["route_time"] = time.time() - self._router_time
         # Were we told to update the router data?
-        time_diff = time.time() - self.start_time
-        self._client_info["route_time"] = time_diff
+        time_diff = time.time() - self._start_time
         if response.router_data is not None:
             if not response.router_data:
                 # An empty router_data object indicates that the record should


### PR DESCRIPTION
Add's full request timing with validation and routing break-outs. Also logs the request
and validation timing even if validation fails or routing otherwise errors out.

Closes #758