### PR TITLE
feat: Add tags back to metrics.

### DIFF
--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -7,7 +7,7 @@ from typing import (  # noqa
 )
 
 from twisted.internet import reactor
-from txstatsd.metrics.metrics import Metrics
+from txstatsd.metrics.metrics import Metrics  # noqa
 
 import mock
 import datadog

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -10,6 +10,7 @@ from twisted.internet import reactor
 from txstatsd.client import StatsDClientProtocol, TwistedStatsDClient
 from txstatsd.metrics.metrics import Metrics
 
+import mock
 import datadog
 from datadog import ThreadStats
 
@@ -59,26 +60,6 @@ class SinkMetrics(IMetrics):
         pass
 
 
-class TwistedMetrics(object):
-    """Twisted implementation of statsd output"""
-    def __init__(self, statsd_host="localhost", statsd_port=8125):
-        self.client = TwistedStatsDClient.create(statsd_host, statsd_port)
-        self._metric = Metrics(connection=self.client, namespace="autopush")
-
-    def start(self):
-        protocol = StatsDClientProtocol(self.client)
-        reactor.listenUDP(0, protocol)
-
-    def increment(self, name, count=1, **kwargs):
-        self._metric.increment(name, count)
-
-    def gauge(self, name, count, **kwargs):
-        self._metric.gauge(name, count)
-
-    def timing(self, name, duration, **kwargs):
-        self._metric.timing(name, duration)
-
-
 def make_tags(base=None, **kwargs):
     # type: (Sequence[str], **Any) -> Sequence[str]
     """Generate a list of tag values"""
@@ -89,11 +70,17 @@ def make_tags(base=None, **kwargs):
 
 class DatadogMetrics(object):
     """DataDog Metric backend"""
-    def __init__(self, api_key, app_key, hostname, flush_interval=10,
-                 namespace="autopush"):
+    def __init__(self, api_key=None, app_key=None,
+                 hostname=None, statsd_host=None, statsd_port=None,
+                 flush_interval=10, namespace="autopush"):
 
-        datadog.initialize(api_key=api_key, app_key=app_key,
-                           host_name=hostname)
+        datadog.initialize(
+            api_key=api_key,
+            app_key=app_key,
+            host_name=hostname,
+            statsd_host=statsd_host,
+            statsd_port=statsd_port,
+        )
         self._client = ThreadStats()
         self._flush_interval = flush_interval
         self._host = hostname
@@ -122,16 +109,16 @@ class DatadogMetrics(object):
 def from_config(conf):
     # type: (AutopushConfig) -> IMetrics
     """Create an IMetrics from the given config"""
-    if conf.datadog_api_key:
+    if conf.statsd_host and not isinstance(conf.statsd_host, mock.Mock):
         return DatadogMetrics(
             hostname=logging.instance_id_or_hostname if conf.ami_id else
             conf.hostname,
             api_key=conf.datadog_api_key,
             app_key=conf.datadog_app_key,
+            statsd_host=conf.statsd_host,
+            statsd_port=conf.statsd_port,
             flush_interval=conf.datadog_flush_interval,
         )
