### PR TITLE
feat: move tests to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,5 @@ omit =
     autopush/gcdump.py
     autopush/webpush_server.py
     autopush/tests/test_webpush_server.py
+    autopush/tests/conftest.py
 show_missing = true

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -504,7 +504,7 @@ class Message(object):
     def fetch_timestamp_messages(
             self,
             uaid,  # type: uuid.UUID
-            timestamp=None,  # type: Optional[int]
+            timestamp=None,  # type: Optional[int or str]
             limit=10,  # type: int
             ):
         # type: (...) -> Tuple[Optional[int], List[WebPushNotification]]

--- a/autopush/tests/conftest.py
+++ b/autopush/tests/conftest.py
@@ -1,0 +1,11 @@
+from autopush.tests import setUp, tearDown
+
+
+def pytest_configure(config):
+    """Called before testing begins"""
+    setUp()
+
+
+def pytest_unconfigure(config):
+    """Called after all tests run and warnings displayed"""
+    tearDown()

--- a/autopush/tests/test_cryptokey.py
+++ b/autopush/tests/test_cryptokey.py
@@ -1,6 +1,6 @@
 import unittest
 
-from nose.tools import (eq_, ok_, assert_raises)
+import pytest
 
 from autopush.crypto_key import CryptoKey, CryptoKeyException
 
@@ -15,47 +15,47 @@ class CryptoKeyTestCase(unittest.TestCase):
 
     def test_parse(self):
         ckey = CryptoKey(self.valid_key)
-        eq_(ckey.get_keyid("p256dh"),
-            {"keyid": "p256dh",
-             "dh": "BDw9T0eImd4ax818VcYqDK_DOhcuDswKero"
-                   "YyNkdhYmygoLSDlSiWpuoWYUSSFxi25cyyNTR5k9Ny93DzZc0UI4"})
-        eq_(ckey.get_label("p256ecdsa"),
+        assert ckey.get_keyid("p256dh") == {
+            "keyid": "p256dh",
+            "dh": "BDw9T0eImd4ax818VcYqDK_DOhcuDswKero"
+                  "YyNkdhYmygoLSDlSiWpuoWYUSSFxi25cyyNTR5k9Ny93DzZc0UI4"}
+        assert ckey.get_label("p256ecdsa") == (
             "BF92zdI_AKcH5Q31_Rr-04bPqOHU_Qg6lAawHbvfQrY"
             "xV_vIsAsHSyaiuyfofvxT8ZVIXccykd4V2Z7iJVfreT8")
-        ok_(ckey.get_keyid("missing") is None)
-        ok_(ckey.get_label("missing") is None)
+        assert ckey.get_keyid("missing") is None
+        assert ckey.get_label("missing") is None
 
     def test_parse_and_get_label(self):
-        eq_(CryptoKey.parse_and_get_label(self.valid_key, "p256ecdsa"),
+        assert CryptoKey.parse_and_get_label(self.valid_key, "p256ecdsa") == (
             "BF92zdI_AKcH5Q31_Rr-04bPqOHU_Qg6lAawHbvfQrY"
             "xV_vIsAsHSyaiuyfofvxT8ZVIXccykd4V2Z7iJVfreT8")
-        ok_(CryptoKey.parse_and_get_label(self.valid_key, "missing") is None)
-        ok_(CryptoKey.parse_and_get_label("invalid key", "missing") is None)
+        assert CryptoKey.parse_and_get_label(self.valid_key, "missing") is None
+        assert CryptoKey.parse_and_get_label("invalid key", "missing") is None
 
     def test_parse_invalid(self):
-        with assert_raises(CryptoKeyException) as ex:
+        with pytest.raises(CryptoKeyException) as ex:
             CryptoKey("invalid key")
-        eq_(ex.exception.message, "Invalid Crypto Key value")
+        assert ex.value.message == "Invalid Crypto Key value"
 
     def test_parse_different_order(self):
         ckey = CryptoKey(self.valid_key)
         ckey2 = CryptoKey(','.join(self.valid_key.split(',')[::-1]))
-        ok_(ckey.get_keyid("p256dh"), ckey2.get_keyid("p256dh"))
-        ok_(ckey.get_label("p256ecdsa") is not None)
-        ok_(ckey.get_label("p256ecdsa"), ckey2.get_label("p256ecdsa"))
+        assert ckey.get_keyid("p256dh") == ckey2.get_keyid("p256dh")
+        assert ckey.get_label("p256ecdsa") is not None
+        assert ckey.get_label("p256ecdsa") == ckey2.get_label("p256ecdsa")
 
     def test_parse_lenient(self):
         ckey = CryptoKey(self.valid_key.replace('"', ''))
         str = ckey.to_string()
         ckey2 = CryptoKey(str)
-        ok_(ckey.get_keyid("p256dh"), ckey2.get_keyid("p256dh"))
-        ok_(ckey.get_label("p256ecdsa") is not None)
-        ok_(ckey.get_label("p256ecdsa"), ckey2.get_label("p256ecdsa"))
+        assert ckey.get_keyid("p256dh") == ckey2.get_keyid("p256dh")
+        assert ckey.get_label("p256ecdsa") is not None
+        assert ckey.get_label("p256ecdsa") == ckey2.get_label("p256ecdsa")
 
     def test_string(self):
         ckey = CryptoKey(self.valid_key)
         str = ckey.to_string()
         ckey2 = CryptoKey(str)
-        ok_(ckey.get_keyid("p256dh"), ckey2.get_keyid("p256dh"))
-        ok_(ckey.get_label("p256ecdsa") is not None)
-        ok_(ckey.get_label("p256ecdsa"), ckey2.get_label("p256ecdsa"))
+        assert ckey.get_keyid("p256dh") == ckey2.get_keyid("p256dh")
+        assert ckey.get_label("p256ecdsa") is not None
+        assert ckey.get_label("p256ecdsa") == ckey2.get_label("p256ecdsa")

--- a/autopush/tests/test_diagnostic_cli.py
+++ b/autopush/tests/test_diagnostic_cli.py
@@ -1,7 +1,6 @@
 import unittest
 
 from mock import Mock, patch
-from nose.tools import eq_, ok_
 
 
 class FakeDict(dict):
@@ -18,7 +17,7 @@ class DiagnosticCLITestCase(unittest.TestCase):
             "--router_tablename=fred",
             "http://someendpoint",
         ])
