### PR TITLE
fix: remove legacy notification saving to address intermittent fails

### DIFF
--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -1263,8 +1263,7 @@ class TestWebPush(IntegrationBase):
         # Send in a notification, verify it landed in last months notification
         # table
         data = uuid.uuid4().hex
-        with self.legacy_endpoint():
-            yield client.send_notification(data=data)
+        yield client.send_notification(data=data)
         ts, notifs = yield deferToThread(lm_message.fetch_timestamp_messages,
                                          uuid.UUID(client.uaid),
                                          " ")
@@ -1366,8 +1365,7 @@ class TestWebPush(IntegrationBase):
         # Send in a notification, verify it landed in last months notification
         # table
         data = uuid.uuid4().hex
-        with self.legacy_endpoint():
-            yield client.send_notification(data=data)
+        yield client.send_notification(data=data)
         _, notifs = yield deferToThread(lm_message.fetch_timestamp_messages,
                                         uuid.UUID(client.uaid),
                                         " ")


### PR DESCRIPTION
We don't actually need to test legacy notification saving here, since
this is supposed to test monthly table rotation. The test would fail
randomly based on whether the channel UUID started with the first two
characters being less than '01' as fetch_timestamp_messages requires
that to locate them.

Closes #878