### PR TITLE
feat: log the python version in client_info

### DIFF
--- a/autopush/base.py
+++ b/autopush/base.py
@@ -1,3 +1,4 @@
+import sys
 import uuid
 
 import cyclone.web
@@ -25,6 +26,7 @@ class BaseHandler(cyclone.web.RequestHandler):
             authorization=self.request.headers.get('authorization', ""),
             message_ttl=self.request.headers.get('ttl', ""),
             uri=self.request.uri,
+            python_version=sys.version,
         )
 
     def write_error(self, code, **kwargs):

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -5,6 +5,7 @@ import os
 import random
 import signal
 import subprocess
+import sys
 import time
 import urlparse
 import uuid
@@ -634,6 +635,15 @@ class TestSimple(IntegrationBase):
                 yield client.sleep(1)
         log.debug("Last connected time: %s", c.get("last_connect", "None"))
         eq_(True, has_connected_this_month(c))
+
+    @inlineCallbacks
+    def test_endpoint_client_info(self):
+        client = yield self.quick_register()
+        result = yield client.send_notification()
+        ok_(result is not None)
+        ok_(self.logs.logged_ci(
+            lambda ci: ci['python_version'] == sys.version))
+        yield self.shut_down(client)
 
 
 class TestData(IntegrationBase):


### PR DESCRIPTION
assuming nothing minds newlines in this value: sys.version should suffice

