### PR TITLE
chore: bump to the latest twisted per CVE-2019-12387

### DIFF
--- a/autopush/tests/test_fcmclient.py
+++ b/autopush/tests/test_fcmclient.py
@@ -96,8 +96,8 @@ class FCMv1TestCase(unittest.TestCase):
     def test_fail_500(self):
         self._m_response.code = 500
         content = "OMG"
-        self._m_response.headers.addRawHeader('Retry-After', 123)
+        self._m_response.headers.addRawHeader('Retry-After', "123")
         self._m_resp_text.callback(content)
         self._m_request.callback(self._m_response)
         result = yield self.fcm.send("token", self.m_payload)
-        assert result.retry_after == 123
+        assert result.retry_after == "123"

--- a/autopush/tests/test_gcmclient.py
+++ b/autopush/tests/test_gcmclient.py
@@ -193,9 +193,9 @@ class GCMClientTestCase(unittest.TestCase):
     def test_fail_500(self):
         self._m_response.code = 500
         content = "OMG"
-        self._m_response.headers.addRawHeader('Retry-After', 123)
+        self._m_response.headers.addRawHeader('Retry-After', "123")
         self._m_resp_text.callback(content)
         self._m_request.callback(self._m_response)
         result = yield self.gcm.send(self.m_payload)
         assert 'some_reg_id' in result.retry_message.registration_ids
-        assert result.retry_after == 123
+        assert result.retry_after == "123"

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,12 +67,15 @@ rsa==4.0                  # via google-auth, oauth2client, python-jose
 s3transfer==0.1.13        # via boto3
 service-identity==18.1.0
 simplejson==3.16.0
-six==1.12.0               # via autobahn, automat, cryptography, firebase-admin, google-api-core, google-auth, google-resumable-media, grpcio, marshmallow-polyfield, oauth2client, protobuf, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
+six==1.12.0               # via autobahn, automat, cryptography, firebase-admin, google-api-core, google-auth, google-resumable-media, grpcio, oauth2client, protobuf, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
 treq==18.6.0
-twisted[tls]==18.9.0
+twisted[tls]==19.2.1
 txaio==18.8.1             # via autobahn
 typing==3.6.6
 ua-parser==0.8.0
 urllib3==1.24.2           # via botocore, requests
 wsaccel==0.6.2 ; platform_python_implementation == "CPython"
 zope.interface==4.6.0
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via google-api-core, protobuf, pyhamcrest, zope.interface


### PR DESCRIPTION
and adapt tests to it

Closes #1336