### PR TITLE
fix: don't save legacy messages from the Rust node

### DIFF
--- a/autopush/webpush_server.py
+++ b/autopush/webpush_server.py
@@ -115,7 +115,7 @@ class WebPushMessage(object):
         )
 
         # If there's no sortkey_timestamp and no topic, its legacy
-        if not notif.sortkey_timestamp and not notif.topic:
+        if notif.sortkey_timestamp is None and not notif.topic:
             notif.legacy = True
 
         return notif


### PR DESCRIPTION
Closes #1198