### PR TITLE
feat: fill in missing metrics for autopush_rs

### DIFF
--- a/autopush/tests/test_webpush_server.py
+++ b/autopush/tests/test_webpush_server.py
@@ -13,8 +13,8 @@ import pytest
 
 from autopush.db import (
     DatabaseManager,
-    make_rotating_tablename,
     generate_last_connect,
+    make_rotating_tablename,
 )
 from autopush.metrics import SinkMetrics
 from autopush.config import AutopushConfig
@@ -234,6 +234,9 @@ class TestHelloProcessor(BaseSetup):
         assert isinstance(result, HelloResponse)
         assert hello.uaid != result.uaid
         assert result.check_storage is False
+        assert result.connected_at == hello.connected_at
+        assert self.metrics.increment.called
+        assert self.metrics.increment.call_args[0][0] == 'ua.command.hello'
 
     def test_existing_uaid(self):
         p = self._makeFUT()
@@ -245,6 +248,9 @@ class TestHelloProcessor(BaseSetup):
         assert isinstance(result, HelloResponse)
         assert hello.uaid.hex == result.uaid
         assert result.check_storage is True
+        assert result.connected_at == hello.connected_at
+        assert self.metrics.increment.called
+        assert self.metrics.increment.call_args[0][0] == 'ua.command.hello'
 
     def test_existing_newer_uaid(self):
         p = self._makeFUT()

--- a/autopush_rs/Cargo.lock
+++ b/autopush_rs/Cargo.lock
@@ -3,6 +3,7 @@ name = "autopush"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cadence 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,6 +82,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cadence"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +101,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crossbeam"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "custom_derive"
@@ -658,8 +672,10 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
+"checksum cadence 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b48d3db3b2321bc9275c142fa2ddf04d2bcaa651a3b2acfaf8f4a1919402c88e"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"

--- a/autopush_rs/Cargo.toml
+++ b/autopush_rs/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bytes = "0.4"
+cadence = "0.12.1"
 env_logger = { version = "0.4", default-features = false }
 error-chain = "0.10"
 futures = "0.1"

--- a/autopush_rs/__init__.py
+++ b/autopush_rs/__init__.py
@@ -36,6 +36,8 @@ class AutopushServer(object):
         cfg.ssl_key = ffi_from_buffer(conf.ssl.key)
         cfg.url = ffi_from_buffer(conf.ws_url)
         cfg.json_logging = True
+        cfg.statsd_host = ffi_from_buffer(conf.statsd_host)
+        cfg.statsd_port = conf.statsd_port
 
         ptr = _call(lib.autopush_server_new, cfg)
         self.ffi = ffi.gc(ptr, lib.autopush_server_free)

--- a/autopush_rs/src/call.rs
+++ b/autopush_rs/src/call.rs
@@ -178,6 +178,7 @@ pub struct HelloResponse {
     pub check_storage: bool,
     pub reset_uaid: bool,
     pub rotate_message_table: bool,
+    pub connected_at: u64,
 }
 
 #[derive(Deserialize)]

--- a/autopush_rs/src/errors.rs
+++ b/autopush_rs/src/errors.rs
@@ -27,6 +27,7 @@ use std::any::Any;
 use std::error;
 use std::io;
 
+use cadence;
 use futures::Future;
 use httparse;
 use serde_json;
@@ -38,6 +39,7 @@ error_chain! {
         Io(io::Error);
         Json(serde_json::Error);
         Httparse(httparse::Error);
+        MetricError(cadence::MetricError);
     }
 
     errors {

--- a/autopush_rs/src/lib.rs
+++ b/autopush_rs/src/lib.rs
@@ -61,6 +61,7 @@
 //! Otherwise be sure to check out each module for more documentation!
 
 extern crate bytes;
+extern crate cadence;
 extern crate env_logger;
 #[macro_use]
 extern crate futures;

--- a/autopush_rs/src/protocol.rs
+++ b/autopush_rs/src/protocol.rs
@@ -87,7 +87,7 @@ pub struct Notification {
     pub topic: Option<String>,
     pub timestamp: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<String>,
+    pub data: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     headers: Option<HashMap<String, String>>,
 }

--- a/autopush_rs/src/server/metrics.rs
+++ b/autopush_rs/src/server/metrics.rs
@@ -1,0 +1,23 @@
+//! Metrics tie-ins
+
+use std::net::UdpSocket;
+
+use cadence::{BufferedUdpMetricSink, NopMetricSink, QueuingMetricSink, StatsdClient};
+
+use errors::*;
+use server::ServerOptions;
+
+/// Create a cadence StatsdClient from the given options
+pub fn metrics_from_opts(opts: &ServerOptions) -> Result<StatsdClient> {
+    Ok(if let Some(statsd_host) = opts.statsd_host.as_ref() {
+        let socket = UdpSocket::bind("0.0.0.0:0")?;
+        socket.set_nonblocking(true)?;
+
+        let host = (statsd_host.as_str(), opts.statsd_port);
+        let udp_sink = BufferedUdpMetricSink::from(host, socket)?;
+        let sink = QueuingMetricSink::from(udp_sink);
+        StatsdClient::from_sink("autopush", sink)
+    } else {
+        StatsdClient::from_sink("autopush", NopMetricSink)
+    })
+}


### PR DESCRIPTION
the rust side's metrics (via cadence) currently lack the ability to
pass datadog tags, currently ua.{message_data,connection.lifespan}

Issue: #1054