-    elif conf.statsd_host:
-        return TwistedMetrics(conf.statsd_host, conf.statsd_port)
     else:
         return SinkMetrics()
 

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -9,7 +9,6 @@ from typing import (  # noqa
 from twisted.internet import reactor
 from txstatsd.metrics.metrics import Metrics  # noqa
 
-import mock
 import datadog
 from datadog import ThreadStats
 
@@ -108,7 +107,7 @@ class DatadogMetrics(object):
 def from_config(conf):
     # type: (AutopushConfig) -> IMetrics
     """Create an IMetrics from the given config"""
-    if conf.statsd_host and not isinstance(conf.statsd_host, mock.Mock):
+    if conf.statsd_host:
         return DatadogMetrics(
             hostname=logging.instance_id_or_hostname if conf.ami_id else
             conf.hostname,

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -7,7 +7,6 @@ from typing import (  # noqa
 )
 
 from twisted.internet import reactor
-from txstatsd.client import StatsDClientProtocol, TwistedStatsDClient
 from txstatsd.metrics.metrics import Metrics
 
 import mock

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -7,7 +7,6 @@ from typing import (  # noqa
 )
 
 from twisted.internet import reactor
-from txstatsd.metrics.metrics import Metrics  # noqa
 
 import datadog
 from datadog import ThreadStats

--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -155,7 +155,7 @@ class WebPushRouter(object):
     def delivered_response(self, notification):
         self.metrics.increment("notification.message_data",
                                notification.data_length,
-                               tags=make_tags(destination='Stored'))
+                               tags=make_tags(destination='Direct'))
         location = "%s/m/%s" % (self.conf.endpoint_url, notification.location)
         return RouterResponse(status_code=201, response_body="",
                               headers={"Location": location,
@@ -165,7 +165,7 @@ class WebPushRouter(object):
     def stored_response(self, notification):
         self.metrics.increment("notification.message_data",
                                notification.data_length,
-                               tags=make_tags(destination='Direct'))
+                               tags=make_tags(destination='Stored'))
         location = "%s/m/%s" % (self.conf.endpoint_url, notification.location)
         return RouterResponse(status_code=201, response_body="",
                               headers={"Location": location,

--- a/autopush/tests/test_db.py
+++ b/autopush/tests/test_db.py
@@ -75,6 +75,17 @@ class DbUtilsTest(unittest.TestCase):
 
 
 class DatabaseManagerTest(unittest.TestCase):
+    def fake_conf(self, table_name=""):
+        fake_conf = Mock()
+        fake_conf.statsd_host = "localhost"
+        fake_conf.statsd_port = 8125
+        fake_conf.allow_table_rotation = False
+        fake_conf.message_table = Mock()
+        fake_conf.message_table.tablename = table_name
+        fake_conf.message_table.read_throughput = 5
+        fake_conf.message_table.write_throughput = 5
+        return fake_conf
+
     def test_init_with_resources(self):
         from autopush.db import DynamoDBResource
         dm = DatabaseManager(router_conf=Mock(),
@@ -85,12 +96,7 @@ class DatabaseManagerTest(unittest.TestCase):
         assert isinstance(dm.resource, DynamoDBResource)
 
     def test_init_with_no_rotate(self):
-        fake_conf = Mock()
-        fake_conf.allow_table_rotation = False
-        fake_conf.message_table = Mock()
-        fake_conf.message_table.tablename = "message_int_test"
-        fake_conf.message_table.read_throughput = 5
-        fake_conf.message_table.write_throughput = 5
+        fake_conf = self.fake_conf("message_int_test")
         dm = DatabaseManager.from_config(
             fake_conf,
             resource=autopush.tests.boto_resource)
@@ -101,12 +107,7 @@ class DatabaseManagerTest(unittest.TestCase):
             )
 
     def test_init_with_no_rotate_create_table(self):
-        fake_conf = Mock()
-        fake_conf.allow_table_rotation = False
-        fake_conf.message_table = Mock()
-        fake_conf.message_table.tablename = "message_bogus"
-        fake_conf.message_table.read_throughput = 5
-        fake_conf.message_table.write_throughput = 5
+        fake_conf = self.fake_conf("message_bogus")
         dm = DatabaseManager.from_config(
             fake_conf,
             resource=autopush.tests.boto_resource)

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -1,7 +1,5 @@
 import unittest
 
-import twisted.internet.base
-
 import pytest
 from mock import Mock, patch, call
 

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -8,7 +8,6 @@ from mock import Mock, patch, call
 from autopush.metrics import (
     IMetrics,
     DatadogMetrics,
-    TwistedMetrics,
     SinkMetrics,
     periodic_reporter,
 )
@@ -33,22 +32,6 @@ class SinkMetricsTestCase(unittest.TestCase):
         assert sm.increment("test") is None
         assert sm.gauge("test", 10) is None
         assert sm.timing("test", 10) is None
-
-
-class TwistedMetricsTestCase(unittest.TestCase):
-    @patch("autopush.metrics.reactor")
-    def test_basic(self, mock_reactor):
-        twisted.internet.base.DelayedCall.debug = True
-        m = TwistedMetrics('127.0.0.1')
-        m.start()
-        assert len(mock_reactor.mock_calls) > 0
-        m._metric = Mock()
-        m.increment("test", 5)
-        m._metric.increment.assert_called_with("test", 5)
-        m.gauge("connection_count", 200)
-        m._metric.gauge.assert_called_with("connection_count", 200)
-        m.timing("lifespan", 113)
-        m._metric.timing.assert_called_with("lifespan", 113)
 
 
 class DatadogMetricsTestCase(unittest.TestCase):

--- a/autopush/tests/test_z_main.py
+++ b/autopush/tests/test_z_main.py
@@ -221,7 +221,6 @@ class ConnectionMainTestCase(unittest.TestCase):
         patchers = [
             "autopush.main.TimerService.startService",
             "autopush.main.reactor",
-            "autopush.metrics.TwistedMetrics",
         ]
         self.mocks = {}
         for name in patchers:
@@ -274,7 +273,7 @@ class EndpointMainTestCase(unittest.TestCase):
         datadog_flush_interval = "datadog_flush_interval"
         hostname = "hostname"
         statsd_host = "statsd_host"
-        statsd_port = "statsd_port"
+        statsd_port = 8125
         router_tablename = "none"
         router_read_throughput = 0
         router_write_throughput = 0
@@ -323,7 +322,6 @@ class EndpointMainTestCase(unittest.TestCase):
             "autopush.db.preflight_check",
             "autopush.main.TimerService.startService",
             "autopush.main.reactor",
-            "autopush.metrics.TwistedMetrics",
         ]
         self.mocks = {}
         for name in patchers:

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -26,7 +26,7 @@ from jose import JOSEError, JWTError
 
 from autopush.crypto_key import CryptoKey
 from autopush.db import DatabaseManager  # noqa
-from autopush.metrics import Metrics, make_tags  # noqa
+from autopush.metrics import IMetrics, make_tags  # noqa
 from autopush.db import hasher
 from autopush.exceptions import (
     InvalidRequest,

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -135,7 +135,7 @@ class WebPushSubscriptionSchema(Schema):
     def _validate_webpush(self, d, result):
         db = self.context["db"]  # type: DatabaseManager
         log = self.context["log"]  # type: Logger
-        metrics = self.context["metrics"]  # type: Metrics
+        metrics = self.context["metrics"]  # type: IMetrics
         channel_id = normalize_id(d["chid"])
         uaid = result["uaid"]
         if 'current_month' not in result:

--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -21,11 +21,6 @@ Implementations
     :special-members: __init__
     :member-order: bysource
 
-.. autoclass:: TwistedMetrics
-    :members:
-    :special-members: __init__
-    :member-order: bysource
-
 .. autoclass:: DatadogMetrics
     :members:
     :special-members: __init__

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ graphviz==0.13.2          # via objgraph
 grpcio==1.27.2            # via google-api-core
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
-httplib2==0.17.0          # via google-api-python-client, google-auth-httplib2, oauth2client
+httplib2==0.18.0          # via google-api-python-client, google-auth-httplib2, oauth2client
 hyper==0.7.0
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==19.0.0         # via twisted


### PR DESCRIPTION
## Description

While this package does not use the officially sanctioned "markus"
metrics package, it does use the same Datadog library.

*Reviewer Note*: this replaces #1401, which does a lot more (replaces metrics libraries with `markus`, changes base tag handling, etc.) This PR carries less risk for a service that's being rewritten anyway.

## Testing

Unit tests included.

## Issue(s)

Closes #1400