-        eq_(cli.db.router.table.table_name, "fred")
+        assert cli.db.router.table.table_name == "fred"
 
     def test_bad_endpoint(self):
         cli = self._makeFUT([
@@ -26,7 +25,7 @@ class DiagnosticCLITestCase(unittest.TestCase):
             "http://someendpoint",
         ])
         returncode = cli.run()
-        ok_(returncode not in (None, 0))
+        assert returncode not in (None, 0)
 
     @patch("autopush.diagnostic_cli.AutopushConfig")
     @patch("autopush.diagnostic_cli.DatabaseManager.from_config")

--- a/autopush/tests/test_health.py
+++ b/autopush/tests/test_health.py
@@ -3,7 +3,6 @@ import json
 import twisted.internet.base
 from boto.dynamodb2.exceptions import InternalServerError
 from mock import Mock
-from nose.tools import eq_
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import globalLogPublisher
 from twisted.trial import unittest
@@ -118,10 +117,10 @@ class HealthTestCase(unittest.TestCase):
     def _assert_reply(self, reply, exception=None):
         resp = yield self.client.get('/health')
         if exception:
-            eq_(resp.get_status(), 503)
+            assert resp.get_status() == 503
             self.flushLoggedErrors(exception)
         payload = json.loads(resp.content)
-        eq_(payload, reply)
+        assert payload == reply
 
 
 class StatusTestCase(unittest.TestCase):

--- a/autopush/tests/test_log_check.py
+++ b/autopush/tests/test_log_check.py
@@ -1,7 +1,6 @@
 import json
 
 import twisted
-from nose.tools import eq_, ok_
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import globalLogPublisher
 from twisted.trial import unittest
