### PR TITLE
refactor: postpone any db table creation/lookup into db.setup()

### DIFF
--- a/autopush/diagnostic_cli.py
+++ b/autopush/diagnostic_cli.py
@@ -19,17 +19,12 @@ class EndpointDiagnosticCLI(object):
     log = Logger()
 
     def __init__(self, sysargs, use_files=True):
-        args = self._load_args(sysargs, use_files)
-        self._settings = settings = AutopushSettings(
-            crypto_key=args.crypto_key,
-            router_tablename=args.router_tablename,
-            storage_tablename=args.storage_tablename,
-            message_tablename=args.message_tablename,
-            statsd_host=None,
-        )
+        ns = self._load_args(sysargs, use_files)
+        self._settings = settings = AutopushSettings.from_argparse(ns)
+        settings.statsd_host = None
         self.db = DatabaseManager.from_settings(settings)
         self.db.setup(settings.preflight_uaid)
-        self._endpoint = args.endpoint
+        self._endpoint = ns.endpoint
         self._pp = pprint.PrettyPrinter(indent=4)
 
     def _load_args(self, sysargs, use_files):

--- a/autopush/http.py
+++ b/autopush/http.py
@@ -22,7 +22,7 @@ from autopush.db import DatabaseManager
 from autopush.router import routers_from_settings
 from autopush.router.interface import IRouter  # noqa
 from autopush.settings import AutopushSettings  # noqa
-from autopush.ssl import AutopushSSLContextFactory
+from autopush.ssl import AutopushSSLContextFactory  # noqa
 from autopush.web.health import (
     HealthHandler,
     MemUsageHandler,
@@ -176,14 +176,7 @@ class EndpointHTTPFactory(BaseHTTPFactory):
 
         """
         settings = self.ap_settings
-        if not settings.ssl_key:
-            return None
-        return AutopushSSLContextFactory(
-            settings.ssl_key,
-            settings.ssl_cert,
-            dh_file=settings.ssl_dh_param,
-            require_peer_certs=settings.enable_tls_auth
-        )
+        return settings.ssl.cf(require_peer_certs=settings.enable_tls_auth)
 
     @classmethod
     def _for_handler(cls, ap_settings, db, routers=None, **kwargs):
@@ -224,14 +217,7 @@ class InternalRouterHTTPFactory(BaseHTTPFactory):
         values.
 
         """
-        settings = self.ap_settings
-        if not settings.router_ssl_key:
-            return None
-        return AutopushSSLContextFactory(
-            settings.router_ssl_key,
-            settings.router_ssl_cert,
-            dh_file=settings.ssl_dh_param
-        )
+        return self.ap_settings.router_ssl.cf()
 
     @classmethod
     def _for_handler(cls, ap_settings, db, clients=None, **kwargs):

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -33,6 +33,7 @@ from autopush.exceptions import RouterException
 from autopush.metrics import make_tags
 from autopush.protocol import IgnoreBody
 from autopush.router.interface import RouterResponse
+from autopush.types import JSONDict  # noqa
 
 TTL_URL = "https://webpush-wg.github.io/webpush-protocol/#rfc.section.6.2"
 

--- a/autopush/tests/support.py
+++ b/autopush/tests/support.py
@@ -8,6 +8,7 @@ from autopush.db import (
     Storage
 )
 from autopush.metrics import SinkMetrics
+from autopush.settings import DDBTableConfig
 
 
 @implementer(ILogObserver)
@@ -41,7 +42,10 @@ class TestingLogObserver(object):
 def test_db(metrics=None):
     """Return a test DatabaseManager: its Storage/Router are mocked"""
     return DatabaseManager(
+        storage_conf=DDBTableConfig(tablename='storage'),
         storage=Mock(spec=Storage),
+        router_conf=DDBTableConfig(tablename='router'),
         router=Mock(spec=Router),
+        message_conf=DDBTableConfig(tablename='message'),
         metrics=SinkMetrics() if metrics is None else metrics
     )

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -344,9 +344,9 @@ class IntegrationBase(unittest.TestCase):
         endpoint_port=endpoint_port,
         endpoint_scheme='http',
         statsd_host=None,
-        router_tablename=ROUTER_TABLE,
-        storage_tablename=STORAGE_TABLE,
-        message_tablename=MESSAGE_TABLE,
+        router_table=dict(tablename=ROUTER_TABLE),
+        storage_table=dict(tablename=STORAGE_TABLE),
+        message_table=dict(tablename=MESSAGE_TABLE),
         use_cryptography=True,
         enable_simplepush=True,
     )
