### PR TITLE
fix: avoid firehose logger spinning the CPU

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -266,9 +266,9 @@ class FirehoseProcessor(object):
         self._last_send = time.time()
         while True:
             time_since_sent = time.time() - self._last_send
+            remaining_wait = self.MAX_INTERVAL - time_since_sent
             try:
-                record = self._records.get(
-                    timeout=max(self.MAX_INTERVAL-time_since_sent, 0))
+                record = self._records.get(timeout=remaining_wait)
             except Queue.Empty:
                 # Send the records
                 self._send_record_batch()
@@ -294,6 +294,7 @@ class FirehoseProcessor(object):
         self._send_record_batch()
 
     def _send_record_batch(self):
+        self._last_send = time.time()
         if not self._prepped:
             return
 
@@ -312,4 +313,3 @@ class FirehoseProcessor(object):
 
         self._prepped = []
         self._total_size = 0
-        self._last_send = time.time()

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -1,5 +1,6 @@
 import json
 import os
+import Queue
 import sys
 import StringIO
 
@@ -210,10 +211,13 @@ class FirehoseProcessorTestCase(twisted.trial.unittest.TestCase):
     def test_queue_timeout(self):
         proc = FirehoseProcessor("test")
         proc.MAX_INTERVAL = 0
+        proc._records.get = mock_get = Mock()
+        proc._send_record_batch = mock_send = Mock()
+        mock_get.side_effect = (Queue.Empty, None)
 
         proc.start()
         proc.stop()
-        eq_(len(self.mock_boto.mock_calls), 1)
+        mock_send.assert_called()
 
     def test_batch_send_failure(self):
         proc = FirehoseProcessor("test")


### PR DESCRIPTION
Under no load, the Firehose logger spun the CPU because the max
of (MAX_INTERVAL-time_since_sent, 0) always resulted in 0. This
is because the time_since_sent became quite large, and the
MAX_INTERVAL was only 30 resulting in a high negative number. 0
was the max, so the loop would spin.

What was actually intended was to never wait more than MAX_INTERVAL
before trying to send a batch. That requires taking the min value
since last sent or the MAX_INTERVAL.