@@ -34,28 +33,28 @@ class LogCheckTestCase(unittest.TestCase):
     @inlineCallbacks
     def test_get_err(self):
         resp = yield self.client.get('/v1/err')
-        eq_(len(self.logs), 2)
-        ok_(self.logs.logged(
+        assert len(self.logs) == 2
+        assert self.logs.logged(
             lambda e: (e['log_level'].name == 'error' and
                        e['log_format'] == 'Test Error Message' and
                        e['status_code'] == 418)
-        ))
+        )
         payload = json.loads(resp.content)
-        eq_(payload.get('code'), 418)
-        eq_(payload.get('message'), "ERROR:Success")
+        assert payload.get('code') == 418
+        assert payload.get('message') == "ERROR:Success"
 
     @inlineCallbacks
     def test_get_crit(self):
         resp = yield self.client.get('/v1/err/crit')
-        eq_(len(self.logs), 2)
-        ok_(self.logs.logged(
+        assert len(self.logs) == 2
+        assert self.logs.logged(
             lambda e: (e['log_level'].name == 'critical' and
                        e['log_failure'] and
                        e['log_format'] == 'Test Critical Message' and
                        e['status_code'] == 418)
-        ))
+        )
         payload = json.loads(resp.content)
-        eq_(payload.get('code'), 418)
-        eq_(payload.get('error'), "Test Failure")
+        assert payload.get('code') == 418
+        assert payload.get('error') == "Test Failure"
 
         self.flushLoggedErrors()

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -9,7 +9,6 @@ import twisted.internet
 import twisted.trial.unittest
 
 from mock import Mock, patch
-from nose.tools import eq_, ok_
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred
 from twisted.logger import Logger
@@ -65,18 +64,18 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
             if not logged:   # pragma: nocover
                 reactor.callLater(0, check)
                 return
-            eq_(len(logged), 1)
+            assert len(logged) == 1
             # Check that the sentry data has the client info as a sub dict
             # Note: these are double quoted, single quote strings.
-            eq_(logged[0].get('extra').get('client_info'),
-                {u"'key'": u"'value'"})
+            assert logged[0].get('extra').get('client_info') == {
+                u"'key'": u"'value'"}
             # Check that the json written actually contains the client info
             # collapsed up into 'Fields'.
             out.seek(0)
             payload = json.loads(out.readline())
-            eq_(payload['Fields']['key'], 'value')
-            eq_(payload['Fields']['key2'], 'value')
-            eq_(payload['Fields']['key3'], True)
+            assert payload['Fields']['key'] == 'value'
+            assert payload['Fields']['key2'] == 'value'
+            assert payload['Fields']['key3'] is True
             self._port.stopListening()
             pl.stop()
             d.callback(True)
@@ -99,12 +98,12 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
                 reactor.callLater(0, check)
                 return
 
-            eq_(len(logged), 1)
+            assert len(logged) == 1
             # Ensure a top level stacktrace was included
             stacktrace = logged[0]['stacktrace']
-            ok_(any(
+            assert any(
                 filename == f['abs_path'] and testname == f['function']
-                for f in stacktrace['frames']))
+                for f in stacktrace['frames'])
 
             self._port.stopListening()
             pl.stop()
@@ -118,19 +117,19 @@ class PushLoggerTestCase(twisted.trial.unittest.TestCase):
         obj = PushLogger.setup_logging("Autopush")
         obj._output = mock_stdout = Mock()
         log.info("omg!", Type=7)
-        eq_(len(mock_stdout.mock_calls), 2)
+        assert len(mock_stdout.mock_calls) == 2
         kwargs = mock_stdout.mock_calls[0][1][0]
-        ok_("Type" in kwargs)
+        assert "Type" in kwargs
         obj.stop()
 
     def test_human_logs(self):
         obj = PushLogger.setup_logging("Autopush", log_format="text")
         obj._output = mock_stdout = Mock()
         log.info("omg!", Type=7)
-        eq_(len(mock_stdout.mock_calls), 2)
+        assert len(mock_stdout.mock_calls) == 2
         mock_stdout.reset_mock()
         log.error("wtf!", Type=7)
