### PR TITLE
bug: Update libjemalloc1 to libjemalloc2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/root/.cargo/bin
 
 RUN \
     apt-get update && \
-    apt-get install -y -qq libexpat1-dev gcc libssl-dev libffi-dev libjemalloc1 && \
+    apt-get install -y -qq libexpat1-dev gcc libssl-dev libffi-dev libjemalloc2 && \
     make clean && \
     pip install -r requirements.txt && \
     pypy setup.py develop


### PR DESCRIPTION
## Description

`docker-compose up` failing because libjemalloc1 was removed from debian

## Testing

run `docker-compose up` and verify that the following containers are executed:
`dynamodb_1`
`autopush_1`
`autoendpoint_1`

## Issue(s)

Closes #1379