### PR TITLE
fix: shrink the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ RUN \
     curl https://sh.rustup.rs | sh -s -- -y && \
     make clean && \
     WITH_RUST=release pip install -r requirements.txt && \
-    pypy setup.py develop
+    pypy setup.py develop && \
+    cd autopush_rs && \
+    cargo clean && \
+    rustup self uninstall -y
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["autopush"]

--- a/Dockerfile.python27
+++ b/Dockerfile.python27
@@ -12,6 +12,9 @@ RUN \
     curl https://sh.rustup.rs | sh -s -- -y && \
     make clean && \
     WITH_RUST=release pip install -r requirements.txt && \
-    python setup.py develop
+    python setup.py develop && \
+    cd autopush_rs && \
+    cargo clean && \
+    rustup self uninstall -y
 
 CMD ["autopush"]

--- a/autopush/tests/test_rs_integration.py
+++ b/autopush/tests/test_rs_integration.py
@@ -584,7 +584,7 @@ class TestRustWebPush(unittest.TestCase):
             yield client.send_notification(data=data, ttl=1)
 
         yield client.send_notification(data=data2)
-        time.sleep(0.75)
+        time.sleep(1)
         yield client.connect()
         yield client.hello()
         result = yield client.get_notification(timeout=4)


### PR DESCRIPTION
by nuking the rustup install & target dir after installation

Issue #1232