### PR TITLE
chore: bump to latest pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
       env: TOXENV=py27 DDB=true CODECOV=true
     - python: pypy2.7-6.0
       env: TOXENV=pypy DDB=true CODECOV=true
-    - env: TOXENV=flake8
+    - python: 2.7
+      env: TOXENV=flake8
     - python: 3.6
       env: TOXENV=py36-mypy
   allow_failures:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:2-6.0.0
+FROM pypy:2-7.1.1
 
 RUN mkdir -p /app
 ADD . /app


### PR DESCRIPTION
also fixes the outdated debian jessie sources.list

Closes #1327