-        eq_(len(mock_stdout.mock_calls), 2)
+        assert len(mock_stdout.mock_calls) == 2
         obj.stop()
 
     def test_start_stop(self):
@@ -149,7 +148,7 @@ class PushLoggerTestCase(twisted.trial.unittest.TestCase):
         obj.stop()
         with open("testfile.txt") as f:
             lines = f.readlines()
-        eq_(len(lines), 1)
+        assert len(lines) == 1
 
     @patch("autopush.logging.boto3")
     def test_firehose_only_output(self, mock_boto3):
@@ -159,8 +158,8 @@ class PushLoggerTestCase(twisted.trial.unittest.TestCase):
         obj.start()
         log.info("wow")
         obj.stop()
-        eq_(len(obj.firehose.mock_calls), 3)
-        eq_(len(obj.firehose.process.mock_calls), 1)
+        assert len(obj.firehose.mock_calls) == 3
+        assert len(obj.firehose.process.mock_calls) == 1
 
 
 class FirehoseProcessorTestCase(twisted.trial.unittest.TestCase):
@@ -175,10 +174,10 @@ class FirehoseProcessorTestCase(twisted.trial.unittest.TestCase):
     def test_full_queue(self):
         proc = FirehoseProcessor("test", 1)
         proc.process("test")
-        eq_(proc._records.full(), True)
+        assert proc._records.full() is True
         proc.process("another")
-        eq_(proc._records.qsize(), 1)
-        eq_(proc._records.get(), "test")
+        assert proc._records.qsize() == 1
+        assert proc._records.get() == "test"
 
     def test_message_max_size(self):
         proc = FirehoseProcessor("test")
@@ -191,8 +190,8 @@ class FirehoseProcessorTestCase(twisted.trial.unittest.TestCase):
         proc.start()
         proc.process("a decently larger message")
         proc.stop()
-        eq_(len(self.mock_boto.mock_calls), 2)
-        eq_(len(proc._client.put_record_batch.mock_calls), 1)
+        assert len(self.mock_boto.mock_calls) == 2
+        assert len(proc._client.put_record_batch.mock_calls) == 1
 
     def test_message_max_batch(self):
         proc = FirehoseProcessor("test")
@@ -205,8 +204,8 @@ class FirehoseProcessorTestCase(twisted.trial.unittest.TestCase):
         proc.start()
         proc.process("a decently larger message")
         proc.stop()
-        eq_(len(self.mock_boto.mock_calls), 2)
-        eq_(len(proc._client.put_record_batch.mock_calls), 1)
+        assert len(self.mock_boto.mock_calls) == 2
+        assert len(proc._client.put_record_batch.mock_calls) == 1
 
     def test_queue_timeout(self):
         proc = FirehoseProcessor("test")
@@ -230,5 +229,5 @@ class FirehoseProcessorTestCase(twisted.trial.unittest.TestCase):
         proc.start()
         proc.process("a decently larger message")
         proc.stop()
-        eq_(len(self.mock_boto.mock_calls), 4)
-        eq_(len(proc._client.put_record_batch.mock_calls), 3)
+        assert len(self.mock_boto.mock_calls) == 4
+        assert len(proc._client.put_record_batch.mock_calls) == 3

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -2,7 +2,7 @@ import unittest
 
 import twisted.internet.base
 
