### PR TITLE
chore: upgrade travis to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 language: python
 cache: pip
 sudo: required
-dist: precise
+dist: trusty
 
 matrix:
   include:
     - python: 2.7
       env: TOXENV=py27 DDB=true CODECOV=true
-    - python: pypy-5.6.0
+    - python: pypy-5.7.1
       env: TOXENV=pypy DDB=true CODECOV=true
     - env: TOXENV=flake8
     - python: 3.6
       env: TOXENV=py36-mypy
   allow_failures:
     - env: TOXENV=py36-mypy
+
+before_install:
+# https://github.com/travis-ci/travis-ci/issues/7940
+- sudo rm -f /etc/boto.cfg
 
 install:
 - ${DDB:+make ddb}


### PR DESCRIPTION
and switch to its more recent pypy

(trusty's becoming travis' default and it's already getting more recent pypy builds vs precise)