### PR TITLE
Bug/1388

### DIFF
--- a/autopush/base.py
+++ b/autopush/base.py
@@ -66,7 +66,7 @@ class BaseHandler(cyclone.web.RequestHandler):
                     client_info=self._client_info)
             else:
                 self.log.error("Error in handler: %s" % code,
-                                 client_info=self._client_info)
+                               client_info=self._client_info)
             self.finish()
         except Exception as ex:
             self.log.failure(

--- a/autopush/base.py
+++ b/autopush/base.py
@@ -65,7 +65,7 @@ class BaseHandler(cyclone.web.RequestHandler):
                     failure=failure.Failure(*kwargs['exc_info']),
                     client_info=self._client_info)
             else:
-                self.log.failure("Error in handler: %s" % code,
+                self.log.error("Error in handler: %s" % code,
                                  client_info=self._client_info)
             self.finish()
         except Exception as ex:

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -147,10 +147,13 @@ class TestBase(unittest.TestCase):
         with an invalid method (e.g. "put" instead of "PUT").
         This is not code that is triggered within normal flow, but
         by the cyclone wrapper.
+
+        NOTE: calling `failure` without an exception triggers an
+        exception. write_error should call `error`. 
         """
         self.base.write_error(999)
         self.status_mock.assert_called_with(999)
-        assert self.base.log.failure.called is True
+        assert self.base.log.error.called is True
 
     @patch('uuid.uuid4', return_value=uuid.UUID(dummy_request_id))
     def test_init_info(self, t):

--- a/autopush/tests/test_web_base.py
+++ b/autopush/tests/test_web_base.py
@@ -149,7 +149,7 @@ class TestBase(unittest.TestCase):
         by the cyclone wrapper.
 
         NOTE: calling `failure` without an exception triggers an
-        exception. write_error should call `error`. 
+        exception. write_error should call `error`.
         """
         self.base.write_error(999)
         self.status_mock.assert_called_with(999)


### PR DESCRIPTION
Closes #1388

A change in `failure` will raise an exception if called without a current Exception in the stack. This leads to undesired results. Changed `base.py:write_error()` to call `self.log.error` if no exception is present, but logging is required.

## Testing

Unit tests altered to include a check.

## Issue(s)

Closes #1388