### PR TITLE
chore: include CIRCLE_TAG in the cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: docker save app:buildcpy
           command: docker save -o /cache/dockercpy.tar "app:buildcpy"
       - save_cache:
-          key: v1-{{ .Branch }}-{{epoch}}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-{{ epoch }}
           paths:
             - /cache/dockerpypy.tar
             - /cache/dockercpy.tar
@@ -56,7 +56,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
       - run:
           name: Restore PyPy Docker image cache
           command: docker load -i /cache/dockerpypy.tar


### PR DESCRIPTION
## Description

to avoid deploy steps potentially picking up a previous merge build
that wrote to the cache out of order

Describe these changes.

## Testing

We don't get this random error that breaks deployment:

```
Failed to clean image:  <...>/pipelines/autopush:1.55.0-282 Command '('docker', 'rmi', '<...>/pipelines/autopush:1.55.0-282')' returned non-zero exit status 1.
Traceback (most recent call last):
  File "./bin/pull-verify-push", line 188, in <module>
    main(sys.argv)
  File "./bin/pull-verify-push", line 160, in main
    verify_digest_circleci(src_build_url, src_digest)
  File "./bin/pull-verify-push", line 130, in verify_digest_circleci
    raise Exception("Digest: {} not found in {}".format(digest, build_url))
Exception: Digest: sha256:4970b3ab3f7f830d4eb715114594eca312f0f732403b328dd246da0b84dd960a not found in https://circleci.com/gh/mozilla-services/autopush/2423
```
