### PR TITLE
refactor: convert handler tests to client/inlineCallbacks

### DIFF
--- a/autopush/http.py
+++ b/autopush/http.py
@@ -92,7 +92,9 @@ class BaseHTTPFactory(cyclone.web.Application):
         thrown.
 
         """
-        for pattern, handler in cls.ap_handlers:
+        if 'handlers' in kwargs:  # pragma: nocover
+            raise ValueError("handler_cls incompatibile with handlers kwarg")
+        for pattern, handler in cls.ap_handlers + cls.health_ap_handlers:
             if handler is handler_cls:
                 return cls(handlers=[(pattern, handler)], *args, **kwargs)
         raise ValueError("{!r} not in ap_handlers".format(

--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -60,15 +60,19 @@ IGNORED_KEYS = frozenset([
 began_logging = False
 
 
-def begin_or_register(observer):
-    # type: (Any) -> None
+def begin_or_register(observer, redirectStandardIO=False, **kwargs):
+    # type: (Any, bool, **Any) -> None
     """Register observer with the global LogPublisher
 
     Registers via the global LogBeginner the first time called.
     """
     global began_logging
     if not began_logging:
-        globalLogBeginner.beginLoggingTo([observer], redirectStandardIO=False)
+        globalLogBeginner.beginLoggingTo(
+            [observer],
+            redirectStandardIO=redirectStandardIO,
+            **kwargs
+        )
         began_logging = True
     else:
         globalLogPublisher.addObserver(observer)

--- a/autopush/tests/support.py
+++ b/autopush/tests/support.py
@@ -1,0 +1,30 @@
+from twisted.logger import ILogObserver
+from zope.interface import implementer
+
+
+@implementer(ILogObserver)
+class TestingLogObserver(object):
+    def __init__(self):
+        self._events = []
+
+    def __call__(self, event):
+        self._events.append(event)
+
+    def __len__(self):
+        return len(self._events)
+
+    def logged(self, predicate):
+        """Determine if any log events satisfy the callable"""
+        assert callable(predicate)
+        return any(predicate(e) for e in self._events)
+
+    def logged_ci(self, predicate):
+        """Determine if any log client_infos satisfy the callable"""
+        assert callable(predicate)
+        return self.logged(
+            lambda e: 'client_info' in e and predicate(e['client_info']))
+
+    def logged_session(self):
+        """Extract the last logged session"""
+        return filter(lambda e: e["log_format"] == "Session",
+                      self._events)[-1]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 python_version = 2.7
-fast_parser = true
 ignore_missing_imports = true
 follow_imports = skip
 warn_unused_ignores = true


### PR DESCRIPTION
and remove mypy's deprecated fast_parser option

issue #871