### PR TITLE
fix: move metric increments to lowest callbacks

### DIFF
--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -173,14 +173,15 @@ class APNSRouter(object):
                                               application=rel_channel))
 
         self.metrics.increment(
-            "updates.client.bridge.apns.%s.sent" %
-            router_data["rel_channel"],
-            self._base_tags
+            "updates.client.bridge.apns.{}.sent".format(
+                router_data["rel_channel"]
+            ),
+            tags=self._base_tags
         )
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(self._base_tags,
-                                          destination='Direct'))
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(self._base_tags,
+                                              destination='Direct'))
         return RouterResponse(status_code=201, response_body="",
                               headers={"TTL": notification.ttl,
                                        "Location": location},

--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -267,11 +267,11 @@ class FCMRouter(object):
                 router_data={},
             )
         self.metrics.increment("notification.bridge.sent",
-                               self._base_tags)
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(self._base_tags,
-                                          destination="Direct"))
+                               tags=self._base_tags)
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(self._base_tags,
+                                              destination="Direct"))
         location = "%s/m/%s" % (self.ap_settings.endpoint_url,
                                 notification.version)
         return RouterResponse(status_code=201, response_body="",

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -193,11 +193,11 @@ class GCMRouter(object):
                                   log_exception=False)
 
         self.metrics.increment("notification.bridge.sent",
-                               self._base_tags)
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(self._base_tags,
-                                          destination='Direct'))
+                               tags=self._base_tags)
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(self._base_tags,
+                                              destination='Direct'))
         location = "%s/m/%s" % (self.ap_settings.endpoint_url,
                                 notification.version)
         return RouterResponse(status_code=201, response_body="",

--- a/autopush/router/simple.py
+++ b/autopush/router/simple.py
@@ -62,15 +62,15 @@ class SimpleRouter(object):
         """Stubbed out for this router"""
 
     def stored_response(self, notification):
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(destination='Stored'))
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(destination='Stored'))
         return RouterResponse(202, "Notification Stored")
 
     def delivered_response(self, notification):
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(destination='Direct'))
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(destination='Direct'))
         return RouterResponse(200, "Delivered")
 
     @inlineCallbacks

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -25,9 +25,9 @@ class WebPushRouter(SimpleRouter):
     """SimpleRouter subclass to store individual messages appropriately"""
 
     def delivered_response(self, notification):
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(destination='Stored'))
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(destination='Stored'))
         location = "%s/m/%s" % (self.ap_settings.endpoint_url,
                                 notification.location)
         return RouterResponse(status_code=201, response_body="",
@@ -36,9 +36,9 @@ class WebPushRouter(SimpleRouter):
                               logged_status=200)
 
     def stored_response(self, notification):
-        self.metrics.gauge("notification.message_data",
-                           notification.data_length,
-                           tags=make_tags(destination='Direct'))
+        self.metrics.increment("notification.message_data",
+                               notification.data_length,
+                               tags=make_tags(destination='Direct'))
         location = "%s/m/%s" % (self.ap_settings.endpoint_url,
                                 notification.location)
         return RouterResponse(status_code=201, response_body="",

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -722,8 +722,8 @@ class TestData(IntegrationBase):
 
         ok_(self.logs.logged_ci(lambda ci: 'message_size' in ci),
             "message_size not logged")
-        eq_(self.conn.db.metrics._client.gauge.call_args[1]['tags'],
-            ['source:Stored'])
+        inc_call = self.conn.db.metrics._client.increment.call_args_list[5]
+        eq_(inc_call[1]['tags'], ['source:Stored'])
         yield self.shut_down(client)
 
     @inlineCallbacks
@@ -1266,8 +1266,9 @@ class TestWebPush(IntegrationBase):
         client = yield self.quick_register(use_webpush=True)
         yield client.send_notification(data=data, topic="topicname")
         self.conn.db.metrics.increment.assert_has_calls([
-            call('updates.notification.topic',
-                 tags=['host:localhost', 'use_webpush:True'])
+            call('ua.command.hello'),
+            call('ua.command.register'),
+            call('ua.notification.topic')
         ])
         yield self.shut_down(client)
 

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -218,14 +218,14 @@ class TestBase(unittest.TestCase):
     def test_router_response(self):
         from autopush.router.interface import RouterResponse
         response = RouterResponse(headers=dict(Location="http://a.com/"))
-        self.base._router_response(response)
+        self.base._router_response(response, None, None)
         self.status_mock.assert_called_with(200, reason=None)
 
     def test_router_response_client_error(self):
         from autopush.router.interface import RouterResponse
         response = RouterResponse(headers=dict(Location="http://a.com/"),
                                   status_code=400)
-        self.base._router_response(response)
+        self.base._router_response(response, None, None)
         self.status_mock.assert_called_with(400, reason=None)
 
     def test_router_fail_err(self):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -1755,7 +1755,7 @@ class WebsocketTestCase(unittest.TestCase):
         d = Deferred()
 
         def check(*args, **kwargs):
-            eq_(self.metrics.gauge.call_args[1]['tags'], ["source:Direct"])
+            eq_(self.metrics.increment.call_args[1]['tags'], ["source:Direct"])
             ok_(self.proto.force_retry.called)
             ok_(self.send_mock.called)
             d.callback(True)


### PR DESCRIPTION
The metric increments were being called for registration API
calls due to an error callback. They weren't called for success
cases as well. Moving them to the lower callbacks with a new
flag should help ensure they're incremented correctly.

Closes #958