### PR TITLE
feat: Add ChannelID report for UAID

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -495,7 +495,8 @@ class Message(object):
         # Functions that call store_message() would be required to
         # update that list as well using register_channel()
         try:
-            result = self.table.get_item(consistent=True, uaid=hasher(uaid),
+            result = self.table.get_item(consistent=True,
+                                         uaid=hasher(uaid),
                                          chidmessageid=" ")
             return (True, result["chids"] or set([]))
         except ItemNotFound:

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -510,3 +510,44 @@ Remove a given ChannelID subscription from a UAID.
 **Return Codes:**
 
 See :ref:`errors`.
+
+Get Known Channels for a UAID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fetch the known ChannelIDs for a given bridged endpoint. This is useful to check link status.
+If no channelIDs are present for a given UAID, an empty set of channelIDs will be returned.
+
+**Call:**
+
+.. http:get:: /v1/{type}/{app_id}/registration/{UAID}/
+
+    Authorization: Bearer {secret}
+
+**Parameters:**
+
+  {}
+
+**Reply:**
+
+.. code-block:: json
+
+    {"uaid": {UAID}, "channelIDs": [{ChannelID}, ...]}
+
+example:
+
+.. code-block:: http
+
+    > GET /v1/gcm/33clienttoken33/registration/abcdef012345/
+    > Authorization: Bearer 00secret00
+    >
+    > {}
+
+.. code-block:: json
+
+    < {"uaid": "abcdef012345",
+    < "channelIDS": ["01234567-0000-1111-2222-0123456789ab", "76543210-0000-1111-2222-0123456789ab"]}
+
+**Return Codes:**
+
+
+See :ref:`errors`.


### PR DESCRIPTION
Adds new bridge system HTTP endpoint to fetch a list of server known
CHIDs for a given UAID. Useful for remote clients to check status. (see
documentation for calling structure and return).

Also fixed an edge case where clients that may have been forced offline
due to external system errors could still register new endpoints. The
behavior will now be to return a 410 error if a client has been flagged
as disconnected by the server. It is up to the client to check the local
bridge connection and re-establish any endpoints.

closes: #844, #843