### PR TITLE
feat: switch to new iOS mutable aps payload

### DIFF
--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -133,7 +133,10 @@ class APNSRouter(object):
                 payload["cryptokey"] = notification.headers["crypto_key"]
             elif "encryption_key" in notification.headers:
                 payload["enckey"] = notification.headers["encryption_key"]
-            payload['aps'] = router_data.get('aps', {"content-available": 1})
+            payload['aps'] = router_data.get('aps', {
+                "mutable-content": 1,
+                "alert": {"title": " ", "body": " "}
+            })
         apns_id = str(uuid.uuid4()).lower()
         try:
             apns_client.send(router_token=router_token, payload=payload,

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -1987,6 +1987,57 @@ class TestAPNSBridgeIntegration(IntegrationBase):
         )
         response, body = yield _agent('POST', url, body=json.dumps(
             {"token": uuid.uuid4().hex,
+             }
+        ))
+        eq_(response.code, 200)
+        jbody = json.loads(body)
+
+        # Send a fake message
+        data = ("\xa2\xa5\xbd\xda\x40\xdc\xd1\xa5\xf9\x6a\x60\xa8\x57\x7b\x48"
+                "\xe4\x43\x02\x5a\x72\xe0\x64\x69\xcd\x29\x6f\x65\x44\x53\x78"
+                "\xe1\xd9\xf6\x46\x26\xce\x69")
+        crypto_key = ("keyid=p256dh;dh=BAFJxCIaaWyb4JSkZopERL9MjXBeh3WdBxew"
+                      "SYP0cZWNMJaT7YNaJUiSqBuGUxfRj-9vpTPz5ANmUYq3-u-HWOI")
+        salt = "keyid=p256dh;salt=S82AseB7pAVBJ2143qtM3A"
+        content_encoding = "aesgcm"
+
+        response, body = yield _agent(
+            'POST',
+            str(jbody['endpoint']),
+            headers=Headers({
+                "crypto-key": [crypto_key],
+                "encryption": [salt],
+                "ttl": ["0"],
+                "content-encoding": [content_encoding],
+            }),
+            body=data
+        )
+
+        ca_data = json.loads(
+            self._mock_connection.request.call_args[1]['body'])
+        eq_(response.code, 201)
+        # ChannelID here MUST match what we got from the registration call.
+        # Currently, this is a lowercase, hex UUID without dashes.
+        eq_(ca_data['chid'], jbody['channelID'])
+        eq_(ca_data['con'], content_encoding)
+        eq_(ca_data['cryptokey'], crypto_key)
+        eq_(ca_data['enc'], salt)
+        ok_('mutable-content' in ca_data['aps'])
+        eq_(ca_data['aps']['alert']['title'], " ")
+        eq_(ca_data['aps']['alert']['body'], " ")
+        eq_(ca_data['body'], base64url_encode(data))
+
+    @inlineCallbacks
+    def test_registration_aps_override(self):
+        self._add_router()
+        # get the senderid
+        url = "{}/v1/{}/{}/registration".format(
+            self.ep.settings.endpoint_url,
+            "apns",
+            "firefox",
+        )
+        response, body = yield _agent('POST', url, body=json.dumps(
+            {"token": uuid.uuid4().hex,
              "aps": {"foo": "bar", "gorp": "baz"}
              }
         ))
@@ -2023,7 +2074,7 @@ class TestAPNSBridgeIntegration(IntegrationBase):
         eq_(ca_data['con'], content_encoding)
         eq_(ca_data['cryptokey'], crypto_key)
         eq_(ca_data['enc'], salt)
-        ok_('alert' not in ca_data['aps'])
+        ok_('mutable-content' not in ca_data['aps'])
         eq_(ca_data['aps']['foo'], "bar")
         eq_(ca_data['body'], base64url_encode(data))
 

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -190,7 +190,8 @@ class APNSRouterTestCase(unittest.TestCase):
             "enc": "test",
             "ver": 10,
             "aps": {
-                "content-available": 1,
+                "mutable-content": 1,
+                "alert": {"title": " ", "body": " "}
             },
             "enckey": "test",
             "con": "aesgcm",

--- a/autopush/web/registration.py
+++ b/autopush/web/registration.py
@@ -3,7 +3,8 @@ import uuid
 from typing import (  # noqa
     Optional,
     Set,
-    Tuple
+    Tuple,
+    Dict
 )
 
 import simplejson as json
@@ -71,7 +72,6 @@ class TokenSchema(SubInfoSchema):
     """Filters allowed values from body data"""
     token = fields.Str(allow_none=True)
     # Temporarily allow 'aps' definition data for iOS.
-    # TODO: lock down dict content to just allowed extra values.
     aps = fields.Dict(allow_none=True)
 
 


### PR DESCRIPTION
This is a 'quick' patch to get a testable version in the hands of
outside parties quickly. A future fix will limit the 'aps' payload
option only to the 'dev' platform.

issue #910