### PR TITLE
chore: Upgrade pytest to 4.6 to fix pytest-cov dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,6 +10,6 @@ pbr==1.10.0
 # locked for python2 eol
 psutil==5.6.7
 pympler==0.5
-pytest>=3.6
+pytest==4.6
 pytest-cov
 websocket-client


### PR DESCRIPTION
## Description

The latest pytest-cov (2.10.0) requires pytest >= 4.6. 4.6 is the last version to support Python 2.7. The CI was using pytest 4.3 instead, which caused issues on https://github.com/mozilla-services/autopush-rs:
https://travis-ci.org/github/mozilla-services/autopush-rs/builds/697653480

pytest-cov changelog:
https://github.com/pytest-dev/pytest-cov/blob/4cbd3bb5ef8a501aeafbca21d22622210fe604a6/CHANGELOG.rst#2100-2020-06-12

## Testing

N/A

## Issue(s)

N/A
