### PR TITLE
fix: have webpush router handle ClientErrors

### DIFF
--- a/autopush/exceptions.py
+++ b/autopush/exceptions.py
@@ -64,3 +64,7 @@ class LogCheckError(Exception):
 
 class InvalidConfig(Exception):
     """Error in initialization of AutopushConfig"""
+
+
+class ItemNotFound(Exception):
+    """Signals missing DynamoDB Item data"""

--- a/autopush/tests/__init__.py
+++ b/autopush/tests/__init__.py
@@ -3,7 +3,6 @@ import os
 import signal
 import subprocess
 
-import boto
 import psutil
 from twisted.internet import reactor
 
@@ -19,7 +18,7 @@ boto_resource = None
 
 
 def setUp():
-    for name in ('boto', 'boto3', 'botocore'):
+    for name in ('boto3', 'botocore'):
         logging.getLogger(name).setLevel(logging.CRITICAL)
     global ddb_process, boto_resource
     cmd = " ".join([
@@ -53,11 +52,6 @@ def tearDown():
     for p in [proc] + child_procs:
         os.kill(p.pid, signal.SIGTERM)
     ddb_process.wait()
-
-    # Clear out the boto config that was loaded so the rest of the tests run
-    # fine
-    for section in boto.config.sections():      # pragma: nocover
-        boto.config.remove_section(section)
 
 
 _multiprocess_shared_ = True

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -4,9 +4,6 @@ import uuid
 from datetime import datetime, timedelta
 
 from autopush.websocket import ms_time
-from boto.dynamodb2.exceptions import (
-    ItemNotFound,
-)
 from botocore.exceptions import ClientError
 from mock import Mock, patch
 import pytest
@@ -27,7 +24,7 @@ from autopush.db import (
     DatabaseManager,
     DynamoDBResource
     )
-from autopush.exceptions import AutopushException
+from autopush.exceptions import AutopushException, ItemNotFound
 from autopush.metrics import SinkMetrics
 from autopush.utils import WebPushNotification
 

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -39,6 +39,7 @@ from autopush.db import (
     has_connected_this_month,
     Message,
 )
+from autopush.exceptions import ItemNotFound
 from autopush.logging import begin_or_register
 from autopush.main import ConnectionApplication, EndpointApplication
 from autopush.utils import base64url_encode, normalize_id
@@ -454,7 +455,6 @@ class Test_Data(IntegrationBase):
 
     @inlineCallbacks
     def test_webpush_data_delivery_to_connected_client_uaid_fail(self):
-        from boto.dynamodb2.exceptions import ItemNotFound
         client = yield self.quick_register()
         self.conn.db.router.get_uaid = Mock(side_effect=ItemNotFound)
         assert client.channels

--- a/autopush/tests/test_web_validation.py
+++ b/autopush/tests/test_web_validation.py
@@ -4,9 +4,6 @@ import uuid
 from hashlib import sha256
 
 import ecdsa
-from boto.dynamodb2.exceptions import (
-    ItemNotFound,
-)
 from cryptography.fernet import InvalidToken
 from cryptography.exceptions import InvalidSignature
 from jose import jws
@@ -17,7 +14,11 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
 from autopush.metrics import SinkMetrics
-from autopush.exceptions import InvalidRequest, InvalidTokenException
+from autopush.exceptions import (
+    InvalidRequest,
+    InvalidTokenException,
+    ItemNotFound
+)
 from autopush.tests.support import test_db
 import autopush.utils as utils
 

--- a/autopush/tests/test_webpush_server.py
+++ b/autopush/tests/test_webpush_server.py
@@ -6,7 +6,6 @@ from uuid import uuid4, UUID
 
 import attr
 import factory
-from boto.dynamodb2.exceptions import ItemNotFound
 from mock import Mock
 from twisted.logger import globalLogPublisher
 import pytest
@@ -19,6 +18,7 @@ from autopush.db import (
 )
 from autopush.metrics import SinkMetrics
 from autopush.config import AutopushConfig
+from autopush.exceptions import ItemNotFound
 from autopush.logging import begin_or_register
 from autopush.tests.support import TestingLogObserver
 from autopush.utils import WebPushNotification, ns_time

--- a/autopush/types.py
+++ b/autopush/types.py
@@ -1,14 +1,7 @@
 """Common types"""
-from boto.dynamodb2.items import Item
-from typing import (
-    Any,
-    Dict,
-    Union
-)
+from typing import Any, Dict
 
 
 # no mypy reucrsive types yet:
 # https://github.com/python/mypy/issues/731
 JSONDict = Dict[str, Any]
-
-ItemLike = Union[Item, Dict[str, Any]]

--- a/autopush/utils.py
+++ b/autopush/utils.py
@@ -26,7 +26,6 @@ from jose import jwt
 
 from autopush.exceptions import (InvalidTokenException, VapidAuthException)
 from autopush.jwt import repad, VerifyJWT
-from autopush.types import ItemLike  # noqa
 from autopush.web.base import AUTH_SCHEMES
 
 
@@ -469,7 +468,7 @@ class WebPushNotification(object):
 
     @classmethod
     def from_message_table(cls, uaid, item):
-        # type: (uuid.UUID, ItemLike) -> WebPushNotification
+        # type: (uuid.UUID, Dict[str, Any]) -> WebPushNotification
         """Create a WebPushNotification from a message table item"""
         key_info = cls.parse_sort_key(item["chidmessageid"])
         if key_info["api_ver"] in ["01", "02"]:

--- a/autopush/web/registration.py
+++ b/autopush/web/registration.py
@@ -10,7 +10,6 @@ from typing import (  # noqa
 )
 
 import simplejson as json
-from boto.dynamodb2.exceptions import ItemNotFound
 from cryptography.hazmat.primitives import constant_time
 from marshmallow import (
     Schema,
@@ -25,7 +24,7 @@ from twisted.internet.defer import Deferred  # noqa
 from twisted.internet.threads import deferToThread
 
 from autopush.db import generate_last_connect, hasher
-from autopush.exceptions import InvalidRequest, RouterException
+from autopush.exceptions import InvalidRequest, ItemNotFound, RouterException
 from autopush.types import JSONDict  # noqa
 from autopush.utils import generate_hash, ms_time
 from autopush.web.base import (

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -1,7 +1,6 @@
 import re
 import time
 
-from boto.dynamodb2.exceptions import ItemNotFound
 from cryptography.fernet import InvalidToken
 from cryptography.exceptions import InvalidSignature
 from marshmallow import (
@@ -32,6 +31,7 @@ from autopush.db import hasher
 from autopush.exceptions import (
     InvalidRequest,
     InvalidTokenException,
+    ItemNotFound,
     VapidAuthException,
 )
 from autopush.types import JSONDict  # noqa

--- a/autopush/webpush_server.py
+++ b/autopush/webpush_server.py
@@ -9,7 +9,6 @@ from attr import (
     attrs,
     attrib,
 )
-from boto.dynamodb2.exceptions import ItemNotFound
 from botocore.exceptions import ClientError
 from typing import (  # noqa
     Dict,
@@ -29,6 +28,7 @@ from autopush.db import (  # noqa
 )
 
 from autopush.config import AutopushConfig  # noqa
+from autopush.exceptions import ItemNotFound
 from autopush.metrics import IMetrics  # noqa
 from autopush.web.webpush import MAX_TTL
 from autopush.types import JSONDict  # noqa

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -48,9 +48,6 @@ from autobahn.twisted.websocket import (
     WebSocketServerProtocol
 )
 from autobahn.websocket.protocol import ConnectionRequest  # noqa
-from boto.dynamodb2.exceptions import (
-    ItemNotFound
-)
 from botocore.exceptions import ClientError
 from botocore.vendored.requests.packages import urllib3
 from twisted.internet import reactor
@@ -91,7 +88,7 @@ from autopush.db import (
     generate_last_connect,
 )
 from autopush.db import DatabaseManager, Message  # noqa
-from autopush.exceptions import MessageOverloadException
+from autopush.exceptions import MessageOverloadException, ItemNotFound
 from autopush.noseplugin import track_object
 from autopush.protocol import IgnoreBody
 from autopush.metrics import IMetrics, make_tags  # noqa

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 apns
 attrs
 autobahn[twisted]
-boto
 boto3
 cffi
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ attrs==17.4.0
 autobahn[twisted]==17.10.1
 automat==0.6.0            # via twisted
 boto3==1.5.23
-boto==2.48.0
 botocore==1.8.37          # via boto3, s3transfer
 certifi==2018.1.18        # via requests
 cffi==1.11.4


### PR DESCRIPTION
it was previously handling only the old boto2 JSONResponseError in
those spots

also kill the remaining boto2 bits

Closes #1138