-from nose.tools import assert_raises, ok_, eq_
+import pytest
 from mock import Mock, patch
 
 from autopush.metrics import (
@@ -17,18 +17,21 @@ class IMetricsTestCase(unittest.TestCase):
     def test_default(self):
         im = IMetrics()
         im.start()
-        assert_raises(NotImplementedError, im.increment, "test")
-        assert_raises(NotImplementedError, im.gauge, "test", 10)
-        assert_raises(NotImplementedError, im.timing, "test", 10)
+        with pytest.raises(NotImplementedError):
+            im.increment("test")
+        with pytest.raises(NotImplementedError):
+            im.gauge("test", 10)
+        with pytest.raises(NotImplementedError):
+            im.timing("test", 10)
 
 
 class SinkMetricsTestCase(unittest.TestCase):
     def test_passing(self):
         sm = SinkMetrics()
         sm.start()
-        eq_(None, sm.increment("test"))
-        eq_(None, sm.gauge("test", 10))
-        eq_(None, sm.timing("test", 10))
+        assert sm.increment("test") is None
+        assert sm.gauge("test", 10) is None
+        assert sm.timing("test", 10) is None
 
 
 class TwistedMetricsTestCase(unittest.TestCase):
@@ -37,7 +40,7 @@ class TwistedMetricsTestCase(unittest.TestCase):
         twisted.internet.base.DelayedCall.debug = True
         m = TwistedMetrics('127.0.0.1')
         m.start()
-        ok_(len(mock_reactor.mock_calls) > 0)
+        assert len(mock_reactor.mock_calls) > 0
         m._metric = Mock()
         m.increment("test", 5)
         m._metric.increment.assert_called_with("test", 5)
@@ -54,7 +57,7 @@ class DatadogMetricsTestCase(unittest.TestCase):
 
         m = DatadogMetrics("someapikey", "someappkey", namespace="testpush",
                            hostname="localhost")
-        ok_(len(mock_dog.mock_calls) > 0)
+        assert len(mock_dog.mock_calls) > 0
         m._client = Mock()
         m.start()
         m._client.start.assert_called_with(flush_interval=10,

--- a/autopush/tests/test_utils.py
+++ b/autopush/tests/test_utils.py
@@ -1,7 +1,6 @@
 import unittest
 
 from mock import patch, Mock
-from nose.tools import eq_
 
 from autopush.tests.test_integration import _get_vapid
 
@@ -13,31 +12,31 @@ class TestUserAgentParser(unittest.TestCase):
 
     def test_linux_extraction(self):
         dd, raw = self._makeFUT('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.2) Gecko/20090807 Mandriva Linux/1.9.1.2-1.1mud2009.1 (2009.1) Firefox/3.5.2 FirePHP/0.3,gzip(gfe),gzip(gfe)')  # NOQA
-        eq_(dd["ua_os_family"], "Linux")
-        eq_(raw["ua_os_family"], "Mandriva")
+        assert dd["ua_os_family"] == "Linux"
+        assert raw["ua_os_family"] == "Mandriva"
 
     def test_windows_extraction(self):
         dd, raw = self._makeFUT('Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 (.NET CLR 3.5.30729)')  # NOQA
-        eq_(dd["ua_os_family"], "Windows")
-        eq_(raw["ua_os_family"], "Windows 7")
+        assert dd["ua_os_family"] == "Windows"
+        assert raw["ua_os_family"] == "Windows 7"
 
     def test_valid_os(self):
         dd, raw = self._makeFUT('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.5; rv:2.1.1) Gecko/ Firefox/5.0.1')  # NOQA
-        eq_(dd["ua_os_family"], "Mac OS X")
-        eq_(raw["ua_os_family"], "Mac OS X")
+        assert dd["ua_os_family"] == "Mac OS X"
+        assert raw["ua_os_family"] == "Mac OS X"
 
     def test_other_os_and_browser(self):
         dd, raw = self._makeFUT('BlackBerry9000/4.6.0.167 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/102')  # NOQA
-        eq_(dd["ua_os_family"], "Other")
-        eq_(raw["ua_os_family"], "BlackBerry OS")
-        eq_(dd["ua_browser_family"], "Other")
-        eq_(raw["ua_browser_family"], "BlackBerry")
+        assert dd["ua_os_family"] == "Other"
+        assert raw["ua_os_family"] == "BlackBerry OS"
+        assert dd["ua_browser_family"] == "Other"
+        assert raw["ua_browser_family"] == "BlackBerry"
 
     def test_trusted_vapid(self):
         from autopush.utils import extract_jwt
         vapid_info = _get_vapid(payload={'sub': 'mailto:foo@example.com'})
         data = extract_jwt(vapid_info['auth'], 'invalid_key', is_trusted=True)
-        eq_(data['sub'], 'mailto:foo@example.com')
+        assert data['sub'] == 'mailto:foo@example.com'
 
     @patch("requests.get")
     def test_get_amid_unknown(self, request_mock):
@@ -46,7 +45,7 @@ class TestUserAgentParser(unittest.TestCase):
 
         request_mock.side_effect = requests.HTTPError
         result = get_amid()
-        eq_(result, "Unknown")
+        assert result == "Unknown"
 
     @patch("requests.get")
     def test_get_ec2_instance_id_unknown(self, request_mock):
@@ -55,7 +54,7 @@ class TestUserAgentParser(unittest.TestCase):
 
         request_mock.side_effect = requests.HTTPError
         result = get_ec2_instance_id()
-        eq_(result, "Unknown")
+        assert result == "Unknown"
 
     @patch("requests.get")
     def test_get_ec2_instance_id(self, request_mock):
@@ -65,4 +64,4 @@ class TestUserAgentParser(unittest.TestCase):
 
         request_mock.return_value = mock_reply
         result = get_ec2_instance_id()
-        eq_(result, "i-123242")
+        assert result == "i-123242"

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -3,7 +3,6 @@ import uuid
 
 from boto.exception import BotoServerError
 from mock import Mock, patch
-from nose.tools import eq_, ok_
 from twisted.internet.defer import Deferred
 from twisted.logger import Logger
 from twisted.python.failure import Failure
@@ -70,19 +69,19 @@ class TestBase(unittest.TestCase):
         ch4 = "Access-Control-Expose-Headers"
         base = self.base
         base.conf.cors = False
-        ok_(base._headers.get(ch1) != "*")
-        ok_(base._headers.get(ch2) != self.CORS_METHODS)
-        ok_(base._headers.get(ch3) != self.CORS_HEADERS)
-        ok_(base._headers.get(ch4) != self.CORS_RESPONSE_HEADERS)
+        assert base._headers.get(ch1) != "*"
+        assert base._headers.get(ch2) != self.CORS_METHODS
+        assert base._headers.get(ch3) != self.CORS_HEADERS
+        assert base._headers.get(ch4) != self.CORS_RESPONSE_HEADERS
 
         base.clear_header(ch1)
         base.clear_header(ch2)
         base.conf.cors = True
         self.base.prepare()
-        eq_(base._headers[ch1], "*")
-        eq_(base._headers[ch2], self.CORS_METHODS)
-        eq_(base._headers[ch3], self.CORS_HEADERS)
-        eq_(base._headers[ch4], self.CORS_RESPONSE_HEADERS)
+        assert base._headers[ch1] == "*"
+        assert base._headers[ch2] == self.CORS_METHODS
+        assert base._headers[ch3] == self.CORS_HEADERS
+        assert base._headers[ch4] == self.CORS_RESPONSE_HEADERS
 
     def test_cors_head(self):
         ch1 = "Access-Control-Allow-Origin"
@@ -94,10 +93,10 @@ class TestBase(unittest.TestCase):
         base.prepare()
         args = {"api_ver": "v1", "token": "test"}
         base.head(args)
-        eq_(base._headers[ch1], "*")
-        eq_(base._headers[ch2], self.CORS_METHODS)
-        eq_(base._headers[ch3], self.CORS_HEADERS)
-        eq_(base._headers[ch4], self.CORS_RESPONSE_HEADERS)
+        assert base._headers[ch1] == "*"
+        assert base._headers[ch2] == self.CORS_METHODS
+        assert base._headers[ch3] == self.CORS_HEADERS
+        assert base._headers[ch4] == self.CORS_RESPONSE_HEADERS
 
     def test_cors_options(self):
         ch1 = "Access-Control-Allow-Origin"
@@ -111,10 +110,10 @@ class TestBase(unittest.TestCase):
         base.conf.cors = True
         base.prepare()
         base.options(args)
-        eq_(base._headers[ch1], "*")
-        eq_(base._headers[ch2], self.CORS_METHODS)
-        eq_(base._headers[ch3], self.CORS_HEADERS)
-        eq_(base._headers[ch4], self.CORS_RESPONSE_HEADERS)
+        assert base._headers[ch1] == "*"
+        assert base._headers[ch2] == self.CORS_METHODS
+        assert base._headers[ch3] == self.CORS_HEADERS
+        assert base._headers[ch4] == self.CORS_RESPONSE_HEADERS
 
     def test_sts_max_age_header(self):
         args = {"api_ver": "v1", "token": "test"}
@@ -123,8 +122,8 @@ class TestBase(unittest.TestCase):
         base.prepare()
         base.options(args)
         sts_header = base._headers.get("Strict-Transport-Security")
-        ok_("max-age=86400" in sts_header)
-        ok_("includeSubDomains" in sts_header)
+        assert "max-age=86400" in sts_header
+        assert "includeSubDomains" in sts_header
 
     def test_write_error(self):
         """ Write error is triggered by sending the app a request
@@ -142,7 +141,7 @@ class TestBase(unittest.TestCase):
 
         self.base.write_error(999, exc_info=exc_info)
         self.status_mock.assert_called_with(999)
-        eq_(self.base.log.failure.called, True)
+        assert self.base.log.failure.called is True
 
     def test_write_error_no_exc(self):
         """ Write error is triggered by sending the app a request
@@ -152,7 +151,7 @@ class TestBase(unittest.TestCase):
         """
         self.base.write_error(999)
         self.status_mock.assert_called_with(999)
-        eq_(self.base.log.failure.called, True)
+        assert self.base.log.failure.called is True
 
     @patch('uuid.uuid4', return_value=uuid.UUID(dummy_request_id))
     def test_init_info(self, t):
@@ -162,16 +161,16 @@ class TestBase(unittest.TestCase):
         self.request_mock.headers["ttl"] = "0"
         self.request_mock.headers["authorization"] = "bearer token fred"
         d = self.base._init_info()
-        eq_(d["request_id"], dummy_request_id)
-        eq_(d["user_agent"], "myself")
-        eq_(d["remote_ip"], "local1")
-        eq_(d["message_ttl"], "0")
-        eq_(d["authorization"], "bearer token fred")
+        assert d["request_id"] == dummy_request_id
+        assert d["user_agent"] == "myself"
+        assert d["remote_ip"] == "local1"
+        assert d["message_ttl"] == "0"
+        assert d["authorization"] == "bearer token fred"
         self.request_mock.headers["x-forwarded-for"] = "local2"
         self.request_mock.headers["authorization"] = "webpush token barney"
         d = self.base._init_info()
-        eq_(d["remote_ip"], "local2")
-        eq_(d["authorization"], "webpush token barney")
+        assert d["remote_ip"] == "local2"
+        assert d["authorization"] == "webpush token barney"
 
     def test_write_response(self):
         self.base._write_response(400, 103, message="Fail",

--- a/autopush/tests/test_web_webpush.py
+++ b/autopush/tests/test_web_webpush.py
@@ -3,7 +3,6 @@ import uuid
 
 from cryptography.fernet import Fernet
 from mock import Mock
-from nose.tools import eq_, ok_
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
@@ -63,10 +62,10 @@ class TestWebpushHandler(unittest.TestCase):
         resp = yield self.client.post(
             self.url(api_ver="v1", token=dummy_token),
         )
-        eq_(resp.get_status(), 503)
+        assert resp.get_status() == 503
         ru = self.db.router.register_user
-        ok_(ru.called)
-        eq_('webpush', ru.call_args[0][0].get('router_type'))
+        assert ru.called
+        assert 'webpush' == ru.call_args[0][0].get('router_type')
 
     @inlineCallbacks
     def test_router_returns_data_without_detail(self):
@@ -90,8 +89,8 @@ class TestWebpushHandler(unittest.TestCase):
         resp = yield self.client.post(
             self.url(api_ver="v1", token=dummy_token),
         )
-        eq_(resp.get_status(), 503)
-        ok_(self.db.router.drop_user.called)
+        assert resp.get_status() == 503
+        assert self.db.router.drop_user.called
 
     @inlineCallbacks
     def test_request_bad_ckey(self):
@@ -100,7 +99,7 @@ class TestWebpushHandler(unittest.TestCase):
             self.url(api_ver="v1", token='ignored'),
             headers={'crypto-key': 'dummy_key'}
         )
-        eq_(resp.get_status(), 404)
+        assert resp.get_status() == 404
 
     @inlineCallbacks
     def test_request_bad_v1_id(self):
@@ -108,7 +107,7 @@ class TestWebpushHandler(unittest.TestCase):
         resp = yield self.client.post(
             self.url(api_ver="v1", token='ignored'),
         )
-        eq_(resp.get_status(), 404)
+        assert resp.get_status() == 404
 
     @inlineCallbacks
     def test_request_bad_v2_id_short(self):
@@ -117,7 +116,7 @@ class TestWebpushHandler(unittest.TestCase):
             self.url(api_ver='v2', token='ignored'),
             headers={'authorization': 'vapid t=dummy_key,k=aaa'}
         )
-        eq_(resp.get_status(), 404)
+        assert resp.get_status() == 404
 
     @inlineCallbacks
     def test_request_bad_draft02_auth(self):
@@ -125,7 +124,7 @@ class TestWebpushHandler(unittest.TestCase):
             self.url(api_ver='v2', token='ignored'),
             headers={'authorization': 'vapid foo'}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401
 
     @inlineCallbacks
     def test_request_bad_draft02_missing_key(self):
@@ -134,7 +133,7 @@ class TestWebpushHandler(unittest.TestCase):
             self.url(api_ver='v2', token='ignored'),
             headers={'authorization': 'vapid t=dummy.key.value,k='}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401
 
     @inlineCallbacks
     def test_request_bad_draft02_bad_pubkey(self):
@@ -143,7 +142,7 @@ class TestWebpushHandler(unittest.TestCase):
             self.url(api_ver='v2', token='ignored'),
             headers={'authorization': 'vapid t=dummy.key.value,k=!aaa'}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401
 
     @inlineCallbacks
     def test_request_bad_v2_id_missing_pubkey(self):
@@ -153,7 +152,7 @@ class TestWebpushHandler(unittest.TestCase):
             headers={'crypto-key': 'key_id=dummy_key',
                      'authorization': 'dummy_key'}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401
 
     @inlineCallbacks
     def test_request_v2_id_variant_pubkey(self):
@@ -170,7 +169,7 @@ class TestWebpushHandler(unittest.TestCase):
             headers={'crypto-key': 'p256ecdsa=' + variant_key,
                      'authorization': 'webpush dummy.key'}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401
 
     @inlineCallbacks
     def test_request_v2_id_no_crypt_auth(self):
@@ -185,7 +184,7 @@ class TestWebpushHandler(unittest.TestCase):
             self.url(api_ver='v1', token='ignored'),
             headers={'authorization': 'webpush dummy.key'}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401
 
     @inlineCallbacks
     def test_request_bad_v2_id_bad_pubkey(self):
@@ -195,4 +194,4 @@ class TestWebpushHandler(unittest.TestCase):
             headers={'crypto-key': 'p256ecdsa=Invalid!',
                      'authorization': 'dummy_key'}
         )
-        eq_(resp.get_status(), 401)
+        assert resp.get_status() == 401

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,4 +10,6 @@ nose
 pbr==1.10.0
 psutil
 pympler==0.5
+pytest
+pytest-cov
 websocket-client


### PR DESCRIPTION
Issue #1039

General sweep of tests to make things "pytest" compliant. This means switching nosetool calls for their assert/pytest primatives. 

Note, there were a few tests in test_cryptokey that were invalid and have been fixed because of this.
In addition, some [light type correction](https://github.com/mozilla-services/autopush/compare/bug/1033?expand=1#diff-8c7a1b5174dad635894310a2ce89eb88L104) was made where appropriate.

(Also note: this PR does not fully close #1039. tox and other functions still use nose.)