### PR TITLE
refactor: bring in cyclone trunk's testing client

### DIFF
--- a/autopush/http.py
+++ b/autopush/http.py
@@ -83,6 +83,21 @@ class BaseHTTPFactory(cyclone.web.Application):
     def _hostname(self):
         return self.ap_settings.hostname
 
+    @classmethod
+    def for_handler(cls, handler_cls, *args, **kwargs):
+        # type: (Type[BaseHandler], *Any, **Any) -> BaseHTTPFactory
+        """Create a cyclone app around a specific handler_cls.
+
+        handler_cls must be included in ap_handlers or a ValueError is
+        thrown.
+
+        """
+        for pattern, handler in cls.ap_handlers:
+            if handler is handler_cls:
+                return cls(handlers=[(pattern, handler)], *args, **kwargs)
+        raise ValueError("{!r} not in ap_handlers".format(
+            handler_cls))  # pragma: nocover
+
 
 class EndpointHTTPFactory(BaseHTTPFactory):
 

--- a/autopush/tests/client.py
+++ b/autopush/tests/client.py
@@ -1,0 +1,133 @@
+#
+# Copyright 2014 David Novakovic
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from cyclone.httpserver import HTTPRequest, HTTPConnection
+from cyclone.web import decode_signed_value
+from cyclone.httputil import HTTPHeaders
+import urllib
+from twisted.test import proto_helpers
+from twisted.internet.defer import inlineCallbacks, returnValue
+from Cookie import SimpleCookie
+
+
+class DecodingSimpleCookie(SimpleCookie):
+    def __init__(self, app, *args, **kwargs):
+        self.app = app
+
+    def get_secure_cookie(self, name, value=None, max_age_days=31):
+
+        if value is None and name in self:
+            value = self[name].value
+        return decode_signed_value(
+            self.app.settings["cookie_secret"],
+            name, value, max_age_days=max_age_days)
+
+
+class Client(object):
+    def __init__(self, app):
+        self.app = app
+        self.cookies = DecodingSimpleCookie(self.app)
+
+    def get(self, uri, params=None, version="HTTP/1.0", headers=None,
+            body=None, remote_ip=None, protocol=None, host=None,
+            files=None, connection=None):
+        return self.request(
+            "GET", uri, params=params, version=version, headers=headers,
+            body=body, remote_ip=remote_ip, protocol=protocol, host=host,
+            files=files, connection=connection
+        )
+
+    def put(self, uri, params=None, version="HTTP/1.0", headers=None,
+            body=None, remote_ip=None, protocol=None, host=None,
+            files=None, connection=None):
+        return self.request(
+            "PUT", uri, params=params, version=version, headers=headers,
+            body=body, remote_ip=remote_ip, protocol=protocol, host=host,
+            files=files, connection=connection
+        )
+
+    def post(self, uri, params=None, version="HTTP/1.0", headers=None,
+             body=None, remote_ip=None, protocol=None, host=None,
+             files=None, connection=None):
+        return self.request(
+            "POST", uri, params=params, version=version, headers=headers,
+            body=body, remote_ip=remote_ip, protocol=protocol, host=host,
+            files=files, connection=connection
+        )
+
+    def delete(self, uri, params=None, version="HTTP/1.0", headers=None,
+               body=None, remote_ip=None, protocol=None, host=None,
+               files=None, connection=None):
+        return self.request(
+            "DELETE", uri, params=params, version=version, headers=headers,
+            body=body, remote_ip=remote_ip, protocol=protocol, host=host,
+            files=files, connection=connection
+        )
+
+    def head(self, uri, params=None, version="HTTP/1.0", headers=None,
+             body=None, remote_ip=None, protocol=None, host=None,
+             files=None, connection=None):
+        return self.request(
+            "HEAD", uri, params=params, version=version, headers=headers,
+            body=body, remote_ip=remote_ip, protocol=protocol, host=host,
+            files=files, connection=connection
+        )
+
+    @inlineCallbacks
+    def request(self, method, uri, *args, **kwargs):
+        params = kwargs.pop("params", {}) or {}
+        if method in ["GET", "HEAD", "OPTIONS"] and params:
+            uri = uri + "?" + urllib.urlencode(params)
+        elif method in ["POST", "PATCH", "PUT"]\
+                and params and not kwargs['body']:
+            kwargs['body'] = urllib.urlencode(params)  # pragma: no cover
+        connection = kwargs.pop('connection')
+        if not connection:
+            connection = HTTPConnection()
+            connection.xheaders = False
+            kwargs['connection'] = connection
+        connection.factory = self.app
+        cookie_value = self.cookies.output(header="")
+        if cookie_value.strip():
+            if kwargs['headers'] is None:
+                kwargs['headers'] = {}
+            kwargs['headers']['Cookie'] = cookie_value.strip()
+        request = HTTPRequest(method, uri, *args, **kwargs)
+        for k, p in params.items():
+            request.arguments.setdefault(k, []).append(p)
+        connection.connectionMade()
+        connection._request = request
+        connection.transport = proto_helpers.StringTransport()
+        request.remote_ip = connection.transport.getHost().host
+        handler = self.app(request)
+
+        def setup_response():
+            headers = HTTPHeaders()
+            for line in handler._generate_headers().split("\r\n"):
+                if line.startswith("HTTP") or not line.strip():
+                    continue
+                headers.parse_line(line)
+            for cookie in headers.get_list("Set-Cookie"):
+                self.cookies.load(cookie)
+            response_body = connection.transport.io.getvalue()
+            handler.content = response_body.split("\r\n\r\n", 1)[1]
+            handler.headers = headers
+
+        if handler._finished:
+            setup_response()
+            returnValue(handler)
+        yield connection.notifyFinish()
+        setup_response()
+        returnValue(handler)

