### PR TITLE
docs: Fix CryptoKey.get_label example

### DIFF
--- a/autopush/crypto_key.py
+++ b/autopush/crypto_key.py
@@ -69,7 +69,7 @@ http://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00#section-4
         Crypto-Key: keyid="apple";foo="fruit",keyid="gorp";bar="snake"
 
         get_label("foo")
-        would return a value of "apple"
+        would return a value of "fruit"
 
         ..note:: This presumes that "label" is unique. Otherwise it will
         only return the FIRST instance of "label". Use get_keyid() if


### PR DESCRIPTION
## Description

The `CryptoKey.get_label` method has an example which was inaccurate.

## Testing

N/A

## Issue(s)

N/A
