### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ cache:
   directories:
     - $HOME/.cache/pip
 sudo: required
-dist: xenial
+dist: bionic
 
 matrix:
   include:
     - python: 2.7
       env: TOXENV=py27 DDB=true CODECOV=true
-    - python: pypy2.7-7.1.1
+    - python: pypy2.7-7.2.0
       env: TOXENV=pypy DDB=true CODECOV=true
     - python: 2.7
       env: TOXENV=flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:2-7.1.1
+FROM pypy:2-7.3.0
 
 RUN mkdir -p /app
 ADD . /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,85 +1,77 @@
 -e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 apns==2.0.1
-asn1crypto==0.24.0        # via cryptography
-attrs==19.1.0
-autobahn[twisted]==19.7.2
-automat==0.7.0            # via twisted
-boto3==1.9.197
-botocore==1.12.197        # via boto3, s3transfer
-cachecontrol==0.12.5      # via firebase-admin
+attrs==19.3.0
+autobahn[twisted]==19.11.2
+automat==0.8.0            # via twisted
+boto3==1.11.11
+botocore==1.14.11         # via boto3, s3transfer
+cachecontrol==0.12.6      # via firebase-admin
 cachetools==3.1.1         # via google-auth
-certifi==2019.6.16        # via requests
-cffi==1.12.3
+certifi==2019.11.28       # via requests
+cffi==1.13.2
 chardet==3.0.4            # via requests
 click==7.0
-configargparse==0.14.0
+configargparse==1.0
 constantly==15.1.0        # via twisted
-contextlib2==0.5.5        # via raven
-cryptography==2.7
+contextlib2==0.6.0.post1  # via raven
+cryptography==2.8
 cyclone==1.2
-datadog==0.29.3
-decorator==4.4.0          # via datadog
-docutils==0.14            # via botocore
-ecdsa==0.13.3             # via python-jose
-enum34==1.1.6             # via cryptography, grpcio, h2
-firebase-admin==2.17.0
-future==0.17.1            # via python-jose
-futures==3.3.0            # via google-api-core, grpcio, s3transfer
+datadog==0.34.0
+decorator==4.4.1          # via datadog
+docutils==0.15.2          # via botocore
+ecdsa==0.15               # via python-jose
+enum34==1.1.6             # via cryptography, h2
+firebase-admin==3.2.1
+futures==3.3.0            # via google-api-core, s3transfer
 gcm-client==0.1.4
-google-api-core[grpc]==1.14.0  # via firebase-admin, google-cloud-core, google-cloud-firestore
-google-api-python-client==1.7.10  # via firebase-admin
+google-api-core==1.16.0   # via google-cloud-core
+google-api-python-client==1.7.11  # via firebase-admin
 google-auth-httplib2==0.0.3  # via google-api-python-client
-google-auth==1.6.3        # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-storage
-google-cloud-core==1.0.2  # via google-cloud-firestore, google-cloud-storage
-google-cloud-firestore==1.3.0  # via firebase-admin
-google-cloud-storage==1.17.0  # via firebase-admin
-google-resumable-media==0.3.2  # via google-cloud-storage
-googleapis-common-protos==1.6.0  # via google-api-core
-graphviz==0.11.1          # via objgraph
-grpcio==1.22.0            # via google-api-core
+google-auth==1.11.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-storage
+google-cloud-core==1.3.0  # via google-cloud-storage
+google-cloud-storage==1.25.0  # via firebase-admin
+google-resumable-media==0.5.0  # via google-cloud-storage
+googleapis-common-protos==1.51.0  # via google-api-core
+graphviz==0.13.2          # via objgraph
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
-httplib2==0.13.0          # via google-api-python-client, google-auth-httplib2, oauth2client
+httplib2==0.17.0          # via google-api-python-client, google-auth-httplib2, oauth2client
 hyper==0.7.0
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests, twisted
 incremental==17.5.0       # via treq, twisted
-ipaddress==1.0.22         # via cryptography, service-identity
+ipaddress==1.0.23         # via cryptography, service-identity
 jmespath==0.9.4           # via boto3, botocore
 marshmallow-polyfield==4.2
 marshmallow==2.19.5
-msgpack==0.6.1            # via cachecontrol
+msgpack==0.6.2            # via cachecontrol
 oauth2client==4.1.3
 objgraph==3.4.1
-protobuf==3.9.0           # via google-api-core, googleapis-common-protos
-pyasn1-modules==0.2.5     # via google-auth, oauth2client, service-identity
-pyasn1==0.4.5
-pycparser==2.19           # via cffi
+protobuf==3.11.3          # via google-api-core, googleapis-common-protos
+pyasn1-modules==0.2.8     # via google-auth, oauth2client, service-identity
+pyasn1==0.4.8
 pyfcm==1.4.7
-pyhamcrest==1.9.0         # via twisted
+pyhamcrest==1.10.1        # via twisted
 pyopenssl==19.0.0
-python-dateutil==2.8.0    # via botocore
-python-jose==3.0.1
-pytz==2019.1              # via google-api-core, google-cloud-firestore
+python-dateutil==2.8.1    # via botocore
+python-jose==3.1.0
+pytz==2019.3              # via google-api-core
 raven==6.10.0
 requests==2.22.0
 rsa==4.0                  # via google-auth, oauth2client, python-jose
-s3transfer==0.2.1         # via boto3
+s3transfer==0.3.2         # via boto3
 service-identity==18.1.0
-simplejson==3.16.0
-six==1.12.0               # via autobahn, automat, cryptography, firebase-admin, google-api-core, google-api-python-client, google-auth, google-resumable-media, grpcio, marshmallow-polyfield, oauth2client, protobuf, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
+simplejson==3.17.0
+six==1.14.0               # via autobahn, automat, cryptography, ecdsa, firebase-admin, google-api-core, google-api-python-client, google-auth, google-resumable-media, marshmallow-polyfield, oauth2client, protobuf, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
 treq==18.6.0
-twisted[tls]==19.7.0
+twisted[tls]==19.2.1
 txaio==18.8.1             # via autobahn
-typing==3.7.4
-ua-parser==0.8.0
-uritemplate==3.0.0        # via google-api-python-client
-urllib3==1.25.3           # via botocore, requests
-wsaccel==0.6.2 ; platform_python_implementation == "CPython"
-zope.interface==4.6.0
+typing==3.7.4.1
+ua-parser==0.9.0
+uritemplate==3.0.1        # via google-api-python-client
+urllib3==1.25.8           # via botocore, requests
+zope.interface==4.7.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via google-api-core, protobuf, pyhamcrest, zope.interface
-
-# use pipdeptree for list of dependant packages
+# setuptools==44.0.0        # via google-api-core, google-auth, protobuf, zope.interface


### PR DESCRIPTION
avoiding latest marshmallow/marshmallow-polyfields (which are now py3
only)

includes bump to pypy

Closes #1358