### PR TITLE
fix: ensure simplepush messages log message_id as str

### DIFF
--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1420,7 +1420,8 @@ class WebsocketTestCase(unittest.TestCase):
         assert_called_included(self.proto.log.info,
                                format="Ack",
                                router_key="simplepush",
-                               message_source="direct")
+                               message_source="direct",
+                               message_id=str(12))
 
     def test_ack_with_bad_input(self):
         self._connect()
@@ -1445,7 +1446,8 @@ class WebsocketTestCase(unittest.TestCase):
         assert_called_included(self.proto.log.info,
                                format="Ack",
                                router_key="webpush",
-                               message_source="direct")
+                               message_source="direct",
+                               message_id=dummy_version)
 
     def test_ack_with_webpush_from_storage(self):
         self._connect()

--- a/autopush/web/simplepush.py
+++ b/autopush/web/simplepush.py
@@ -109,7 +109,7 @@ class SimplePushHandler(BaseWebHandler):
         self._client_info.update(
             uaid_hash=hasher(user_data.get("uaid")),
             channel_id=user_data.get("chid"),
-            message_id=version,
+            message_id=str(version),
             router_key=user_data["router_type"]
         )
         notification = Notification(

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -1445,7 +1445,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
            self.ps.direct_updates[chid] <= version:
             del self.ps.direct_updates[chid]
             self.log.info(format="Ack", router_key="simplepush",
-                          channel_id=chid, message_id=version,
+                          channel_id=chid, message_id=str(version),
                           message_source="direct",
                           uaid_hash=self.ps.uaid_hash,
                           user_agent=self.ps.user_agent, code=code,
@@ -1453,7 +1453,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             self.ps.stats.direct_acked += 1
             return
         self.log.info(format="Ack", router_key="simplepush", channel_id=chid,
-                      message_id=version, message_source="stored",
+                      message_id=str(version), message_source="stored",
                       uaid_hash=self.ps.uaid_hash,
                       user_agent=self.ps.user_agent, code=code,
                       **self.ps.raw_agent)
@@ -1491,7 +1491,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             return
 
         self.log.info(format="Nack", uaid_hash=self.ps.uaid_hash,
-                      user_agent=self.ps.user_agent, message_id=version,
+                      user_agent=self.ps.user_agent, message_id=str(version),
                       code=code, **self.ps.raw_agent)
         self.ps.stats.nacks += 1
 


### PR DESCRIPTION
For logging consistency on the backend we should use the same type
for logging values for the same key. Simplepush was logging its
version as an int however.

Closes #925