### PR TITLE
feat: capture and metric item not found instead of log

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = -rtest-requirements.txt
 usedevelop = True
 passenv = SKIP_INTEGRATION
 commands =
-    nosetests {posargs} --with-object-tracker autopush
+    nosetests {posargs} autopush
 install_command = pip install --pre {opts} {packages}
 
 [testenv:pypy]


### PR DESCRIPTION
There's no need to log exceptions failing to save a message for a
user that has been deleted. Now a metric will be emitted instead.

This also tweaks the tox runner to no longer include object memory
tracking by default.

Closes #811