### PR TITLE
feat: add megaphone API query and repeating service updating

### DIFF
--- a/autopush/config.py
+++ b/autopush/config.py
@@ -120,6 +120,8 @@ class AutopushConfig(object):
 
     statsd_host = attrib(default="localhost")  # type: str
     statsd_port = attrib(default=8125)  # type: int
+    megaphone_api_url = attrib(default=None)  # type: Optional[str]
+    megaphone_poll_interval = attrib(default=30)  # type: int
 
     datadog_api_key = attrib(default=None)  # type: Optional[str]
     datadog_app_key = attrib(default=None)  # type: Optional[str]

--- a/autopush/main.py
+++ b/autopush/main.py
@@ -380,5 +380,6 @@ class RustConnectionApplication(AutopushMultiService):
             max_connections=ns.max_connections,
             close_handshake_timeout=ns.close_handshake_timeout,
             aws_ddb_endpoint=ns.aws_ddb_endpoint,
+            megaphone_api_url=ns.megaphone_api_url,
             resource=resource
         )

--- a/autopush/main_argparse.py
+++ b/autopush/main_argparse.py
@@ -228,6 +228,13 @@ def parse_connection(config_files, args):
                         help="The client handshake timeout. Set to 0 to"
                         "disable.", default=0, type=int,
                         env_var="HELLO_TIMEOUT")
+    parser.add_argument('--megaphone_api_url',
+                        help="The megaphone API URL to query for updates",
+                        default=None, type=str, env_var="MEGAPHONE_API_URL")
+    parser.add_argument('--megaphone_poll_interval',
+                        help="The megaphone API polling interval",
+                        default=30, type=int,
+                        env_var="MEGAPHONE_POLL_INTERVAL")
 
     add_shared_args(parser)
     return parser.parse_args(args)

--- a/autopush_rs/Cargo.toml
+++ b/autopush_rs/Cargo.toml
@@ -18,17 +18,17 @@ httparse = "1.2.4"
 hyper = "0.11.15"
 libc = "0.2.36"
 # log: Use this version for debug builds
-#log = "0.3"
+# log = "0.4.1"
 # log: Use this for release builds (leave in for commits)
 log = { version = "0.4.1", features = ["max_level_trace", "release_max_level_warn"] }
 openssl = "0.10.2"
-reqwest = "0.8.4"
+reqwest = { version = "0.8.4", features = ["unstable"] }
 sentry = "0.2.0"
 serde = "1.0.27"
 serde_derive = "1.0.27"
 serde_json = "1.0.9"
 # slog: Use this first version for debug builds
-#slog = { version = "2.0.12" , features = ["max_level_trace", "release_max_level_debug"] }
+# slog = { version = "2.1.1" , features = ["max_level_trace", "release_max_level_debug"] }
 # slog: Use this for release builds (leave in for commits)
 slog = "2.1.1"
 slog-async = "2.2.0"

--- a/autopush_rs/__init__.py
+++ b/autopush_rs/__init__.py
@@ -35,6 +35,8 @@ class AutopushServer(object):
         cfg.json_logging = True
         cfg.statsd_host = ffi_from_buffer(conf.statsd_host)
         cfg.statsd_port = conf.statsd_port
+        cfg.megaphone_api_url = ffi_from_buffer(conf.megaphone_api_url)
+        cfg.megaphone_poll_interval = conf.megaphone_poll_interval
 
         ptr = _call(lib.autopush_server_new, cfg)
         self.ffi = ffi.gc(ptr, lib.autopush_server_free)


### PR DESCRIPTION
Megaphone API is now queried on startup and at every poll interval to
update the change state tracker.

Issue #1129 

Remaining work after this is going to be a fairly large set of integration tests to close out the issue.