### PR TITLE
feat: remove use of moto dynamodb2 from tests

### DIFF
--- a/autopush/tests/__init__.py
+++ b/autopush/tests/__init__.py
@@ -1,3 +1,56 @@
+import logging
+import os
+import signal
+import subprocess
+
+import boto
+import psutil
+
+from autopush.db import create_rotating_message_table
+
+here_dir = os.path.abspath(os.path.dirname(__file__))
+root_dir = os.path.dirname(os.path.dirname(here_dir))
+ddb_dir = os.path.join(root_dir, "ddb")
+ddb_lib_dir = os.path.join(ddb_dir, "DynamoDBLocal_lib")
+ddb_jar = os.path.join(ddb_dir, "DynamoDBLocal.jar")
+ddb_process = None
+
+
+def setUp():
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    boto_path = os.path.join(root_dir, "automock", "boto.cfg")
+    boto.config.load_from_path(boto_path)
+    global ddb_process
+    cmd = " ".join([
+        "java", "-Djava.library.path=%s" % ddb_lib_dir,
+        "-jar", ddb_jar, "-sharedDb", "-inMemory"
+    ])
+    ddb_process = subprocess.Popen(cmd, shell=True, env=os.environ)
+
+    # Setup the necessary message tables
+    message_table = os.environ.get("MESSAGE_TABLE", "message_int_test")
+    create_rotating_message_table(prefix=message_table, delta=-1)
+    create_rotating_message_table(prefix=message_table)
+
+
+def tearDown():
+    global ddb_process
+    # This kinda sucks, but its the only way to nuke the child procs
+    proc = psutil.Process(pid=ddb_process.pid)
+    child_procs = proc.children(recursive=True)
+    for p in [proc] + child_procs:
+        os.kill(p.pid, signal.SIGTERM)
+    ddb_process.wait()
+
+    # Clear out the boto config that was loaded so the rest of the tests run
+    # fine
+    for section in boto.config.sections():
+        boto.config.remove_section(section)
+
+
+_multiprocess_shared_ = True
+
+
 class MockAssist(object):
     def __init__(self, results):
         self.cur = 0

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -35,16 +35,6 @@ dummy_uaid = str(uuid.UUID("abad1dea00000000aabbccdd00000000"))
 dummy_chid = str(uuid.UUID("deadbeef00000000decafbad00000000"))
 
 