@@ -358,9 +358,9 @@ class IntegrationBase(unittest.TestCase):
         router_port=9030,
         endpoint_scheme='http',
         statsd_host=None,
-        router_tablename=ROUTER_TABLE,
-        storage_tablename=STORAGE_TABLE,
-        message_tablename=MESSAGE_TABLE,
+        router_table=dict(tablename=ROUTER_TABLE),
+        storage_table=dict(tablename=STORAGE_TABLE),
+        message_table=dict(tablename=MESSAGE_TABLE),
         use_cryptography=True,
         enable_simplepush=True,
     )
@@ -428,8 +428,7 @@ class SSLEndpointMixin(object):
     def endpoint_kwargs(self):
         return dict(
             super(SSLEndpointMixin, self).endpoint_kwargs(),
-            ssl_key=self.servercert,
-            ssl_cert=self.servercert,
+            ssl=dict(key=self.servercert, cert=self.servercert),
             endpoint_scheme='https'
         )
 
@@ -1351,7 +1350,7 @@ class TestWebPush(IntegrationBase):
 
         # Move the client back one month to the past
         last_month = make_rotating_tablename(
-            prefix=self.conn.db._message_prefix, delta=-1)
+            prefix=self.conn.settings.message_table.tablename, delta=-1)
         lm_message = self.conn.db.message_tables[last_month]
         yield deferToThread(
             self.conn.db.router.update_message_month,
@@ -1462,7 +1461,7 @@ class TestWebPush(IntegrationBase):
 
         # Move the client back one month to the past
         last_month = make_rotating_tablename(
-            prefix=self.conn.db._message_prefix, delta=-1)
+            prefix=self.conn.settings.message_table.tablename, delta=-1)
         lm_message = self.conn.db.message_tables[last_month]
         yield deferToThread(
             self.conn.db.router.update_message_month,
@@ -1559,7 +1558,7 @@ class TestWebPush(IntegrationBase):
 
         # Move the client back one month to the past
         last_month = make_rotating_tablename(
-            prefix=self.conn.db._message_prefix, delta=-1)
+            prefix=self.conn.settings.message_table.tablename, delta=-1)
         yield deferToThread(
             self.conn.db.router.update_message_month,
             client.uaid,

--- a/autopush/tests/test_log_check.py
+++ b/autopush/tests/test_log_check.py
@@ -1,30 +1,17 @@
 import json
 
 import twisted
-from moto import mock_dynamodb2
 from nose.tools import eq_, ok_
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import globalLogPublisher
 from twisted.trial import unittest
 
-from autopush.db import create_rotating_message_table
 from autopush.http import EndpointHTTPFactory
 from autopush.logging import begin_or_register
 from autopush.settings import AutopushSettings
 from autopush.tests.client import Client
 from autopush.tests.support import TestingLogObserver
 from autopush.web.log_check import LogCheckHandler
-
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-    create_rotating_message_table()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class LogCheckTestCase(unittest.TestCase):

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -136,7 +136,10 @@ class SettingsAsyncTestCase(trialtest.TestCase):
         eq_(len(db.message_tables), 3)
 
         # Grab next month's table name and remove it
-        next_month = get_rotating_message_table(db._message_prefix, delta=1)
+        next_month = get_rotating_message_table(
+            settings.message_table.tablename,
+            delta=1
+        )
         db.message_tables.pop(next_month.table_name)
 
         # Get the deferred back

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -3,17 +3,13 @@ import uuid
 
 from boto.exception import BotoServerError
 from mock import Mock, patch
-from moto import mock_dynamodb2
 from nose.tools import eq_, ok_
 from twisted.internet.defer import Deferred
 from twisted.logger import Logger
 from twisted.python.failure import Failure
 from twisted.trial import unittest
 
-from autopush.db import (
-    create_rotating_message_table,
-    ProvisionedThroughputExceededException,
-)
+from autopush.db import ProvisionedThroughputExceededException
 from autopush.http import EndpointHTTPFactory
 from autopush.exceptions import InvalidRequest
 from autopush.settings import AutopushSettings
@@ -23,16 +19,6 @@ from autopush.tests.support import test_db
 dummy_request_id = "11111111-1234-1234-1234-567812345678"
 dummy_uaid = str(uuid.UUID("abad1dea00000000aabbccdd00000000"))
 dummy_chid = str(uuid.UUID("deadbeef00000000decafbad00000000"))
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-    create_rotating_message_table()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class TestBase(unittest.TestCase):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -118,7 +118,7 @@ class WebsocketTestCase(unittest.TestCase):
         )
         db = DatabaseManager.from_settings(settings)
         self.metrics = db.metrics = Mock(spec=SinkMetrics)
