### PR TITLE
bug: enforce `senderID` for gcm/fcm

### DIFF
--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -111,13 +111,11 @@ class GCMRouter(object):
             dry_run=self.dryRun or ("dryrun" in router_data),
             data=data,
         )
-        creds = router_data.get("creds", {"senderID": "missing id"})
         try:
-            gcm = self.gcm[creds['senderID']]
+            gcm = self.gcm[router_data['creds']['senderID']]
             result = gcm.send(payload)
         except KeyError:
-            self.log.critical("Missing GCM bridge credentials for : %s" %
-                              creds.get("senderID"))
+            self.log.critical("Missing GCM bridge credentials")
             raise RouterException("Server error", status_code=500)
         except gcmclient.GCMAuthenticationError as e:
             self.log.error("GCM Authentication Error: %s" % e)

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -310,6 +310,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         result, errors = schema.load(self._make_test_data())
         eq_(errors, {})
@@ -325,6 +326,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         data = self._make_test_data(body="asdfasdf")
 
@@ -421,6 +423,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         info = self._make_test_data(
             headers={
@@ -444,6 +447,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         info = self._make_test_data(
             headers={
@@ -470,6 +474,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         info = self._make_test_data(
             headers={
@@ -494,6 +499,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         info = self._make_test_data(
             headers={
@@ -518,6 +524,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         info = self._make_test_data(
             headers={
@@ -543,6 +550,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
             uaid=dummy_uaid,
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         info = self._make_test_data(
             headers={
@@ -568,6 +576,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
             uaid=dummy_uaid,
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         schema.context["settings"].max_data = 1
 
@@ -590,6 +599,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
 
         with assert_raises(InvalidRequest) as cm:
@@ -606,6 +616,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
 
         padded_value = "asdfjiasljdf==="
@@ -633,6 +644,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         )
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
 
         padded_value = "asdfjiasljdf==="
@@ -664,6 +676,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
             uaid=dummy_uaid,
+            router_data=dict(creds=dict(senderID="bogus")),
         )
 
         info = self._make_test_data(
@@ -691,6 +704,7 @@ class TestWebPushRequestSchema(unittest.TestCase):
         schema.context["settings"].router.get_uaid.return_value = dict(
             router_type="gcm",
             uaid=dummy_uaid,
+            router_data=dict(creds=dict(senderID="bogus")),
         )
 
         info = self._make_test_data(
@@ -780,6 +794,7 @@ class TestWebPushRequestSchemaUsingVapid(unittest.TestCase):
         settings.router.get_uaid.return_value = dict(
             router_type="gcm",
             uaid=dummy_uaid,
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         settings.fernet = self.fernet_mock = Mock()
         return schema

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -175,7 +175,8 @@ class TestWebpushHandler(unittest.TestCase):
         self.ap_settings.router.get_uaid.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
-            router_type="gcm"
+            router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         self.wp.post()
         return self.finish_deferred
@@ -192,7 +193,8 @@ class TestWebpushHandler(unittest.TestCase):
         self.ap_settings.router.get_uaid.return_value = dict(
             uaid=dummy_uaid,
             chid=dummy_chid,
-            router_type="gcm"
+            router_type="gcm",
+            router_data=dict(creds=dict(senderID="bogus")),
         )
         self.wp.post()
         return self.finish_deferred

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -78,6 +78,14 @@ class WebPushSubscriptionSchema(Schema):
         if result.get("router_type") not in ["webpush", "gcm", "apns", "fcm"]:
             raise InvalidRequest("Wrong URL for user", errno=108)
 
+        if (result.get("router_type") in ["gcm", "fcm"]
+            and 'senderID' not in result.get('router_data',
+                                             {}).get("creds", {})):
+                # Make sure we note that this record is bad.
+                result['critical_failure'] = \
+                    result.get('critical_failure', "Missing SenderID")
+                settings.router.register_user(result)
+
         if result.get("critical_failure"):
             raise InvalidRequest("Critical Failure: %s" %
                                  result.get("critical_failure"),


### PR DESCRIPTION
closes #868