--- a/autopush/tests/test_client.py
+++ b/autopush/tests/test_client.py
@@ -1,0 +1,131 @@
+#
+# Copyright 2014 David Novakovic
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from twisted.trial import unittest
+from cyclone.web import Application, RequestHandler, asynchronous
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
+
+from autopush.tests.client import Client
+
+
+class TestHandler(RequestHandler):
+    def get(self):
+        self.write("Something")
+
+    def post(self):
+        self.write("Something posted")
+
+    def put(self):
+        self.write("Something put")
+
+    def head(self):
+        self.write("")
+
+    def delete(self):
+        self.write("")
+
+
+class DeferredTestHandler(RequestHandler):
+    @asynchronous
+    def get(self):
+        self.write("Something...")
+        reactor.callLater(0.1, self.do_something)
+
+    def do_something(self):
+        self.write("done!")
+        self.finish()
+
+
+class CookieTestHandler(RequestHandler):
+    def get(self):
+        self.set_secure_cookie("test_cookie", "test_value")
+        self.finish()
+
+    def post(self):
+        value = self.get_secure_cookie("test_cookie")
+        self.finish(value)
+
+
+def mock_app_builder():
+    return Application([
+        (r'/testing/', TestHandler),
+        (r'/deferred_testing/', DeferredTestHandler),
+        (r'/cookie_testing/', CookieTestHandler),
+    ], cookie_secret="insecure")
+
+
+class TestClient(unittest.TestCase):
+    def setUp(self):
+        self.app = mock_app_builder()
+        self.client = Client(self.app)
+
+    def test_create_client(self):
+        app = mock_app_builder()
+        client = Client(app)
+        self.assertTrue(client.app)
+
+    @inlineCallbacks
+    def test_get_request(self):
+        response = yield self.client.get("/testing/")
+        self.assertEqual(response.content, "Something")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_get_request_with_params(self):
+        response = yield self.client.get("/testing/", {"q": "query"})
+        self.assertEqual(response.content, "Something")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_post_request(self):
+        response = yield self.client.post("/testing/")
+        self.assertEqual(response.content, "Something posted")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_put_request(self):
+        response = yield self.client.put("/testing/")
+        self.assertEqual(response.content, "Something put")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_head_request(self):
+        response = yield self.client.head("/testing/")
+        self.assertEqual(response.content, "")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_delete_request(self):
+        response = yield self.client.delete("/testing/")
+        self.assertEqual(response.content, "")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_get_deferred_request(self):
+        response = yield self.client.get("/deferred_testing/")
+        self.assertEqual(response.content, "Something...done!")
+        self.assertTrue(len(response.headers) > 3)
+
+    @inlineCallbacks
+    def test_cookies(self):
+        response = yield self.client.get("/cookie_testing/")
+        self.assertEqual(
+            self.client.cookies.get_secure_cookie("test_cookie"),
+            "test_value"
+        )
+
+        response = yield self.client.post("/cookie_testing/")
+        self.assertEqual(response.content, "test_value")

--- a/autopush/web/message.py
+++ b/autopush/web/message.py
@@ -14,9 +14,6 @@ class MessageSchema(Schema):
     @pre_load
     def extract_data(self, req):
         message_id = req['path_kwargs'].get('message_id')
-        if not message_id:
-            raise InvalidRequest("Missing Token",
-                                 status_code=400)
         try:
             notif = WebPushNotification.from_message_id(
                 bytes(message_id),


### PR DESCRIPTION
(from:
 https://github.com/fiorix/cyclone/blob/c1f830e/cyclone/testing/client.py
 https://github.com/fiorix/cyclone/blob/9f0dff1/cyclone/tests/test_testing.py
 -> test_client.py)

refactor test_endpoint around it & inlineCallbacks

issue #871