-        db.create_initial_message_tables()
+        db.setup_tables()
 
         self.mock_agent = agent = Mock(spec=Agent)
         self.factory = PushServerFactory(settings, db, agent, {})
@@ -484,7 +484,7 @@ class WebsocketTestCase(unittest.TestCase):
         target_day = datetime.date(2016, 2, 29)
         msg_day = datetime.date(2015, 12, 15)
         msg_date = "{}_{}_{}".format(
-            self.proto.db._message_prefix,
+            self.ap_settings.message_table.tablename,
             msg_day.year,
             msg_day.month)
         msg_data = {
@@ -552,7 +552,7 @@ class WebsocketTestCase(unittest.TestCase):
         target_day = datetime.date(2016, 2, 29)
         msg_day = datetime.date(2016, 3, 1)
         msg_date = "{}_{}_{}".format(
-            self.proto.db._message_prefix,
+            self.ap_settings.message_table.tablename,
             msg_day.year,
             msg_day.month)
         msg_data = {
@@ -611,7 +611,7 @@ class WebsocketTestCase(unittest.TestCase):
         target_day = datetime.date(2016, 2, 29)
         msg_day = datetime.date(2016, 3, 1)
         msg_date = "{}_{}_{}".format(
-            self.proto.db._message_prefix,
+            self.ap_settings.message_table.tablename,
             msg_day.year,
             msg_day.month)
         msg_data = {

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -191,7 +191,7 @@ def decipher_public_key(key_data):
 
 
 def extract_jwt(token, crypto_key, is_trusted=False, use_crypto=False):
-    # type: (str, str, bool) -> Dict[str, str]
+    # type: (str, str, bool, bool) -> Dict[str, str]
     """Extract the claims from the validated JWT. """
     # first split and convert the jwt.
     if not token or not crypto_key:

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -96,7 +96,7 @@ from autopush.noseplugin import track_object
 from autopush.protocol import IgnoreBody
 from autopush.metrics import IMetrics, make_tags  # noqa
 from autopush.settings import AutopushSettings  # noqa
-from autopush.ssl import AutopushSSLContextFactory
+from autopush.ssl import AutopushSSLContextFactory  # noqa
 from autopush.types import JSONDict  # noqa
 from autopush.utils import (
     parse_user_agent,
@@ -1630,14 +1630,7 @@ class ConnectionWSSite(Site):
         Configured from the ssl_key/cert/dh_param values.
 
         """
-        settings = self.ap_settings
-        if not settings.ssl_key:
-            return None
-        return AutopushSSLContextFactory(
-            settings.ssl_key,
-            settings.ssl_cert,
-            dh_file=settings.ssl_dh_param
-        )
+        return self.ap_settings.ssl.cf()
 
 
 class DefaultResource(Resource):


### PR DESCRIPTION
specify read/write_throughput settings in initial/update rotating
tables

remove some unneeded moto usage

Closes #956
Closes #928