### PR TITLE
feat: add integration testing for Rust connection node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ include/*
 lib_pypy/*
 *.swp
 pypy/
-src/
+./src/
 .tox/
 .eggs/
 autopush_rs/target
 autopush_rs/_native*
+*.rs.bk

--- a/autopush/tests/test_z_main.py
+++ b/autopush/tests/test_z_main.py
@@ -1,3 +1,9 @@
+"""Test main instantiation
+
+This is named test_z_main.py to run it last. Due to issues in this test, the
+testing environment is unclean and no further tests can be run reliably.
+
+"""
 import unittest
 import datetime
 import json

--- a/autopush_rs/src/call.rs
+++ b/autopush_rs/src/call.rs
@@ -141,7 +141,7 @@ enum Call {
         uaid: String,
         message_month: String,
         include_topic: bool,
-        timestamp: Option<i64>,
+        timestamp: Option<u64>,
     },
 
     DeleteMessage {
@@ -152,7 +152,7 @@ enum Call {
     IncStoragePosition {
         uaid: String,
         message_month: String,
-        timestamp: i64,
+        timestamp: u64,
     },
 
     DropUser { uaid: String },
@@ -210,7 +210,7 @@ pub enum UnRegisterResponse {
 pub struct CheckStorageResponse {
     pub include_topic: bool,
     pub messages: Vec<protocol::Notification>,
-    pub timestamp: Option<i64>,
+    pub timestamp: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -293,7 +293,7 @@ impl Server {
         uaid: String,
         message_month: String,
         include_topic: bool,
-        timestamp: Option<i64>,
+        timestamp: Option<u64>,
     ) -> MyFuture<CheckStorageResponse> {
         let (call, fut) = PythonCall::new(&Call::CheckStorage {
             uaid: uaid,
@@ -309,7 +309,7 @@ impl Server {
         &self,
         uaid: String,
         message_month: String,
-        timestamp: i64,
+        timestamp: u64,
     ) -> MyFuture<IncStorageResponse> {
         let (call, fut) = PythonCall::new(&Call::IncStoragePosition {
             uaid: uaid,

--- a/autopush_rs/src/http.rs
+++ b/autopush_rs/src/http.rs
@@ -26,18 +26,18 @@ impl Service for Push {
 
     fn call(&self, req: hyper::Request) -> Self::Future {
         if *req.method() != Method::Put && *req.method() != Method::Post {
-            println!("not a PUT: {}", req.method());
+            debug!("not a PUT: {}", req.method());
             return Box::new(err(hyper::Error::Method));
         }
         if req.uri().path().len() == 0 {
-            println!("empty uri path");
+            debug!("empty uri path");
             return Box::new(err(hyper::Error::Incomplete));
         }
         let req_uaid = req.uri().path()[6..].to_string();
         let uaid = match Uuid::parse_str(&req_uaid) {
             Ok(id) => id,
             Err(_) => {
-                println!("uri not uuid: {}", req_uaid);
+                debug!("uri not uuid: {}", req.uri().to_string());
                 return Box::new(err(hyper::Error::Status));
             }
         };

--- a/autopush_rs/src/protocol.rs
+++ b/autopush_rs/src/protocol.rs
@@ -20,7 +20,7 @@ pub enum ServerNotification {
 #[serde(tag = "messageType", rename_all = "lowercase")]
 pub enum ClientMessage {
     Hello {
-        uaid: Option<Uuid>,
+        uaid: Option<String>,
         #[serde(rename = "channelIDs", skip_serializing_if = "Option::is_none")]
         channel_ids: Option<Vec<Uuid>>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,18 +82,26 @@ pub enum ServerMessage {
     Notification(Notification),
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Notification {
     pub uaid: Option<String>,
     #[serde(rename = "channelID")]
     pub channel_id: Uuid,
     pub version: String,
+    #[serde(default = "default_ttl")]
     pub ttl: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic: Option<String>,
-    pub timestamp: u64,
+    pub timestamp: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
+    #[serde(skip_serializing)]
+    pub sortkey_timestamp: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     headers: Option<HashMap<String, String>>,
+}
+
+
+fn default_ttl() -> u32 {
+    0
 }


### PR DESCRIPTION
Adds the following functionality for capability parity:

- Skip sending messages if the message is expired
- Properly handle legacy messages in a message stream
- Set appropriate flags for a uaid not found in the db
- Always return a timestamp when querying into timestamp messages
- Send messages in the order they're retrieved from the db
- Accept messages from endpoint while waiting for acks
- Don't save TTL:0 messages in the db if the client fails to ack them
- Allow TTL:None from endpoint and treat as TTL:0

Closes #1060