### PR TITLE
feat: handle JSONResponse errors like provisioned errors

### DIFF
--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -937,8 +937,11 @@ class WebsocketTestCase(unittest.TestCase):
 
         return self._check_response(check_result)
 
-    def test_hello_jsonresponseerror_logged(self):
+    def test_hello_jsonresponseerror(self):
         self._connect()
+
+        self.proto.randrange = Mock()
+        self.proto.randrange.return_value = 0.1
 
         def throw_error(*args, **kwargs):
             raise JSONResponseError(None, None)
@@ -950,9 +953,7 @@ class WebsocketTestCase(unittest.TestCase):
 
         def check_result(msg):
             eq_(msg["status"], 503)
-            eq_(msg["reason"], "error")
-            self.proto.log.info.assert_called()
-            self.proto.log.failure.assert_not_called()
+            eq_(msg["reason"], "error - overloaded")
             self.flushLoggedErrors()
 
         return self._check_response(check_result)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -445,12 +445,8 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
 
     def log_failure(self, failure, **kwargs):
         """Log a twisted failure out through twisted's log.failure"""
-        exc = failure.value
-        if isinstance(exc, JSONResponseError):
-            self.log.info("JSONResponseError: {exc}", exc=exc, **kwargs)
-        else:
-            self.log.failure(format="Unexpected error", failure=failure,
-                             **kwargs)
+        self.log.failure(format="Unexpected error", failure=failure,
+                         **kwargs)
 
     @property
     def paused(self):
@@ -724,7 +720,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             self.sendClose()
 
     def err_overload(self, failure, message_type, disconnect=True):
-        """Handle database overloads
+        """Handle database overloads and errors
 
         If ``disconnect`` is False, the an overload error is returned and the
         client is not disconnected.
@@ -738,7 +734,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         :param disconnect: Whether the client should be disconnected or not.
 
         """
-        failure.trap(ProvisionedThroughputExceededException)
+        failure.trap(JSONResponseError)
 
         if disconnect:
             self.transport.pauseProducing()


### PR DESCRIPTION
When handling provisioned errors, the same logic should be used as when
a JSONResponseError occurs.

Closes #744