### PR TITLE
refactor: more impl trait, etc

### DIFF
--- a/autopush_rs/src/db/commands.rs
+++ b/autopush_rs/src/db/commands.rs
@@ -52,6 +52,7 @@ pub fn fetch_messages(
         limit: Some(limit as i64),
         ..Default::default()
     };
+
     let cond = |err: &QueryError| matches!(err, &QueryError::ProvisionedThroughputExceeded(_));
     retry_if(move || ddb.query(&input), cond)
         .chain_err(|| "Error fetching messages")
@@ -110,6 +111,7 @@ pub fn fetch_timestamp_messages(
         limit: Some(limit as i64),
         ..Default::default()
     };
+
     let cond = |err: &QueryError| matches!(err, &QueryError::ProvisionedThroughputExceeded(_));
     retry_if(move || ddb.query(&input), cond)
         .chain_err(|| "Error fetching messages")
@@ -182,6 +184,7 @@ pub fn register_user(
         ":router_type".to_string() => val!(S => user.router_type),
         ":connected_at".to_string() => val!(N => user.connected_at),
     };
+
     retry_if(
         move || {
             debug!("Registering user: {:?}", item);
@@ -225,6 +228,7 @@ pub fn update_user_message_month(
         table_name: router_table_name.to_string(),
         ..Default::default()
     };
+
     retry_if(
         move || ddb.update_item(&update_item).and_then(|_| future::ok(())),
         |err: &UpdateItemError| matches!(err, &UpdateItemError::ProvisionedThroughputExceeded(_)),
@@ -245,6 +249,7 @@ pub fn all_channels(
         },
         ..Default::default()
     };
+
     let cond = |err: &GetItemError| matches!(err, &GetItemError::ProvisionedThroughputExceeded(_));
     retry_if(move || ddb.get_item(&input), cond)
         .and_then(|output| {
@@ -283,6 +288,7 @@ pub fn save_channels(
         table_name: message_table_name.to_string(),
         ..Default::default()
     };
+
     retry_if(
         move || ddb.update_item(&update_item).and_then(|_| future::ok(())),
         |err: &UpdateItemError| matches!(err, &UpdateItemError::ProvisionedThroughputExceeded(_)),
@@ -309,6 +315,7 @@ pub fn unregister_channel_id(
         table_name: message_table_name.to_string(),
         ..Default::default()
     };
+
     retry_if(
         move || ddb.update_item(&update_item),
         |err: &UpdateItemError| matches!(err, &UpdateItemError::ProvisionedThroughputExceeded(_)),


### PR DESCRIPTION
In separate commits:

Attempting impl trait in db.mod, it moves the boxing calls into client.rs but doesn't buy us much at all in here otherwise.

Moved as much as the metrics as possible (without refactoring lookup_user) out of db.mod: they really don't belong in there

and fixed the weird indents