### PR TITLE
chore: Library update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ service-identity==18.1.0
 simplejson==3.17.0
 six==1.14.0               # via autobahn, automat, cryptography, ecdsa, firebase-admin, google-api-core, google-api-python-client, google-auth, google-resumable-media, grpcio, marshmallow-polyfield, oauth2client, protobuf, pyhamcrest, pyopenssl, python-dateutil, python-jose, treq, txaio
 treq==18.6.0
-twisted[tls]==19.10.0
+twisted[tls]==20.3.0
 txaio==18.8.1             # via autobahn
 typing==3.7.4.1
 ua-parser==0.9.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,8 @@ mock>=1.0.1
 -e git+https://github.com/bbangert/moto.git@3bdb75a961148ea5aa526f0e88d9e7835a30df3a#egg=moto
 nose
 pbr==1.10.0
-psutil
+# locked for python2 eol
+psutil==5.6.7
 pympler==0.5
 pytest>=3.6
 pytest-cov


### PR DESCRIPTION
## Description
Due to later versions of pyutil no longer supporting 2.7, I've locked to the last working version.

Depending on how pyup does it's detection, we may need to segregate these sorts of version lockdowns to their own, ignored `requirements.txt` file until we can replace this with a rust version.

## Testing 

Library update. Tests should return nominally

## Issue(s)

N/A - Scheduled update.