### PR TITLE
feat: address HTTP2 errors in APNS

### DIFF
--- a/autopush/noseplugin.py
+++ b/autopush/noseplugin.py
@@ -10,7 +10,7 @@ except ImportError:
 
 try:
     from pympler import asizeof
-except:
+except Exception:
     asizeof = None
 
 

--- a/autopush/router/gcm.py
+++ b/autopush/router/gcm.py
@@ -37,7 +37,7 @@ class GCMRouter(object):
             self.senderIDs[sid] = auth
             try:
                 self.gcm[sid] = gcmclient.GCM(auth)
-            except:
+            except Exception:
                 raise IOError("GCM Bridge not initiated in main")
         self._base_tags = ["platform:gcm"]
         self.log.debug("Starting GCM router...")

--- a/autopush/tests/certs/makecerts.py
+++ b/autopush/tests/certs/makecerts.py
@@ -19,7 +19,7 @@ def make_cert(filename, cacert=None, cakey=None):
     subject.ST = b"Çorum"
     subject.L = b"Başmakçı"
     subject.CN = b"localhost"
-    subject.O = b"Mozilla Test"
+    subject.O = b"Mozilla Test"  # noqa: E741
     subject.OU = b"Autopush Test %s" % filename
     subject.emailAddress = b"otto.push@example.com"
     subjectAltName = X509Extension(b'subjectAltName', False, b'DNS:localhost')

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -234,7 +234,7 @@ keyid="http://example.org/bob/keys/123;salt="XZwpw6o37R-6qoZjw6KwAw"\
             d = self.ws.recv()
             log.debug("Recv: %s", d)
             return json.loads(d)
-        except:
+        except Exception:
             return None
         finally:
             self.ws.settimeout(orig_timeout)

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -136,7 +136,7 @@ class TestBase(unittest.TestCase):
 
         try:
             raise TestX()
-        except:
+        except Exception:
             exc_info = sys.exc_info()
 
         self.base.write_error(999, exc_info=exc_info)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -374,7 +374,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             try:
                 result = func(*args, **kwargs)
                 d.callback(result)
-            except:
+            except Exception:
                 d.errback(failure.Failure())
         reactor.callLater(when, f)
         return d
@@ -498,7 +498,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         data = None
         try:
             data = json.loads(payload.decode('utf8'))
-        except:
+        except (TypeError, ValueError):
             pass
 
         if not isinstance(data, dict):

--- a/configs/autopush_shared.ini.sample
+++ b/configs/autopush_shared.ini.sample
@@ -124,8 +124,11 @@ endpoint_port = 8082
 ;        "key": "path_to_key_file",
 ;        "topic": "com.mozilla.org.Firefox",  // Bundle ID for associated app
 ;        "max_connections": 100, // Max number of connection pool entries.
-;        "sandbox": False},  // Use the APNs sandbox feature
-;     ... }
-; e.g {"firefox":{"cert":"certs/main.cert","key":"certs/main.key","topic":"com.mozilla.org.Firefox"},"beta":{"cert":"certs/beta.cert","key":"certs/beta.key","topic":"com.mozilla.org.FirefoxBeta"}}
+;        "sandbox": False,  // Use the APNs sandbox feature
+;        "max_retry": 2, // Max number of retries in event of an HTTP2 error
+;        },
+;       ...
+; }
+; e.g {"firefox":{"cert":"certs/main.cert","key":"certs/main.key","topic":"com.mozilla.org.Firefox","max_retry":2},"beta":{"cert":"certs/beta.cert","key":"certs/beta.key","topic":"com.mozilla.org.FirefoxBeta"}}
 #apns_creds =
 


### PR DESCRIPTION
Converts two errors into metrics and attempts retry on Connection or
HTTP2 errors.

Closes #1052