### PR TITLE
fix: switch back to TwistedMetrics (w/ our custom txstatsd)

### DIFF
--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -70,13 +70,13 @@ class TwistedMetrics(object):
         reactor.listenUDP(0, protocol)
 
     def increment(self, name, count=1, **kwargs):
-        self._metric.increment(name, count)
+        self._metric.increment(name, count, **kwargs)
 
     def gauge(self, name, count, **kwargs):
-        self._metric.gauge(name, count)
+        self._metric.gauge(name, count, **kwargs)
 
     def timing(self, name, duration, **kwargs):
-        self._metric.timing(name, duration)
+        self._metric.timing(name, duration, **kwargs)
 
 
 def make_tags(base=None, **kwargs):

--- a/autopush/metrics.py
+++ b/autopush/metrics.py
@@ -1,6 +1,4 @@
 """Metrics interface and implementations"""
-import time
-import threading
 from typing import (  # noqa
     TYPE_CHECKING,
     Any,
@@ -9,16 +7,16 @@ from typing import (  # noqa
 )
 
 from twisted.internet import reactor
-from twisted.logger import Logger
-import markus
+from txstatsd.client import StatsDClientProtocol, TwistedStatsDClient
+from txstatsd.metrics.metrics import Metrics
+
+import datadog
+from datadog import ThreadStats
 
 from autopush import logging
 
 if TYPE_CHECKING:  # pragma: nocover
     from autopush.config import AutopushConfig  # noqa
-
-
-log = Logger()
 
 
 class IMetrics(object):
@@ -61,6 +59,26 @@ class SinkMetrics(IMetrics):
         pass
 
 
+class TwistedMetrics(object):
+    """Twisted implementation of statsd output"""
+    def __init__(self, statsd_host="localhost", statsd_port=8125):
+        self.client = TwistedStatsDClient.create(statsd_host, statsd_port)
+        self._metric = Metrics(connection=self.client, namespace="autopush")
+
+    def start(self):
+        protocol = StatsDClientProtocol(self.client)
+        reactor.listenUDP(0, protocol)
+
+    def increment(self, name, count=1, **kwargs):
+        self._metric.increment(name, count)
+
+    def gauge(self, name, count, **kwargs):
+        self._metric.gauge(name, count)
+
+    def timing(self, name, duration, **kwargs):
+        self._metric.timing(name, duration)
+
+
 def make_tags(base=None, **kwargs):
     # type: (Sequence[str], **Any) -> Sequence[str]
     """Generate a list of tag values"""
@@ -69,96 +87,51 @@ def make_tags(base=None, **kwargs):
     return tags
 
 
-class TaggedMetrics(IMetrics):
-    """DataDog like tagged Metric backend"""
-    def __init__(self, hostname, statsd_host=None, statsd_port=None,
-                 namespace="autopush", flush_interval=10):
-        markus.configure(
-            backends=[{
-                'class': 'markus.backends.datadog.DatadogMetrics',
-                'options': {
-                    'statsd_host': statsd_host,
-                    'statsd_port': statsd_port,
-                }}])
-        self._client = markus.get_metrics(namespace)
+class DatadogMetrics(object):
+    """DataDog Metric backend"""
+    def __init__(self, api_key, app_key, hostname, flush_interval=10,
+                 namespace="autopush"):
+
+        datadog.initialize(api_key=api_key, app_key=app_key,
+                           host_name=hostname)
+        self._client = ThreadStats()
+        self._flush_interval = flush_interval
         self._host = hostname
         self._namespace = namespace
 
-        self._metrics = []
-        self._flush_interval = flush_interval
-        self._thread = None
-        self._lock = threading.RLock()
-
-        self.start()
-
     def _prefix_name(self, name):
-        return name
+        return "%s.%s" % (self._namespace, name)
 
     def start(self):
+        self._client.start(flush_interval=self._flush_interval,
+                           roll_up_interval=self._flush_interval)
 
-        def flush_thread():
-            while True:
-                try:
-                    self._flush()
-                except Exception:
-                    log.failure("Error flushing metrics")
-                time.sleep(self._flush_interval)
-        self._thread = thread = threading.Thread(target=flush_thread)
-        thread.daemon = True
-        thread.start()
+    def increment(self, name, count=1, **kwargs):
+        self._client.increment(self._prefix_name(name), count, host=self._host,
+                               **kwargs)
 
-    def _flush(self):
-        with self._lock:
-            metrics = self._metrics
-            self._metrics = []
-        for (fn, name, kwargs) in metrics:
-            fn(name, **kwargs)
+    def gauge(self, name, count, **kwargs):
+        self._client.gauge(self._prefix_name(name), count, host=self._host,
+                           **kwargs)
 
-    def _make_tags(self, tags):
-        if tags is None:
-            tags = []
-        tags.append('host:%s' % self._host)
-        return tags
-
-    def _queue_metric(self, fn, name, **kwargs):
-        with self._lock:
-            self._metrics.append((fn, name, kwargs))
-
-    def increment(self, name, count=1, tags=None, **kwargs):
-        self._queue_metric(
-            self._client.incr,
-            self._prefix_name(name),
-            value=count,
-            tags=self._make_tags(tags)
-        )
-
-    def gauge(self, name, count, tags=None, **kwargs):
-        self._queue_metric(
-            self._client.gauge,
-            self._prefix_name(name),
-            value=count,
-            tags=self._make_tags(tags)
-        )
-
-    def timing(self, name, duration, tags=None, **kwargs):
-        self._queue_metric(
-            self._client.timing,
-            self._prefix_name(name),
-            value=duration,
-            tags=self._make_tags(tags)
-        )
+    def timing(self, name, duration, **kwargs):
+        self._client.timing(self._prefix_name(name), value=duration,
+                            host=self._host, **kwargs)
 
 
 def from_config(conf):
     # type: (AutopushConfig) -> IMetrics
     """Create an IMetrics from the given config"""
-    if conf.statsd_host:
-        return TaggedMetrics(
+    if conf.datadog_api_key:
+        return DatadogMetrics(
             hostname=logging.instance_id_or_hostname if conf.ami_id else
             conf.hostname,
-            statsd_host=conf.statsd_host,
-            statsd_port=conf.statsd_port,
+            api_key=conf.datadog_api_key,
+            app_key=conf.datadog_app_key,
+            flush_interval=conf.datadog_flush_interval,
         )
+    elif conf.statsd_host:
+        return TwistedMetrics(conf.statsd_host, conf.statsd_port)
     else:
         return SinkMetrics()
 

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -49,7 +49,7 @@ from autopush.exceptions import ItemNotFound
 from autopush.logging import begin_or_register
 from autopush.main import ConnectionApplication, EndpointApplication
 from autopush.utils import base64url_encode, normalize_id
-from autopush.metrics import SinkMetrics, TaggedMetrics
+from autopush.metrics import SinkMetrics, TwistedMetrics
 import autopush.tests
 from autopush.tests.support import _TestingLogObserver
 from autopush.websocket import PushServerFactory
@@ -538,7 +538,7 @@ class Test_Data(IntegrationBase):
         db.Message.all_channels = safe
         yield self.shut_down(client)
 
-    @patch("autopush.metrics.markus")
+    @patch("autopush.metrics.Metrics")
     @inlineCallbacks
     def test_webpush_data_delivery_to_disconnected_client(self, m_ddog):
         tests = {
@@ -553,10 +553,7 @@ class Test_Data(IntegrationBase):
                 data=b"\xc3\x28\xa0\xa1\xe2\x28\xa1", result="wyigoeIooQ"),
         }
         # Piggy back a check for stored source metrics
-        self.conn.db.metrics = TaggedMetrics(
-            namespace="testpush",
-            hostname="localhost",
-            flush_interval=1)
+        self.conn.db.metrics = TwistedMetrics()
         self.conn.db.metrics._client = Mock()
 
         client = Client("ws://localhost:{}/".format(self.connection_port))
@@ -585,9 +582,8 @@ class Test_Data(IntegrationBase):
             yield client.ack(chan, result["version"])
 
         assert self.logs.logged_ci(lambda ci: 'message_size' in ci)
-        time.sleep(1.5)
-        inc_call = self.conn.db.metrics._client.incr.call_args_list[5]
-        assert inc_call[1]['tags'] == ['source:Stored', 'host:localhost']
+        inc_call = self.conn.db.metrics._metric.increment.call_args_list[5]
+        assert inc_call[1]['tags'] == ['source:Stored']
         yield self.shut_down(client)
 
     @inlineCallbacks

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -1,11 +1,13 @@
 import unittest
 
+import twisted.internet.base
 import pytest
 from mock import Mock, patch, call
 
 from autopush.metrics import (
     IMetrics,
-    TaggedMetrics,
+    DatadogMetrics,
+    TwistedMetrics,
     SinkMetrics,
     periodic_reporter,
 )
@@ -32,23 +34,43 @@ class SinkMetricsTestCase(unittest.TestCase):
         assert sm.timing("test", 10) is None
 
 
-class TaggedMetricsTestCase(unittest.TestCase):
-    @patch("autopush.metrics.markus")
-    def test_basic(self, mock_tag):
-        m = TaggedMetrics(namespace="testpush", hostname="localhost")
-        assert len(mock_tag.mock_calls) > 0
+class TwistedMetricsTestCase(unittest.TestCase):
+    @patch("autopush.metrics.reactor")
+    def test_basic(self, mock_reactor):
+        twisted.internet.base.DelayedCall.debug = True
+        m = TwistedMetrics('127.0.0.1')
+        m.start()
+        assert len(mock_reactor.mock_calls) > 0
+        m._metric = Mock()
+        m.increment("test", 5)
+        m._metric.increment.assert_called_with("test", 5)
+        m.gauge("connection_count", 200)
+        m._metric.gauge.assert_called_with("connection_count", 200)
+        m.timing("lifespan", 113)
+        m._metric.timing.assert_called_with("lifespan", 113)
+
+
+class DatadogMetricsTestCase(unittest.TestCase):
+    @patch("autopush.metrics.datadog")
+    def test_basic(self, mock_dog):
+        hostname = "localhost"
+
+        m = DatadogMetrics("someapikey", "someappkey", namespace="testpush",
+                           hostname="localhost")
+        assert len(mock_dog.mock_calls) > 0
         m._client = Mock()
         m.start()
-        yield m.increment("test", 5)
-        # Namespace is now auto-prefixed by the underlying markus lib
-        m._client.increment.assert_called_with(
-            "test", 5, tags=['host:localhost'])
+        m._client.start.assert_called_with(flush_interval=10,
+                                           roll_up_interval=10)
+        m.increment("test", 5)
+        m._client.increment.assert_called_with("testpush.test", 5,
+                                               host=hostname)
         m.gauge("connection_count", 200)
-        m._client.gauge.assert_called_with("connection_count", 200,
-                                           tags=['host:localhost'])
+        m._client.gauge.assert_called_with("testpush.connection_count", 200,
+                                           host=hostname)
         m.timing("lifespan", 113)
-        m._client.timing.assert_called_with("lifespan", value=113,
-                                            tags=['host:localhost'])
+        m._client.timing.assert_called_with("testpush.lifespan", value=113,
+                                            host=hostname)
 
 
 class PeriodicReporterTestCase(unittest.TestCase):

--- a/autopush/tests/test_metrics.py
+++ b/autopush/tests/test_metrics.py
@@ -49,6 +49,19 @@ class TwistedMetricsTestCase(unittest.TestCase):
         m.timing("lifespan", 113)
         m._metric.timing.assert_called_with("lifespan", 113)
 
+    @patch("autopush.metrics.reactor")
+    def test_tags(self, mock_reactor):
+        twisted.internet.base.DelayedCall.debug = True
+        m = TwistedMetrics('127.0.0.1')
+        m.start()
+        assert len(mock_reactor.mock_calls) > 0
+        m._metric = Mock()
+        m.increment("test", 5, tags=["foo:bar"])
+        m._metric.increment.assert_called_with("test", 5, tags=["foo:bar"])
+        m.gauge("connection_count", 200, tags=["foo:bar", "baz:quux"])
+        m._metric.gauge.assert_called_with("connection_count", 200,
+                                           tags=["foo:bar", "baz:quux"])
+
 
 class DatadogMetricsTestCase(unittest.TestCase):
     @patch("autopush.metrics.datadog")

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ service-identity
 simplejson
 treq
 twisted
--e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
+-e git+https://github.com/mozilla-services/txstatsd.git@b744ccc6d5e299c5dd2de2568b0e61ed6e3e89aa#egg=txStatsD-master
 typing
 ua-parser
 wsaccel ; platform_python_implementation == "CPython"

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,6 @@ firebase-admin
 hyper
 marshmallow
 marshmallow-polyfield
-markus
 oauth2client
 objgraph
 pyasn1
@@ -26,6 +25,7 @@ service-identity
 simplejson
 treq
 twisted
+-e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 typing
 ua-parser
 wsaccel ; platform_python_implementation == "CPython"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
 apns==2.0.1
 attrs==19.3.0
 autobahn[twisted]==19.11.2
@@ -45,7 +46,6 @@ idna==2.8                 # via hyperlink, requests, twisted
 incremental==17.5.0       # via treq, twisted
 ipaddress==1.0.23         # via cryptography, service-identity
 jmespath==0.9.4           # via boto3, botocore
-markus==2.2.0
 marshmallow-polyfield==4.2
 marshmallow==2.19.5
 msgpack==0.6.2            # via cachecontrol

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/habnabit/txstatsd.git@157ef85fbdeafe23865c7c4e176237ffcb3c3f1f#egg=txStatsD-master
+-e git+https://github.com/mozilla-services/txstatsd.git@b744ccc6d5e299c5dd2de2568b0e61ed6e3e89aa#egg=txStatsD-master
 apns==2.0.1
 attrs==19.3.0
 autobahn[twisted]==19.11.2


### PR DESCRIPTION
## Description

Brings back TwistedMetrics backed by our custom txstatsd w/ tags support

## Testing

Metrics emitted during runtime, e.g. `nc -l -u 8125`

## Issue(s)

Closes #1413
