### PR TITLE
bug: Add missing metric for notification encoding

### DIFF
--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -477,6 +477,9 @@ class WebPushHandler(BaseWebHandler):
         encoding = ''
         if notification.data and notification.headers:
             encoding = notification.headers.get('encoding', '')
+            self.metrics.increment(
+                "updates.notification.encoding.{}".format(encoding)
+            )
         self._client_info.update(
             message_id=notification.message_id,
             uaid_hash=hasher(user_data.get("uaid")),


### PR DESCRIPTION
Added "updates.notification.encoding.{content-encoding}",
we already track vapid as "updates.vapid.{version}"

Closes #992