-def setUp():
-    from .test_integration import setUp
-    setUp()
-
-
-def tearDown():
-    from .test_integration import tearDown
-    tearDown()
-
-
 def make_webpush_notification(uaid, chid, ttl=100):
     message_id = str(uuid.uuid4())
     return WebPushNotification(

--- a/autopush/tests/test_diagnostic_cli.py
+++ b/autopush/tests/test_diagnostic_cli.py
@@ -1,19 +1,7 @@
 import unittest
 
 from mock import Mock, patch
-from moto import mock_dynamodb2
 from nose.tools import eq_, ok_
-
-
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class FakeDict(dict):

--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -14,7 +14,6 @@ from autopush.db import (
     ProvisionedThroughputExceededException,
     Message,
     ItemNotFound,
-    create_rotating_message_table,
     has_connected_this_month,
 )
 from autopush.exceptions import RouterException
@@ -35,17 +34,6 @@ from autopush.web.registration import NewRegistrationHandler
 dummy_uaid = uuid.UUID("abad1dea00000000aabbccdd00000000")
 dummy_chid = uuid.UUID("deadbeef00000000decafbad00000000")
 dummy_token = dummy_uaid.hex + ":" + str(dummy_chid)
-
-
-def setUp():
-    from .test_integration import setUp
-    setUp()
-    create_rotating_message_table()
-
-
-def tearDown():
-    from .test_integration import tearDown
-    tearDown()
 
 
 class FileConsumer(object):  # pragma: no cover

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -3,7 +3,6 @@ import json
 import twisted.internet.base
 from boto.dynamodb2.exceptions import InternalServerError
 from mock import Mock
-from moto import mock_dynamodb2
 from nose.tools import eq_
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import globalLogPublisher
@@ -24,10 +23,6 @@ class HealthTestCase(unittest.TestCase):
     def setUp(self):
         self.timeout = 0.5
         twisted.internet.base.DelayedCall.debug = True
-
-        self.mock_dynamodb2 = mock_dynamodb2()
-        self.mock_dynamodb2.start()
-        self.addCleanup(self.mock_dynamodb2.stop)
 
         settings = AutopushSettings(
             hostname="localhost",

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -3,8 +3,6 @@ import json
 import logging
 import os
 import random
-import signal
-import subprocess
 import sys
 import time
 import urlparse
@@ -18,9 +16,7 @@ from unittest.case import SkipTest
 
 from zope.interface import implementer
 
-import boto
 import ecdsa
-import psutil
 import twisted.internet.base
 import websocket
 from cryptography.fernet import Fernet
@@ -39,7 +35,6 @@ from twisted.web.http_headers import Headers
 import autopush.db as db
 from autopush import __version__
 from autopush.db import (
-    create_rotating_message_table,
     get_month,
     has_connected_this_month
 )
@@ -52,48 +47,14 @@ from autopush.tests.support import TestingLogObserver
 from autopush.websocket import PushServerFactory
 
 log = logging.getLogger(__name__)
-here_dir = os.path.abspath(os.path.dirname(__file__))
-root_dir = os.path.dirname(os.path.dirname(here_dir))
-ddb_dir = os.path.join(root_dir, "ddb")
-ddb_lib_dir = os.path.join(ddb_dir, "DynamoDBLocal_lib")
-ddb_jar = os.path.join(ddb_dir, "DynamoDBLocal.jar")
-ddb_process = None
 
 twisted.internet.base.DelayedCall.debug = True
 
 
 def setUp():
     logging.getLogger('boto').setLevel(logging.CRITICAL)
-    boto_path = os.path.join(root_dir, "automock", "boto.cfg")
-    boto.config.load_from_path(boto_path)
     if "SKIP_INTEGRATION" in os.environ:  # pragma: nocover
         raise SkipTest("Skipping integration tests")
-    global ddb_process
-    cmd = " ".join([
-        "java", "-Djava.library.path=%s" % ddb_lib_dir,
-        "-jar", ddb_jar, "-sharedDb", "-inMemory"
-    ])
-    ddb_process = subprocess.Popen(cmd, shell=True, env=os.environ)
-
-    # Setup the necessary message tables
-    message_table = os.environ.get("MESSAGE_TABLE", "message_int_test")
-    create_rotating_message_table(prefix=message_table, delta=-1)
-    create_rotating_message_table(prefix=message_table)
-
-
-def tearDown():
-    global ddb_process
-    # This kinda sucks, but its the only way to nuke the child procs
-    proc = psutil.Process(pid=ddb_process.pid)
-    child_procs = proc.children(recursive=True)
-    for p in [proc] + child_procs:
-        os.kill(p.pid, signal.SIGTERM)
-    ddb_process.wait()
-
-    # Clear out the boto config that was loaded so the rest of the tests run
-    # fine
-    for section in boto.config.sections():
-        boto.config.remove_section(section)
 
 
 def _get_vapid(key=None, payload=None):

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -3,7 +3,6 @@ import datetime
 import json
 
 from mock import Mock, patch
-from moto import mock_dynamodb2
 from nose.tools import (
     assert_raises,
     eq_,
@@ -14,6 +13,7 @@ from twisted.trial import unittest as trialtest
 import hyper
 import hyper.tls
 
+import autopush.db
 from autopush.db import DatabaseManager, get_rotating_message_table
 from autopush.exceptions import InvalidSettings
 from autopush.http import skip_request_logging
@@ -27,15 +27,6 @@ from autopush.utils import resolve_ip
 
 connection_main = ConnectionApplication.main
 endpoint_main = EndpointApplication.main
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class SettingsTestCase(unittest.TestCase):
@@ -292,6 +283,7 @@ class EndpointMainTestCase(unittest.TestCase):
     def tearDown(self):
         for mock in self.mocks.values():
             mock.stop()
+        autopush.db.key_hash = ""
 
     def test_basic(self):
         endpoint_main([

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -7,7 +7,6 @@ import decimal
 
 from autopush.utils import WebPushNotification
 from mock import Mock, PropertyMock, patch
-from moto import mock_dynamodb2
 from nose.tools import eq_, ok_, assert_raises
 from twisted.trial import unittest
 from twisted.internet.error import ConnectError, ConnectionRefusedError
@@ -24,7 +23,6 @@ from autopush.db import (
     Message,
     ProvisionedThroughputExceededException,
     ItemNotFound,
-    create_rotating_message_table,
 )
 from autopush.exceptions import RouterException
 from autopush.metrics import SinkMetrics
@@ -40,18 +38,6 @@ from autopush.settings import AutopushSettings
 from autopush.tests import MockAssist
 from autopush.tests.support import test_db
 from autopush.web.base import Notification
-
-
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-    create_rotating_message_table()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class RouterInterfaceTestCase(TestCase):

--- a/autopush/tests/test_utils.py
+++ b/autopush/tests/test_utils.py
@@ -40,6 +40,15 @@ class TestUserAgentParser(unittest.TestCase):
         eq_(data['sub'], 'mailto:foo@example.com')
 
     @patch("requests.get")
+    def test_get_amid_unknown(self, request_mock):
+        import requests
+        from autopush.utils import get_amid
+
+        request_mock.side_effect = requests.HTTPError
+        result = get_amid()
+        eq_(result, "Unknown")
+
+    @patch("requests.get")
     def test_get_ec2_instance_id_unknown(self, request_mock):
         import requests
         from autopush.utils import get_ec2_instance_id

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -12,12 +12,10 @@ from cryptography.exceptions import InvalidSignature
 from jose import jws
 from marshmallow import Schema, fields
 from mock import Mock, patch
-from moto import mock_dynamodb2
 from nose.tools import eq_, ok_, assert_raises
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
-from autopush.db import create_rotating_message_table
 from autopush.metrics import SinkMetrics
 from autopush.exceptions import InvalidRequest, InvalidTokenException
 from autopush.tests.support import test_db
@@ -27,16 +25,6 @@ import autopush.utils as utils
 dummy_uaid = str(uuid.UUID("abad1dea00000000aabbccdd00000000"))
 dummy_chid = str(uuid.UUID("deadbeef00000000decafbad00000000"))
 dummy_token = dummy_uaid + ":" + dummy_chid
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-    create_rotating_message_table()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class InvalidSchema(Schema):

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -3,12 +3,11 @@ import uuid
 
 from cryptography.fernet import Fernet
 from mock import Mock
-from moto import mock_dynamodb2
 from nose.tools import eq_, ok_
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
-from autopush.db import Message, create_rotating_message_table
+from autopush.db import Message
 from autopush.http import EndpointHTTPFactory
 from autopush.router.interface import IRouter, RouterResponse
 from autopush.settings import AutopushSettings
@@ -18,16 +17,6 @@ from autopush.tests.support import test_db
 dummy_uaid = str(uuid.UUID("abad1dea00000000aabbccdd00000000"))
 dummy_chid = str(uuid.UUID("deadbeef00000000decafbad00000000"))
 dummy_token = dummy_uaid + ":" + dummy_chid
-mock_dynamodb2 = mock_dynamodb2()
-
-
-def setUp():
-    mock_dynamodb2.start()
-    create_rotating_message_table()
-
-
-def tearDown():
-    mock_dynamodb2.stop()
 
 
 class TestWebpushHandler(unittest.TestCase):

--- a/autopush/tests/test_websocket.py
+++ b/autopush/tests/test_websocket.py
@@ -26,7 +26,7 @@ from twisted.trial import unittest
 from twisted.web.client import Agent
 
 import autopush.db as db
-from autopush.db import DatabaseManager, create_rotating_message_table
+from autopush.db import DatabaseManager
 from autopush.http import InternalRouterHTTPFactory
 from autopush.metrics import SinkMetrics
 from autopush.settings import AutopushSettings
@@ -82,17 +82,6 @@ def dummy_notif(**kwargs):
     return WebPushNotification(**_kwargs)
 
 
-def setUp():
-    from .test_integration import setUp
-    setUp()
-    create_rotating_message_table()
-
-
-def tearDown():
-    from .test_integration import tearDown
-    tearDown()
-
-
 def assert_called_included(mock, **kwargs):  # pragma: nocover
     """Like assert_called_with but asserts a call was made including
     the specified kwargs (but allowing additional args/kwargs)"""
@@ -105,6 +94,7 @@ def assert_called_included(mock, **kwargs):  # pragma: nocover
 
 
 class WebsocketTestCase(unittest.TestCase):
+    _multiprocess_can_split_ = True
 
     def setUp(self):
         from twisted.logger import Logger


### PR DESCRIPTION
Moves the local DynamoDB run to the package level and all tests use
it instead of running moto's incomplete dynamodb mock.

This also fixes a bug in the tests that left autopush.db.key_hash
set after an endpoint test ran.