### PR TITLE
fix: prefer the create method

### DIFF
--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -50,7 +50,7 @@ class SinkMetrics(IMetrics):
 class TwistedMetrics(object):
     """Twisted implementation of statsd output"""
     def __init__(self, statsd_host="localhost", statsd_port=8125):
-        self.client = TwistedStatsDClient(statsd_host, statsd_port)
+        self.client = TwistedStatsDClient.create(statsd_host, statsd_port)
         self._metric = Metrics(connection=self.client, namespace="autopush")
 
     def start(self):

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -35,7 +35,7 @@ class TwistedMetricsTestCase(unittest.TestCase):
     @patch("autopush.metrics.reactor")
     def test_basic(self, mock_reactor):
         twisted.internet.base.DelayedCall.debug = True
-        m = TwistedMetrics()
+        m = TwistedMetrics('127.0.0.1')
         m.start()
         ok_(len(mock_reactor.mock_calls) > 0)
         m._metric = Mock()


### PR DESCRIPTION
avoids the host resolver preventing flushing of the queued up metrics
in some cases

fixes #840