### PR TITLE
bug: delete users if bridge connection reports they're gone

### DIFF
--- a/autopush/router/apns2.py
+++ b/autopush/router/apns2.py
@@ -151,7 +151,7 @@ class APNSClient(object):
                     raise RouterException(
                         "APNS Transmit Error {}:{}".format(response.status,
                                                            reason),
-                        status_code=502,
+                        status_code=response.status,
                         response_body="APNS could not process "
                                       "your message {}".format(reason),
                         log_exception=False

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -163,6 +163,21 @@ class APNSRouter(object):
                 reason = "http2_error"
             else:
                 reason = "unknown"
+            if isinstance(e, RouterException) and e.status_code in [404, 410]:
+                self.metrics.increment(
+                    "notification.bridge.connection.error",
+                    tags=make_tags(
+                        self._base_tags,
+                        application=rel_channel,
+                        reason="unregistered"
+                        ))
+                raise RouterException(
+                    str(e),
+                    status_code=e.status_code,
+                    errno=106,
+                    response_body="User is no longer registered",
+                    log_exception=False
+                )
             self.metrics.increment("notification.bridge.connection.error",
                                    tags=make_tags(self._base_tags,
                                                   application=rel_channel,

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -252,15 +252,17 @@ class APNSRouterTestCase(unittest.TestCase):
 
     @inlineCallbacks
     def test_bad_send(self):
-        self.mock_response.status = 400
-        self.mock_response.read.return_value = json.dumps({'reason': 'boo'})
+        self.mock_response.status = 410
+        self.mock_response.read.return_value = json.dumps(
+            {'reason': 'Unregistered'})
         with pytest.raises(RouterException) as ex:
-            yield self.router.route_notification(self.notif, self.router_data)
+            yield self.router.route_notification(
+                self.notif, self.router_data)
         assert isinstance(ex.value, RouterException)
-        assert ex.value.status_code == 502
-        assert str(ex.value) == 'APNS Transmit Error 400:boo'
+        assert ex.value.status_code == 410
+        assert str(ex.value) == 'APNS Transmit Error 410:Unregistered'
         assert ex.value.response_body == (
-            'APNS returned an error processing request')
+            'User is no longer registered')
 
     @inlineCallbacks
     def test_aaaa_fail_send(self):

--- a/autopush/web/webpush.py
+++ b/autopush/web/webpush.py
@@ -535,7 +535,8 @@ class WebPushHandler(BaseWebHandler):
                       vapid=jwt)
         d.addErrback(self._router_fail_err,
                      router_type=router_type,
-                     vapid=jwt is not None)
+                     vapid=jwt is not None,
+                     uaid=user_data.get("uaid"))
         d.addErrback(self._response_err)
         return d
 


### PR DESCRIPTION
Closes #1414

## Description

We were not deleting users if the bridge was reporting that the associated user token was unregistered or invalid. This may have lead to impolite behavior by autopush

## Testing

Tests included

## Issue(s)

Closes #1414, https://github.com/mozilla-services/autopush/issues/1383
