### PR TITLE
feat: fixup metrics + tags

### DIFF
--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -49,7 +49,7 @@ from autopush.exceptions import ItemNotFound
 from autopush.logging import begin_or_register
 from autopush.main import ConnectionApplication, EndpointApplication
 from autopush.utils import base64url_encode, normalize_id
-from autopush.metrics import SinkMetrics, DatadogMetrics
+from autopush.metrics import SinkMetrics, TaggedMetrics
 import autopush.tests
 from autopush.tests.support import _TestingLogObserver
 from autopush.websocket import PushServerFactory
@@ -538,7 +538,7 @@ class Test_Data(IntegrationBase):
         db.Message.all_channels = safe
         yield self.shut_down(client)
 
-    @patch("autopush.metrics.datadog")
+    @patch("autopush.metrics.markus")
     @inlineCallbacks
     def test_webpush_data_delivery_to_disconnected_client(self, m_ddog):
         tests = {
@@ -553,8 +553,8 @@ class Test_Data(IntegrationBase):
                 data=b"\xc3\x28\xa0\xa1\xe2\x28\xa1", result="wyigoeIooQ"),
         }
         # Piggy back a check for stored source metrics
-        self.conn.db.metrics = DatadogMetrics(
-            "someapikey", "someappkey", namespace="testpush",
+        self.conn.db.metrics = TaggedMetrics(
+            namespace="testpush",
             hostname="localhost")
         self.conn.db.metrics._client = Mock()
 
@@ -584,8 +584,8 @@ class Test_Data(IntegrationBase):
             yield client.ack(chan, result["version"])
 
         assert self.logs.logged_ci(lambda ci: 'message_size' in ci)
-        inc_call = self.conn.db.metrics._client.increment.call_args_list[5]
-        assert inc_call[1]['tags'] == ['source:Stored']
+        inc_call = self.conn.db.metrics._client.incr.call_args_list[5]
+        assert inc_call[1]['tags'] == ['source:Stored', 'host:localhost']
         yield self.shut_down(client)
 
     @inlineCallbacks

--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -21,7 +21,7 @@ Implementations
     :special-members: __init__
     :member-order: bysource
 
-.. autoclass:: DatadogMetrics
+.. autoclass:: TaggedMetrics
     :members:
     :special-members: __init__
     :member-order: bysource

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ apns
 attrs
 autobahn[twisted]
 boto3
-cffi
+cffi ; platform_python_implementation == "CPython"
 click
 configargparse
 cryptography
@@ -13,6 +13,7 @@ firebase-admin
 hyper
 marshmallow
 marshmallow-polyfield
+markus
 oauth2client
 objgraph
 pyasn1
@@ -25,7 +26,6 @@ service-identity
 simplejson
 treq
 twisted
--e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 typing
 ua-parser
 wsaccel ; platform_python_implementation == "CPython"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 apns==2.0.1
 attrs==19.3.0
 autobahn[twisted]==19.11.2
@@ -8,15 +7,16 @@ botocore==1.14.11         # via boto3, s3transfer
 cachecontrol==0.12.6      # via firebase-admin
 cachetools==3.1.1         # via google-auth
 certifi==2019.11.28       # via requests
-cffi==1.13.2
+cffi==1.13.2 ; platform_python_implementation == "CPython"
 chardet==3.0.4            # via requests
 click==7.0
 configargparse==1.0
+configparser==4.0.2       # via datadog
 constantly==15.1.0        # via twisted
 contextlib2==0.6.0.post1  # via raven
 cryptography==2.8
 cyclone==1.2
-datadog==0.34.0
+datadog==0.37.1
 decorator==4.4.1          # via datadog
 docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose
@@ -45,6 +45,7 @@ idna==2.8                 # via hyperlink, requests, twisted
 incremental==17.5.0       # via treq, twisted
 ipaddress==1.0.23         # via cryptography, service-identity
 jmespath==0.9.4           # via boto3, botocore
+markus==2.2.0
 marshmallow-polyfield==4.2
 marshmallow==2.19.5
 msgpack==0.6.2            # via cachecontrol


### PR DESCRIPTION
## Description

remove datadog's ThreadStats (as it only speaks datadog's http protocol)
w/ markus backed by the plain statsd compatible Datadog backend

upgrade datadog to avoid its own telemetry metrics producing garbage
tags

Note:

This is simplified from #1401 and has a couple other fixes:

- markus is actually expecting the original datadog style tags arguments we currently use e.g. `['foo:bar', 'baz:quux']`, and the PR had a few straggler uses of the old style anyway, so kept what we have
- fixes passes them along via the `tags=` kwarg it expects
- doesn't pass the namespace option to Datadog (as markus inserts it for us)

## Testing

Running against a local statsd collector produces expected metrics + tags

## Issue(s)

Closes #1400
