### PR TITLE
fix: remove debug assertions

### DIFF
--- a/autopush_rs/Cargo.toml
+++ b/autopush_rs/Cargo.toml
@@ -25,6 +25,3 @@ tokio-service = "0.1"
 tokio-tungstenite = "0.3"
 tungstenite = "0.4"
 uuid = { version = "0.5", features = ["serde", "v4"] }
-
-[profile.release]
-debug-assertions = true


### PR DESCRIPTION
tok-io has an expensive debug assertion, this turns them all off for now.