### PR TITLE
bug: Handle legacy simplepush records as candidate webpush records

### DIFF
--- a/autopush/tests/test_endpoint.py
+++ b/autopush/tests/test_endpoint.py
@@ -330,7 +330,7 @@ class RegistrationTestCase(unittest.TestCase):
         self.patch('uuid.uuid4', return_value=dummy_uaid)
 
         resp = yield self.client.post(
-            self.url(router_type="foo"),
+            self.url(router_type="simplepush"),
             headers={"Authorization": self.auth},
             body=json.dumps(dict(
                 type="invalid",

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -462,6 +462,21 @@ class Test_Data(IntegrationBase):
         ))
         yield self.shut_down(client)
 
+    @inlineCallbacks
+    def test_legacy_simplepush_record(self):
+        """convert to webpush record and see if it works"""
+        client = yield self.quick_register()
+        uaid = "deadbeef00000000deadbeef00000001"
+        self.ep.db.router.get_uaid = Mock(
+            return_value={'router_type': 'simplepush',
+                          'uaid': uaid,
+                          'current_month': self.ep.db.current_msg_month})
+        self.ep.db.message_tables[
+            self.ep.db.current_msg_month].all_channels = Mock(
+            return_value=(True, client.channels))
+        yield client.send_notification()
+        yield self.shut_down(client)
+
     @patch("autopush.metrics.datadog")
     @inlineCallbacks
     def test_webpush_data_delivery_to_disconnected_client(self, m_ddog):

--- a/autopush/web/registration.py
+++ b/autopush/web/registration.py
@@ -176,7 +176,7 @@ class AuthorizationCheckSchema(Schema):
 def conditional_token_check(object_dict, parent_dict):
     ptype = parent_dict['path_kwargs']['type']
     # Basic "bozo-filter" to prevent customer surprises later.
-    if ptype not in ['apns', 'fcm', 'gcm', 'webpush', 'simplepush', 'test']:
+    if ptype not in ['apns', 'fcm', 'gcm', 'webpush', 'test']:
         raise InvalidRequest("Unknown registration type",
                              status_code=400,
                              errno=108,

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -99,6 +99,11 @@ class WebPushSubscriptionSchema(Schema):
                                  result.get("critical_failure"),
                                  status_code=410,
                                  errno=105)
+        # Some stored user records are marked as "simplepush".
+        # If you encounter one, may need to tweak it a bit to get it as
+        # a valid WebPush record.
+        if result["router_type"] == "simplepush":
+            result["router_type"] = "webpush"
 
         if result["router_type"] == "webpush":
             self._validate_webpush(d, result)


### PR DESCRIPTION
Some older records in the database appear to have been miscategorized as
"simplepush". We should try to handle those as "webpush".

Closes #1033