### PR TITLE
rustfmt all the rust

### DIFF
--- a/autopush_rs/src/client.rs
+++ b/autopush_rs/src/client.rs
@@ -26,7 +26,7 @@ use errors::*;
 use protocol::{ClientMessage, Notification, ServerMessage, ServerNotification};
 use server::Server;
 use util::{ms_since_epoch, parse_user_agent, sec_since_epoch};
-use util::ddb_helpers::{CheckStorageResponse};
+use util::ddb_helpers::CheckStorageResponse;
 use util::megaphone::{ClientServices, Service, ServiceClientInit};
 
 // Created and handed to the AutopushServer
@@ -643,7 +643,11 @@ where
             }
         };
 
-        let SendThenWait { data, remaining_data, .. } = send.take();
+        let SendThenWait {
+            data,
+            remaining_data,
+            ..
+        } = send.take();
         if start_send {
             transition!(SendThenWait {
                 remaining_data,
@@ -702,9 +706,11 @@ where
                 };
                 if let Some(delta) = service_delta {
                     transition!(SendThenWait {
-                        remaining_data: vec![ServerMessage::Broadcast {
-                            broadcasts: Service::into_hashmap(delta),
-                        }],
+                        remaining_data: vec![
+                            ServerMessage::Broadcast {
+                                broadcasts: Service::into_hashmap(delta),
+                            },
+                        ],
                         poll_complete: false,
                         data,
                     });
@@ -825,9 +831,9 @@ where
             .ok_or("unacked_stored_highest unset")?
             .to_string();
         let ddb_response = increment_storage.data.srv.ddb.increment_storage(
-                &webpush.message_month,
-                &webpush.uaid,
-                &timestamp
+            &webpush.message_month,
+            &webpush.uaid,
+            &timestamp,
         );
         transition!(AwaitIncrementStorage {
             ddb_response,
@@ -894,7 +900,10 @@ where
                     .unacked_stored_notifs
                     .extend(messages.iter().cloned());
                 transition!(SendThenWait {
-                    remaining_data: messages.into_iter().map(ServerMessage::Notification).collect(),
+                    remaining_data: messages
+                        .into_iter()
+                        .map(ServerMessage::Notification)
+                        .collect(),
                     poll_complete: false,
                     data,
                 })

--- a/autopush_rs/src/lib.rs
+++ b/autopush_rs/src/lib.rs
@@ -85,15 +85,15 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_dynamodb;
 #[macro_use]
-extern crate slog;
+extern crate serde_json;
 #[macro_use]
-extern crate slog_scope;
-extern crate slog_term;
+extern crate slog;
 extern crate slog_async;
 extern crate slog_json;
-extern crate slog_stdlog;
 #[macro_use]
-extern crate serde_json;
+extern crate slog_scope;
+extern crate slog_stdlog;
+extern crate slog_term;
 #[macro_use]
 extern crate state_machine_future;
 extern crate time;

--- a/autopush_rs/src/protocol.rs
+++ b/autopush_rs/src/protocol.rs
@@ -52,13 +52,14 @@ pub enum ClientMessage {
         broadcasts: HashMap<String, String>,
     },
 
-    Ack { updates: Vec<ClientAck> },
+    Ack {
+        updates: Vec<ClientAck>,
+    },
 
     Nack {
         code: Option<i32>,
         version: String,
     },
-
 }
 
 #[derive(Deserialize)]
@@ -118,7 +119,6 @@ pub struct Notification {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
 }
-
 
 fn default_ttl() -> u32 {
     0

--- a/autopush_rs/src/util/rc.rs
+++ b/autopush_rs/src/util/rc.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::cell::{RefCell, RefMut};
 
-use futures::{Stream, Sink, StartSend, Poll};
+use futures::{Poll, Sink, StartSend, Stream};
 
 /// Helper object to turn `Rc<RefCell<T>>` into a `Stream` and `Sink`
 ///

--- a/autopush_rs/src/util/send_all.rs
+++ b/autopush_rs/src/util/send_all.rs
@@ -1,4 +1,4 @@
-use futures::{Stream, Future, Sink, Poll, Async, AsyncSink};
+use futures::{Async, AsyncSink, Future, Poll, Sink, Stream};
 use futures::stream::Fuse;
 
 // This is a copy of `Future::forward`, except that it doesn't close the sink
@@ -25,24 +25,26 @@ where
     }
 
     fn sink_mut(&mut self) -> &mut U {
-        self.sink.as_mut().take().expect(
-            "Attempted to poll MySendAll after completion",
-        )
+        self.sink
+            .as_mut()
+            .take()
+            .expect("Attempted to poll MySendAll after completion")
     }
 
     fn stream_mut(&mut self) -> &mut Fuse<T> {
-        self.stream.as_mut().take().expect(
-            "Attempted to poll MySendAll after completion",
-        )
+        self.stream
+            .as_mut()
+            .take()
+            .expect("Attempted to poll MySendAll after completion")
     }
 
     fn take_result(&mut self) -> (T, U) {
-        let sink = self.sink.take().expect(
-            "Attempted to poll MySendAll after completion",
-        );
-        let fuse = self.stream.take().expect(
-            "Attempted to poll MySendAll after completion",
-        );
+        let sink = self.sink
+            .take()
+            .expect("Attempted to poll MySendAll after completion");
+        let fuse = self.stream
+            .take()
+            .expect("Attempted to poll MySendAll after completion");
         (fuse.into_inner(), sink)
     }
 


### PR DESCRIPTION
We had previously run rustfmt over a few files, but not everything. Here it is run over everything. 

Note that the other PR for porting the check storage command should be merged first as this goes after that commit to avoid conflicts with it.