### PR TITLE
feat: cache SSLContexts created by ssl.wrap_socket

### DIFF
--- a/autopush/config.py
+++ b/autopush/config.py
@@ -173,6 +173,9 @@ class AutopushConfig(object):
     # Strict-Transport-Security max age (Default 1 year in secs)
     sts_max_age = attrib(default=31536000)  # type: int
 
+    # Don't cache ssl.wrap_socket's SSLContexts
+    no_sslcontext_cache = attrib(default=False)  # type: bool
+
     def __attrs_post_init__(self):
         """Initialize the Settings object"""
         # Setup hosts/ports/urls
@@ -303,6 +306,7 @@ class AutopushConfig(object):
             connect_timeout=ns.connection_timeout,
             memusage_port=ns.memusage_port,
             use_cryptography=ns.use_cryptography,
+            no_sslcontext_cache=ns._no_sslcontext_cache,
             router_table=dict(
                 tablename=ns.router_tablename,
                 read_throughput=ns.router_read_throughput,

--- a/autopush/db.py
+++ b/autopush/db.py
@@ -65,6 +65,7 @@ from typing import (  # noqa
     Set,
     TypeVar,
     Tuple,
+    Union,
 )
 from twisted.internet.defer import Deferred  # noqa
 from twisted.internet.defer import inlineCallbacks, returnValue
@@ -504,7 +505,7 @@ class Message(object):
     def fetch_timestamp_messages(
             self,
             uaid,  # type: uuid.UUID
-            timestamp=None,  # type: Optional[int or str]
+            timestamp=None,  # type: Optional[Union[int, str]]
             limit=10,  # type: int
             ):
         # type: (...) -> Tuple[Optional[int], List[WebPushNotification]]

--- a/autopush/main_argparse.py
+++ b/autopush/main_argparse.py
@@ -97,6 +97,10 @@ def add_shared_args(parser):
                         help="Max Strict Transport Age in seconds",
                         type=int, default=31536000,
                         env_var="STS_MAX_AGE")
+    parser.add_argument('--_no_sslcontext_cache',
+                        help="Don't cache ssl.wrap_socket's SSLContexts",
+                        action="store_true", default=False,
+                        env_var="_NO_SSLCONTEXT_CACHE")
     # No ENV because this is for humans
     _add_external_router_args(parser)
     _obsolete_args(parser)

--- a/autopush/tests/test_main.py
+++ b/autopush/tests/test_main.py
@@ -257,6 +257,7 @@ class EndpointMainTestCase(unittest.TestCase):
         disable_simplepush = True
         use_cryptography = False
         sts_max_age = 1234
+        _no_sslcontext_cache = False
 
     def setUp(self):
         patchers = [
@@ -318,8 +319,7 @@ class EndpointMainTestCase(unittest.TestCase):
             "--memusage_port=8083",
         ], False)
 
-    @patch('hyper.tls', spec=hyper.tls)
-    def test_client_certs_parse(self, mock):
+    def test_client_certs_parse(self):
         conf = AutopushConfig.from_argparse(self.TestArg)
         assert conf.client_certs["1A:"*31 + "F9"] == 'partner1'
         assert conf.client_certs["2B:"*31 + "E8"] == 'partner2'
@@ -377,11 +377,8 @@ class EndpointMainTestCase(unittest.TestCase):
             """--senderid_list={"123":{"auth":"abcd"}}""",
         ], False)
 
-    @patch('autopush.router.apns2.HTTP20Connection',
-           spec=hyper.HTTP20Connection)
-    @patch('hyper.tls', spec=hyper.tls)
     @patch("requests.get")
-    def test_aws_ami_id(self, request_mock, mt, mc):
+    def test_aws_ami_id(self, request_mock):
         class MockReply:
             content = "ami_123"
 
@@ -389,3 +386,10 @@ class EndpointMainTestCase(unittest.TestCase):
         self.TestArg.no_aws = False
         conf = AutopushConfig.from_argparse(self.TestArg)
         assert conf.ami_id == "ami_123"
+
+    def test_no_sslcontext_cache(self):
+        conf = AutopushConfig.from_argparse(self.TestArg)
+        assert not conf.no_sslcontext_cache
+        self.TestArg._no_sslcontext_cache = True
+        conf = AutopushConfig.from_argparse(self.TestArg)
+        assert conf.no_sslcontext_cache

--- a/autopush/tests/test_ssl.py
+++ b/autopush/tests/test_ssl.py
@@ -1,0 +1,36 @@
+import socket
+import ssl
+from twisted.trial import unittest
+
+from autopush.ssl import (
+    monkey_patch_ssl_wrap_socket,
+    ssl_wrap_socket_cached,
+    undo_monkey_patch_ssl_wrap_socket
+)
+
+
+class SSLContextCacheTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # XXX: test_main doesn't cleanup after itself
+        undo_monkey_patch_ssl_wrap_socket()
+
+    def test_monkey_patch_ssl_wrap_socket(self):
+        assert ssl.wrap_socket is not ssl_wrap_socket_cached
+        orig = ssl.wrap_socket
+        monkey_patch_ssl_wrap_socket()
+        self.addCleanup(undo_monkey_patch_ssl_wrap_socket)
+
+        assert ssl.wrap_socket is ssl_wrap_socket_cached
+        undo_monkey_patch_ssl_wrap_socket()
+        assert ssl.wrap_socket is orig
+
+    def test_ssl_wrap_socket_cached(self):
+        monkey_patch_ssl_wrap_socket()
+        self.addCleanup(undo_monkey_patch_ssl_wrap_socket)
+
+        s1 = socket.create_connection(('search.yahoo.com', 443))
+        s2 = socket.create_connection(('google.com', 443))
+        ssl1 = ssl.wrap_socket(s1, do_handshake_on_connect=False)
+        ssl2 = ssl.wrap_socket(s2, do_handshake_on_connect=False)
+        assert ssl1.context is ssl2.context

--- a/autopush/webpush_server.py
+++ b/autopush/webpush_server.py
@@ -11,7 +11,13 @@ from attr import (
 )
 from boto.dynamodb2.exceptions import ItemNotFound
 from boto.exception import JSONResponseError
-from typing import Dict, List, Optional  # noqa
+from typing import (  # noqa
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union
+)
 from twisted.logger import Logger
 
 from autopush.db import (  # noqa
@@ -201,7 +207,7 @@ class StoreMessagesResponse(OutputCommand):
 ###############################################################################
 class WebPushServer(object):
     def __init__(self, conf, db, num_threads=10):
-        # type: (AutopushConfig, DatabaseManager) -> WebPushServer
+        # type: (AutopushConfig, DatabaseManager, int) -> WebPushServer
         self.conf = conf
         self.db = db
         self.db.setup_tables()


### PR DESCRIPTION
avoids unnecessary allocation of them which appears to stress pypy's
GC (w/ their finalization needs)

also fix some type signatures and kill some now unnecessary mock patches

Closes: #1038