### PR TITLE
bug: do not require `encryption` header for APNs `aes128gcm` encoded messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/root/.cargo/bin
 
 RUN \
     apt-get update && \
-    apt-get install -y -qq libexpat1-dev gcc libssl-dev libffi-dev libjemalloc1 && \
+    apt-get install -y -qq libexpat1-dev gcc libssl-dev libffi-dev libjemalloc2 && \
     make clean && \
     pip install -r requirements.txt && \
     pypy setup.py develop

--- a/autopush/base.py
+++ b/autopush/base.py
@@ -66,10 +66,12 @@ class BaseHandler(cyclone.web.RequestHandler):
                     client_info=self._client_info)
             else:
                 self.log.failure("Error in handler: %s" % code,
-                                    client_info=self._client_info)
+                                 client_info=self._client_info)
             self.finish()
         except Exception as ex:
-            self.log.failure("error in write_error: {} while printing {}".format(ex, kwargs))
+            self.log.failure(
+                "error in write_error: {} while printing {}".format(
+                    ex, kwargs))
 
     def authenticate_peer_cert(self):
         """Authenticate the client per the configured client_certs.

--- a/autopush/base.py
+++ b/autopush/base.py
@@ -57,16 +57,19 @@ class BaseHandler(cyclone.web.RequestHandler):
         websocket.
 
         """
-        self.set_status(code)
-        if 'exc_info' in kwargs:
-            self.log.failure(
-                format=kwargs.get('format', "Exception"),
-                failure=failure.Failure(*kwargs['exc_info']),
-                client_info=self._client_info)
-        else:
-            self.log.failure("Error in handler: %s" % code,
-                             client_info=self._client_info)
-        self.finish()
+        try:
+            self.set_status(code)
+            if 'exc_info' in kwargs:
+                self.log.failure(
+                    format=kwargs.get('format', "Exception"),
+                    failure=failure.Failure(*kwargs['exc_info']),
+                    client_info=self._client_info)
+            else:
+                self.log.failure("Error in handler: %s" % code,
+                                    client_info=self._client_info)
+            self.finish()
+        except Exception as ex:
+            self.log.failure("error in write_error: {} while printing {}".format(ex, kwargs))
 
     def authenticate_peer_cert(self):
         """Authenticate the client per the configured client_certs.

--- a/autopush/base.py
+++ b/autopush/base.py
@@ -70,8 +70,8 @@ class BaseHandler(cyclone.web.RequestHandler):
             self.finish()
         except Exception as ex:
             self.log.failure(
-                "error in write_error: {} while printing {}".format(
-                    ex, kwargs))
+                "error in write_error: {}:{} while printing {};{}".format(
+                    code, ex, kwargs, self._client_info))
 
     def authenticate_peer_cert(self):
         """Authenticate the client per the configured client_certs.

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -137,9 +137,10 @@ class APNSRouter(object):
                 raise RouterException(
                     "Payload error",
                     status_code=400,
-                    response_body="APNS missing required fields. {}".format(ex),
+                    response_body="APNS missing required fields. {}".format(
+                        ex),
                     log_exception=False
-            )
+                )
             if "crypto_key" in notification.headers:
                 payload["cryptokey"] = notification.headers["crypto_key"]
             elif "encryption_key" in notification.headers:

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -129,18 +129,10 @@ class APNSRouter(object):
         }
         if notification.data:
             payload["body"] = notification.data
-            try:
-                payload["con"] = notification.headers["encoding"]
-                if payload["con"] != "aes128gcm":
-                    payload["enc"] = notification.headers["encryption"]
-            except KeyError as ex:
-                raise RouterException(
-                    "Payload error",
-                    status_code=400,
-                    response_body="APNS missing required fields. {}".format(
-                        ex),
-                    log_exception=False
-                )
+            payload["con"] = notification.headers["encoding"]
+
+            if "encryption" in notification.headers:
+                payload["enc"] = notification.headers["encryption"]
             if "crypto_key" in notification.headers:
                 payload["cryptokey"] = notification.headers["crypto_key"]
             elif "encryption_key" in notification.headers:

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -129,9 +129,17 @@ class APNSRouter(object):
         }
         if notification.data:
             payload["body"] = notification.data
-            payload["con"] = notification.headers["encoding"]
-            payload["enc"] = notification.headers["encryption"]
-
+            try:
+                payload["con"] = notification.headers["encoding"]
+                if payload["con"] != "aes128gcm":
+                    payload["enc"] = notification.headers["encryption"]
+            except KeyError as ex:
+                raise RouterException(
+                    "Payload error",
+                    status_code=400,
+                    response_body="APNS missing required fields. {}".format(ex),
+                    log_exception=False
+            )
             if "crypto_key" in notification.headers:
                 payload["cryptokey"] = notification.headers["crypto_key"]
             elif "encryption_key" in notification.headers:

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -2384,7 +2384,6 @@ class TestAPNSBridgeIntegration(IntegrationBase):
                 "\xe1\xd9\xf6\x46\x26\xce\x69")
         crypto_key = ("keyid=p256dh;dh=BAFJxCIaaWyb4JSkZopERL9MjXBeh3WdBxew"
                       "SYP0cZWNMJaT7YNaJUiSqBuGUxfRj-9vpTPz5ANmUYq3-u-HWOI")
-        salt = "keyid=p256dh;salt=S82AseB7pAVBJ2143qtM3A"
         content_encoding = "aesgcm"
 
         response, body = yield _agent(
@@ -2439,7 +2438,6 @@ class TestAPNSBridgeIntegration(IntegrationBase):
         assert ca_data['con'] == content_encoding
         assert ca_data['body'] == base64url_encode(data)
         assert 'enc' not in ca_data
-
 
     @inlineCallbacks
     def test_registration_no_token(self):


### PR DESCRIPTION
## Description

Includes better logging for uncaught APNs errors, since those were
getting dropped by cyclone.

## Testing

Tests included in integration suite.

## Issue(s)

Addresses Issue #1383
Closes #1384
