### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ cache:
   directories:
     - $HOME/.cache/pip
 sudo: required
-dist: trusty
+dist: xenial
 
 matrix:
   include:
     - python: 2.7
       env: TOXENV=py27 DDB=true CODECOV=true
-    - python: pypy
+    - python: pypy2.7-6.0
       env: TOXENV=pypy DDB=true CODECOV=true
     - env: TOXENV=flake8
     - python: 3.6

--- a/autopush/logging.py
+++ b/autopush/logging.py
@@ -148,7 +148,7 @@ class PushLogger(object):
             # include the current stack for at least some
             # context. sentry's expecting that "Frames should be
             # sorted from oldest to newest."
-            stack = reversed(list(iter_stack_frames())[5:])  # approx.
+            stack = list(iter_stack_frames())[:-5]  # approx.
             extra = dict(no_failure_tb=True)
         extra.update(
             log_format=event.get('log_format'),

--- a/requirements.in
+++ b/requirements.in
@@ -9,9 +9,11 @@ cryptography
 cyclone
 datadog
 gcm-client
+firebase-admin
 hyper
 marshmallow
 marshmallow-polyfield
+oauth2client
 objgraph
 pyasn1
 pyfcm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,72 +2,77 @@
 apns==2.0.1
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
-autobahn[twisted]==18.9.2
+autobahn[twisted]==18.12.1
 automat==0.7.0            # via twisted
-boto3==1.9.18
-botocore==1.12.18         # via boto3, s3transfer
-certifi==2018.8.24        # via requests
+boto3==1.9.74
+botocore==1.12.74         # via boto3, s3transfer
+cachecontrol==0.12.5      # via firebase-admin
+cachetools==3.0.0         # via google-auth
+certifi==2018.11.29       # via requests
 cffi==1.11.5
 chardet==3.0.4            # via requests
 click==7.0
 configargparse==0.13.0
 constantly==15.1.0        # via twisted
 contextlib2==0.5.5        # via raven
-cryptography==2.3.1
-cyclone==1.1
-datadog==0.22.0
+cryptography==2.4.2
+cyclone==1.2
+datadog==0.26.0
 decorator==4.3.0          # via datadog
 docutils==0.14            # via botocore
 ecdsa==0.13               # via python-jose
-enum34==1.1.6             # via cryptography, h2
-cachecontrol==0.12.5            # via firebase-admin
-firebase-admin==2.13.0          # via firebase-admin
-google-api-core==1.5.2          # via firebase-admin
-google-cloud-core==0.28.1       # via firebase-admin
-google-cloud-firestore==0.30.0  # via firebase-admin
-google-cloud-storage==1.13.0    # via firebase-admin
-google-resumable-media==0.3.1   # via firebase-admin
-googleapis-common-protos==1.5.5 # via firebase-admin
-msgpack==0.6.0                  # via firebase-admin
-protobuf==3.6.1                 # via firebase-admin
-oauth2client==4.1.3
-future==0.16.0            # via python-jose
-futures==3.2.0            # via s3transfer
+enum34==1.1.6             # via cryptography, firebase-admin, grpcio, h2
+firebase-admin==2.14.0
+future==0.17.1            # via python-jose
+futures==3.2.0            # via google-api-core, grpcio, s3transfer
 gcm-client==0.1.4
-graphviz==0.9             # via objgraph
+google-api-core[grpc]==1.7.0  # via google-cloud-core, google-cloud-firestore, google-cloud-storage
+google-auth==1.6.2        # via firebase-admin, google-api-core
+google-cloud-core==0.29.1  # via google-cloud-firestore, google-cloud-storage
+google-cloud-firestore==0.31.0  # via firebase-admin
+google-cloud-storage==1.13.2  # via firebase-admin
+google-resumable-media==0.3.2  # via google-cloud-storage
+googleapis-common-protos==1.5.5  # via google-api-core
+graphviz==0.10.1          # via objgraph
+grpcio==1.17.1            # via google-api-core
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
+httplib2==0.12.0          # via oauth2client
 hyper==0.7.0
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==18.0.0         # via twisted
-idna==2.7                 # via cryptography, hyperlink, requests, twisted
+idna==2.8                 # via cryptography, hyperlink, requests, twisted
 incremental==17.5.0       # via treq, twisted
-ipaddress==1.0.22         # via cryptography
+ipaddress==1.0.22         # via cryptography, service-identity
 jmespath==0.9.3           # via boto3, botocore
 marshmallow-polyfield==3.2
-marshmallow==2.15.6
+marshmallow==2.16.3
+msgpack==0.6.0            # via cachecontrol
+oauth2client==4.1.3
 objgraph==3.4.0
-pyasn1-modules==0.2.2     # via service-identity
-pyasn1==0.4.4
+protobuf==3.6.1           # via google-api-core, googleapis-common-protos
+pyasn1-modules==0.2.3     # via google-auth, oauth2client, service-identity
+pyasn1==0.4.5
 pycparser==2.19           # via cffi
 pyfcm==1.4.5
 pyhamcrest==1.9.0         # via twisted
 pyopenssl==18.0.0
-python-dateutil==2.7.3    # via botocore
+python-dateutil==2.7.5    # via botocore
 python-jose==3.0.1
-raven==6.9.0
+pytz==2018.7              # via google-api-core, google-cloud-firestore
+raven==6.10.0
 requests-toolbelt==0.8.0  # via pyfcm
-requests==2.20.0
-rsa==4.0                  # via python-jose
+requests==2.21.0
+rsa==4.0                  # via google-auth, oauth2client, python-jose
 s3transfer==0.1.13        # via boto3
-service-identity==17.0.0
+service-identity==18.1.0
 simplejson==3.16.0
-six==1.11.0               # via autobahn, automat, cryptography, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
+six==1.12.0               # via autobahn, automat, cryptography, firebase-admin, google-api-core, google-auth, google-resumable-media, grpcio, marshmallow-polyfield, oauth2client, protobuf, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
 treq==18.6.0
-twisted[tls]==18.7.0
+twisted[tls]==18.9.0
 txaio==18.8.1             # via autobahn
 typing==3.6.6
 ua-parser==0.8.0
-urllib3==1.23             # via botocore, requests
+urllib3==1.24.1           # via botocore, requests
 wsaccel==0.6.2 ; platform_python_implementation == "CPython"
-zope.interface==4.5.0
+zope.interface==4.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 coverage
-ecdsa==0.13
 factory_boy==2.8.1
 flake8==3.3.0
 funcsigs==1.0.2
@@ -10,6 +9,6 @@ nose
 pbr==1.10.0
 psutil
 pympler==0.5
-pytest
+pytest>=3.6
 pytest-cov
 websocket-client


### PR DESCRIPTION
but avoid the latest marshmallow (2.17.0 spams us with strict=True
warning changes and 3.0 is still beta)

and adapt to http://github.com/getsentry/raven-python/pull/1261

switch travis to xenial for pypy6 (so grpcio builds)

Closes #1311