### PR TITLE
refactor: begin tearing apart AutopushSettings

### DIFF
--- a/autopush/base.py
+++ b/autopush/base.py
@@ -1,9 +1,15 @@
 import sys
 import uuid
+from typing import TYPE_CHECKING
 
 import cyclone.web
 from twisted.logger import Logger
 from twisted.python import failure
+
+if TYPE_CHECKING:  # pragma: nocover
+    from autopush.db import DatabaseManager  # noqa
+    from autopush.metrics import IMetrics  # noqa
+    from autopush.settings import AutopushSettings  # noqa
 
 
 class BaseHandler(cyclone.web.RequestHandler):
@@ -11,10 +17,24 @@ class BaseHandler(cyclone.web.RequestHandler):
 
     log = Logger()
 
-    def initialize(self, ap_settings):
-        """Setup basic attributes from AutopushSettings"""
-        self.ap_settings = ap_settings
+    def initialize(self):
+        """Initialize info from the client"""
         self._client_info = self._init_info()
+
+    @property
+    def ap_settings(self):
+        # type: () -> AutopushSettings
+        return self.application.ap_settings
+
+    @property
+    def db(self):
+        # type: () -> DatabaseManager
+        return self.application.db
+
+    @property
+    def metrics(self):
+        # type: () -> IMetrics
+        return self.db.metrics
 
     def _init_info(self):
         return dict(

--- a/autopush/router/__init__.py
+++ b/autopush/router/__init__.py
@@ -4,11 +4,32 @@ This package contains notification routers that handle routing a notification
 through the appropriate system for a given client.
 
 """
+from typing import Dict  # noqa
+
+from autopush.db import DatabaseManager  # noqa
 from autopush.router.apnsrouter import APNSRouter
 from autopush.router.gcm import GCMRouter
+from autopush.router.interface import IRouter  # noqa
 from autopush.router.simple import SimpleRouter
 from autopush.router.webpush import WebPushRouter
 from autopush.router.fcm import FCMRouter
+from autopush.settings import AutopushSettings  # noqa
 
 __all__ = ["APNSRouter", "FCMRouter", "GCMRouter", "SimpleRouter",
            "WebPushRouter"]
+
+
+def routers_from_settings(settings, db):
+    # type: (AutopushSettings, DatabaseManager) -> Dict[str, IRouter]
+    """Create a dict of IRouters for the given settings"""
+    router_conf = settings.router_conf
+    routers = dict(
+        simplepush=SimpleRouter(
+            settings, router_conf.get("simplepush"), db),
+        webpush=WebPushRouter(settings, None, db)
+    )
+    if 'apns' in router_conf:
+        routers["apns"] = APNSRouter(settings, router_conf["apns"], db.metrics)
+    if 'gcm' in router_conf:
+        routers["gcm"] = GCMRouter(settings, router_conf["gcm"], db.metrics)
+    return routers

--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -100,15 +100,16 @@ class FCMRouter(object):
         }
     }
 
-    def __init__(self, ap_settings, router_conf):
+    def __init__(self, ap_settings, router_conf, metrics):
         """Create a new FCM router and connect to FCM"""
+        self.ap_settings = ap_settings
         self.config = router_conf
+        self.metrics = metrics
         self.min_ttl = router_conf.get("ttl", 60)
         self.dryRun = router_conf.get("dryrun", False)
         self.collapseKey = router_conf.get("collapseKey", "webpush")
         self.senderID = router_conf.get("senderID")
         self.auth = router_conf.get("auth")
-        self.metrics = ap_settings.metrics
         self._base_tags = []
         try:
             self.fcm = pyfcm.FCMNotification(api_key=self.auth)
@@ -117,7 +118,6 @@ class FCMRouter(object):
                            ex=e)
             raise IOError("FCM Bridge not initiated in main")
         self.log.debug("Starting FCM router...")
-        self.ap_settings = ap_settings
 
     def amend_endpoint_response(self, response, router_data):
         # type: (JSONDict, JSONDict) -> None

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -18,9 +18,11 @@ class GCMRouter(object):
     collapseKey = "simplepush"
     MAX_TTL = 2419200
 
-    def __init__(self, ap_settings, router_conf):
+    def __init__(self, ap_settings, router_conf, metrics):
         """Create a new GCM router and connect to GCM"""
+        self.ap_settings = ap_settings
         self.config = router_conf
+        self.metrics = metrics
         self.min_ttl = router_conf.get("ttl", 60)
         self.dryRun = router_conf.get("dryrun", False)
         self.collapseKey = router_conf.get("collapseKey", "simplepush")
@@ -36,11 +38,8 @@ class GCMRouter(object):
                 self.gcm[sid] = gcmclient.GCM(auth)
             except:
                 raise IOError("GCM Bridge not initiated in main")
-        self.metrics = ap_settings.metrics
         self._base_tags = []
-        self.router_table = ap_settings.router
         self.log.debug("Starting GCM router...")
-        self.ap_settings = ap_settings
 
     def amend_endpoint_response(self, response, router_data):
         # type: (JSONDict, JSONDict) -> None

--- a/autopush/router/interface.py
+++ b/autopush/router/interface.py
@@ -24,7 +24,7 @@ class RouterResponse(object):
 
 
 class IRouter(object):
-    def __init__(self, settings, router_conf):
+    def __init__(self, settings, router_conf, **kwargs):
         """Initialize the Router to handle notifications and registrations with
         the given settings and router conf."""
         raise NotImplementedError("__init__ must be implemented")

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -40,12 +40,16 @@ class SimpleRouter(object):
     """
     log = Logger()
 
-    def __init__(self, ap_settings, router_conf):
+    def __init__(self, ap_settings, router_conf, db):
         """Create a new SimpleRouter"""
         self.ap_settings = ap_settings
-        self.metrics = ap_settings.metrics
         self.conf = router_conf
+        self.db = db
         self.waker = None
+
+    @property
+    def metrics(self):
+        return self.db.metrics
 
     def register(self, uaid, router_data, app_id, *args, **kwargs):
         # type: (str, JSONDict, str, *Any, **Any) -> None
@@ -70,7 +74,7 @@ class SimpleRouter(object):
         node_id = uaid_data.get("node_id")
         uaid = uaid_data["uaid"]
         self.udp = uaid_data.get("udp")
-        router = self.ap_settings.router
+        router = self.db.router
 
         # Node_id is present, attempt delivery.
         # - Send Notification to node
@@ -181,7 +185,7 @@ class SimpleRouter(object):
 
         """
         uaid = uaid_data["uaid"]
-        return deferToThread(self.ap_settings.storage.save_notification,
+        return deferToThread(self.db.storage.save_notification,
                              uaid=uaid, chid=notification.channel_id,
                              version=notification.version)
 

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -89,6 +89,6 @@ class WebPushRouter(SimpleRouter):
                                            "Location": location},
                                   logged_status=204)
         return deferToThread(
-            self.ap_settings.message_tables[month_table].store_message,
+            self.db.message_tables[month_table].store_message,
             notification=notification,
         )

--- a/autopush/tests/support.py
+++ b/autopush/tests/support.py
@@ -1,5 +1,13 @@
+from mock import Mock
 from twisted.logger import ILogObserver
 from zope.interface import implementer
+
+from autopush.db import (
+    DatabaseManager,
+    Router,
+    Storage
+)
+from autopush.metrics import SinkMetrics
 
 
 @implementer(ILogObserver)
@@ -28,3 +36,12 @@ class TestingLogObserver(object):
         """Extract the last logged session"""
         return filter(lambda e: e["log_format"] == "Session",
                       self._events)[-1]
+
+
+def test_db(metrics=None):
+    """Return a test DatabaseManager: its Storage/Router are mocked"""
+    return DatabaseManager(
+        storage=Mock(spec=Storage),
+        router=Mock(spec=Router),
+        metrics=SinkMetrics() if metrics is None else metrics
+    )

--- a/autopush/tests/test_diagnostic_cli.py
+++ b/autopush/tests/test_diagnostic_cli.py
@@ -30,7 +30,7 @@ class DiagnosticCLITestCase(unittest.TestCase):
             "--router_tablename=fred",
             "http://someendpoint",
         ])
-        eq_(cli._settings.router_table.table_name, "fred")
+        eq_(cli.db.router.table.table_name, "fred")
 
     def test_bad_endpoint(self):
         cli = self._makeFUT([
@@ -41,16 +41,19 @@ class DiagnosticCLITestCase(unittest.TestCase):
         ok_(returncode not in (None, 0))
 
     @patch("autopush.diagnostic_cli.AutopushSettings")
-    def test_successfull_lookup(self, mock_settings_class):
+    @patch("autopush.diagnostic_cli.DatabaseManager.from_settings")
+    def test_successfull_lookup(self, mock_db_cstr, mock_settings_class):
         from autopush.diagnostic_cli import run_endpoint_diagnostic_cli
         mock_settings_class.return_value = mock_settings = Mock()
         mock_settings.parse_endpoint.return_value = dict(
             uaid="asdf", chid="asdf")
-        mock_settings.router.get_uaid.return_value = mock_item = FakeDict()
+
+        mock_db_cstr.return_value = mock_db = Mock()
+        mock_db.router.get_uaid.return_value = mock_item = FakeDict()
         mock_item._data = {}
         mock_item["current_month"] = "201608120002"
         mock_message_table = Mock()
-        mock_settings.message_tables = {"201608120002": mock_message_table}
+        mock_db.message_tables = {"201608120002": mock_message_table}
 
         run_endpoint_diagnostic_cli([
             "--router_tablename=fred",

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -2,7 +2,6 @@ import sys
 import uuid
 
 from boto.exception import BotoServerError
-from cyclone.web import Application
 from mock import Mock, patch
 from moto import mock_dynamodb2
 from nose.tools import eq_, ok_
@@ -15,6 +14,7 @@ from autopush.db import (
     create_rotating_message_table,
     ProvisionedThroughputExceededException,
 )
+from autopush.http import EndpointHTTPFactory
 from autopush.exceptions import InvalidRequest
 from autopush.settings import AutopushSettings
 
@@ -57,9 +57,10 @@ class TestBase(unittest.TestCase):
                                  headers={"ttl": "0"},
                                  host='example.com:8080')
 
-        self.base = BaseWebHandler(Application(),
-                                   self.request_mock,
-                                   ap_settings=settings)
+        self.base = BaseWebHandler(
+            EndpointHTTPFactory(settings, db=None, routers=None),
+            self.request_mock
+        )
         self.status_mock = self.base.set_status = Mock()
         self.write_mock = self.base.write = Mock()
         self.base.log = Mock(spec=Logger)

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -55,8 +55,13 @@ class ThreadedValidate(object):
             "arguments": request_handler.request.arguments,
         }
         schema = self.schema()
-        schema.context["settings"] = request_handler.ap_settings
-        schema.context["log"] = self.log
+        schema.context.update(
+            settings=request_handler.ap_settings,
+            metrics=request_handler.metrics,
+            db=request_handler.db,
+            routers=request_handler.routers,
+            log=self.log
+        )
         return schema.load(data)
 
     def _call_func(self, result, func, request_handler):
@@ -139,13 +144,16 @@ class BaseWebHandler(BaseHandler):
     #############################################################
     #                    Cyclone API Methods
     #############################################################
-    def initialize(self, ap_settings):
+    def initialize(self):
         """Setup basic aliases and attributes"""
-        super(BaseWebHandler, self).initialize(ap_settings)
-        self.metrics = ap_settings.metrics
+        super(BaseWebHandler, self).initialize()
         self._base_tags = {}
         self._start_time = time.time()
         self._timings = {}
+
+    @property
+    def routers(self):
+        return self.application.routers
 
     def prepare(self):
         """Common request preparation"""

--- a/autopush/web/health.py
+++ b/autopush/web/health.py
@@ -32,8 +32,8 @@ class HealthHandler(BaseWebHandler):
         }
 
         dl = DeferredList([
-            self._check_table(self.ap_settings.router.table),
-            self._check_table(self.ap_settings.storage.table)
+            self._check_table(self.db.router.table),
+            self._check_table(self.db.storage.table)
         ])
         dl.addBoth(self._finish_response)
 

--- a/autopush/web/message.py
+++ b/autopush/web/message.py
@@ -40,8 +40,7 @@ class MessageHandler(BaseWebHandler):
 
 
         """
-        d = deferToThread(self.ap_settings.message.delete_message,
-                          notification)
+        d = deferToThread(self.db.message.delete_message, notification)
         d.addCallback(self._delete_completed)
         self._db_error_handling(d)
         return d


### PR DESCRIPTION
- move db concerns (incl. metrics) into a simple DatabaseManager.
heavier db init's moved into its own setup() method that most tests
don't even call
- split out routers, now connection doesn't even create them
- kill PushState.msg_limit, nor did it need a metrics attrib

issue #632