### PR TITLE
fix: prefer the LogBeginner observer entry point

### DIFF
--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -45,6 +45,7 @@ from autopush.db import (
     get_month,
     has_connected_this_month
 )
+from autopush.logging import begin_or_register
 from autopush.main import endpoint_paths
 from autopush.settings import AutopushSettings
 from autopush.utils import base64url_encode
@@ -372,7 +373,7 @@ class IntegrationBase(unittest.TestCase):
         )
 
         self.logs = TestingLogObserver()
-        globalLogPublisher.addObserver(self.logs)
+        begin_or_register(self.logs)
 
         router_table = os.environ.get("ROUTER_TABLE", "router_int_test")
         storage_table = os.environ.get("STORAGE_TABLE", "storage_int_test")


### PR DESCRIPTION
otherwise its buffer pointlessly keeps around 65k old log message events for replaying

fixes #786

This should improve our memory usage

e.g. I was getting endpoint/connection up towards almost 1gb/360mb rss w/ about 15min of load from a bunch of aplt's notification_forever. With this fix we hover more around 225/190mb, maybe 250/200mb tops with more time/load thrown at it. Measurements all done on a local linux VM under pypy 5.6.0