### PR TITLE
fix: reverse our filled in stack trace order

### DIFF
--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -142,8 +142,10 @@ class PushLogger(object):
         extra = dict()
         tb = f.getTracebackObject()
         if not tb:
-            # include the current stack for at least some context
-            stack = list(iter_stack_frames())[4:]  # approx.
+            # include the current stack for at least some
+            # context. sentry's expecting that "Frames should be
+            # sorted from oldest to newest."
+            stack = reversed(list(iter_stack_frames())[5:])  # approx.
             extra = dict(no_failure_tb=True)
         extra.update(
             log_format=event.get('log_format'),

--- a/autopush/tests/test_logging.py
+++ b/autopush/tests/test_logging.py
@@ -99,11 +99,12 @@ class SentryLogTestCase(twisted.trial.unittest.TestCase):
                 return
 
             assert len(logged) == 1
-            # Ensure a top level stacktrace was included
-            stacktrace = logged[0]['stacktrace']
-            assert any(
-                filename == f['abs_path'] and testname == f['function']
-                for f in stacktrace['frames'])
+            # Ensure a stacktrace was included w/ the current frame as
+            # the last entry
+            frames = logged[0]['stacktrace']['frames']
+            last = frames[-1]
+            assert last['abs_path'] == filename
+            assert last['function'] == testname
 
             self._port.stopListening()
             pl.stop()


### PR DESCRIPTION
frames should be sorted from oldest to newest despite raven's
iter_stack_frames

Closes #1134