### PR TITLE
bug: regression: wrap metric calls in thread handler

### DIFF
--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -6,7 +6,7 @@ from typing import (  # noqa
     Sequence
 )
 
-from twisted.internet import (reactor, threads)
+from twisted.internet import reactor
 
 import markus
 
@@ -92,7 +92,7 @@ class TaggedMetrics(IMetrics):
         return tags
 
     def increment(self, name, count=1, tags=None, **kwargs):
-        threads.deferToThread(
+        reactor.callInThread(
             self._client.incr,
             self._prefix_name(name),
             count,
@@ -100,7 +100,7 @@ class TaggedMetrics(IMetrics):
         )
 
     def gauge(self, name, count, tags=None, **kwargs):
-        threads.deferToThread(
+        reactor.callInThread(
             self._client.gauge,
             self._prefix_name(name),
             count,
@@ -108,7 +108,7 @@ class TaggedMetrics(IMetrics):
         )
 
     def timing(self, name, duration, tags=None, **kwargs):
-        threads.deferToThread(
+        reactor.callInThread(
             self._client.timing,
             self._prefix_name(name),
             value=duration,

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -93,20 +93,26 @@ class TaggedMetrics(IMetrics):
 
     def increment(self, name, count=1, tags=None, **kwargs):
         threads.deferToThread(
-            self._client.incr(self._prefix_name(name), count,
-                              tags=self._make_tags(tags))
+            self._client.incr,
+            self._prefix_name(name),
+            count,
+            tags=self._make_tags(tags)
         )
 
     def gauge(self, name, count, tags=None, **kwargs):
         threads.deferToThread(
-            self._client.gauge(self._prefix_name(name), count,
-                               tags=self._make_tags(tags))
+            self._client.gauge,
+            self._prefix_name(name),
+            count,
+            tags=self._make_tags(tags)
         )
 
     def timing(self, name, duration, tags=None, **kwargs):
         threads.deferToThread(
-            self._client.timing(self._prefix_name(name), value=duration,
-                                tags=self._make_tags(tags))
+            self._client.timing,
+            self._prefix_name(name),
+            value=duration,
+            tags=self._make_tags(tags)
         )
 
 

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -41,8 +41,8 @@ class TaggedMetricsTestCase(unittest.TestCase):
         m.start()
         yield m.increment("test", 5)
         # Namespace is now auto-prefixed by the underlying markus lib
-        m._client.increment.assert_called_with("test", 5,
-                                          tags=['host:localhost'])
+        m._client.increment.assert_called_with(
+            "test", 5, tags=['host:localhost'])
         m.gauge("connection_count", 200)
         m._client.gauge.assert_called_with("connection_count", 200,
                                            tags=['host:localhost'])

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -39,9 +39,9 @@ class TaggedMetricsTestCase(unittest.TestCase):
         assert len(mock_tag.mock_calls) > 0
         m._client = Mock()
         m.start()
-        m.increment("test", 5)
+        yield m.increment("test", 5)
         # Namespace is now auto-prefixed by the underlying markus lib
-        m._client.incr.assert_called_with("test", 5,
+        m._client.increment.assert_called_with("test", 5,
                                           tags=['host:localhost'])
         m.gauge("connection_count", 200)
         m._client.gauge.assert_called_with("connection_count", 200,

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -94,8 +94,9 @@ class WebPushSubscriptionSchema(Schema):
             self.context["log"].debug(format="Dropping User", code=102,
                                       uaid_hash=hasher(result["uaid"]),
                                       uaid_record=repr(result))
-            self.context["metrics"].increment("updates.drop_user",
-                                              tags=make_tags(errno=102))
+            self.context["metrics"].increment(
+                "updates.drop_user",
+                tags=make_tags(errno=102))
             self.context["db"].router.drop_user(result["uaid"])
             raise InvalidRequest("No such subscription", status_code=410,
                                  errno=106)
@@ -142,7 +143,9 @@ class WebPushSubscriptionSchema(Schema):
             log.debug(format="Dropping User", code=102,
                       uaid_hash=hasher(uaid),
                       uaid_record=repr(result))
-            metrics.increment("updates.drop_user", tags=make_tags(errno=102))
+            metrics.increment(
+                "updates.drop_user",
+                tags=make_tags(errno=102))
             db.router.drop_user(uaid)
             raise InvalidRequest("No such subscription", status_code=410,
                                  errno=106)
@@ -152,7 +155,9 @@ class WebPushSubscriptionSchema(Schema):
             log.debug(format="Dropping User", code=103,
                       uaid_hash=hasher(uaid),
                       uaid_record=repr(result))
-            metrics.increment("updates.drop_user", tags=make_tags(errno=103))
+            metrics.increment(
+                "updates.drop_user",
+                tags=make_tags(errno=103))
             db.router.drop_user(uaid)
             raise InvalidRequest("No such subscription", status_code=410,
                                  errno=106)

--- a/autopush/websocket.py
+++ b/autopush/websocket.py
@@ -91,7 +91,7 @@ from autopush.db import DatabaseManager, Message  # noqa
 from autopush.exceptions import MessageOverloadException, ItemNotFound
 from autopush.noseplugin import track_object
 from autopush.protocol import IgnoreBody
-from autopush.metrics import IMetrics  # noqa
+from autopush.metrics import IMetrics, make_tags  # noqa
 from autopush.ssl import AutopushSSLContextFactory  # noqa
 from autopush.utils import (
     parse_user_agent,
@@ -895,7 +895,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         self.ps._check_notifications = False
         self.ps._more_notifications = True
 
-        d = self.deferToThread(self.webpush_fetch)
+        d = self.deferToThread(self.webpush_fetch())
         d.addCallback(self.finish_notifications)
         d.addErrback(self.error_notification_overload)
         d.addErrback(self.trap_cancel)
@@ -1321,7 +1321,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
         mcode = code if code in NACK_CODES else 0
         self.metrics.increment(
             'ua.command.nack',
-            tags=self.metrics.make_tags(code=mcode))
+            tags=make_tags(code=mcode))
         self.ps.stats.nacks += 1
 
     def check_missed_notifications(self, results, resume=False):
@@ -1377,7 +1377,7 @@ class PushServerProtocol(WebSocketServerProtocol, policies.TimeoutMixin):
             self.metrics.increment("ua.notification.topic")
         self.metrics.increment(
             'ua.message_data', notif.data_length,
-            tags=self.metrics.make_tags(source=notif.source))
+            tags=make_tags(source=notif.source))
 
 
 class PushServerFactory(WebSocketServerFactory):


### PR DESCRIPTION
## Description
The metric calls were blocking. It was recommended that they be wrapped
by a discrete thread handler.

## Testing

How should reviewers test?

## Issue(s)

Issue: #1408
