### PR TITLE
bug: Fix diagnostic cli to handle tuple args

### DIFF
--- a/autopush/db.py
+++ b/autopush/db.py
@@ -363,6 +363,7 @@ def preflight_check(message, router, uaid="deadbeef00000000deadbeef00000000"):
     # Store a router entry, fetch it, delete it
     router.register_user(dict(uaid=uaid.hex, node_id=node_id,
                               connected_at=connected_at,
+                              current_month=datetime.date.today().month,
                               router_type="webpush"))
     item = router.get_uaid(uaid.hex)
     assert item.get("node_id") == node_id
@@ -694,7 +695,7 @@ class Message(object):
 class Router(object):
     """Create a Router table abstraction on top of a DynamoDB Table object"""
     def __init__(self, table, metrics, max_ttl=MAX_EXPIRY):
-        # type: (Table, IMetrics) -> None
+        # type: (Table, IMetrics, int) -> None
         """Create a new Router object
 
         :param table: :class:`Table` object.

--- a/autopush/diagnostic_cli.py
+++ b/autopush/diagnostic_cli.py
@@ -30,11 +30,11 @@ class EndpointDiagnosticCLI(object):
     def _load_args(self, sysargs, use_files):
         shared_config_files = AutopushMultiService.shared_config_files
         if use_files:
-            config_files = shared_config_files + [  # pragma: nocover
+            config_files = shared_config_files + (  # pragma: nocover
                 '/etc/autopush_endpoint.ini',
                 '~/.autopush_endpoint.ini',
                 '.autopush_endpoint.ini'
-            ]
+            )
         else:
             config_files = []  # pragma: nocover
 
@@ -68,10 +68,11 @@ class EndpointDiagnosticCLI(object):
         self._pp.pprint(rec._data)
         print("\n")
 
-        mess_table = rec["current_month"]
-        chans = self.db.message_tables[mess_table].all_channels(uaid)
-        print("Channels in message table:")
-        self._pp.pprint(chans)
+        if "current_month" in rec:
+            mess_table = rec["current_month"]
+            chans = self.db.message_tables[mess_table].all_channels(uaid)
+            print("Channels in message table:")
+            self._pp.pprint(chans)
 
 
 def run_endpoint_diagnostic_cli(sysargs=None, use_files=True):

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -337,6 +337,7 @@ class RouterTestCase(unittest.TestCase):
             "router_type": "webupsh",
             "last_connect": generate_last_connect(),
             "connected_at": ms_time(),
+            "current_month": datetime.today().month,
         }
         return data
 

--- a/autopush/tests/test_diagnostic_cli.py
+++ b/autopush/tests/test_diagnostic_cli.py
@@ -47,3 +47,10 @@ class DiagnosticCLITestCase(unittest.TestCase):
             "http://something/wpush/v1/legit_endpoint",
         ], use_files=False)
         mock_message_table.all_channels.assert_called()
+
+    def test_parser_tuple(self):
+        from autopush.diagnostic_cli import EndpointDiagnosticCLI
+
+        edc = EndpointDiagnosticCLI(("http://someendpoint",))
+        assert edc is not None
+        assert edc._endpoint == "http://someendpoint"


### PR DESCRIPTION
Also we were inconsistent about passing `current_month` when registering
`webpush` protocol entities. While not strictly an error now, it could
cause issues later if we do stricter lookups.

Closes #1096