### PR TITLE
feat: add metric for all mobile bridge "unregistered" user drops

### DIFF
--- a/autopush/router/adm.py
+++ b/autopush/router/adm.py
@@ -191,7 +191,7 @@ class ADMRouter(object):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(
                                        self._base_tags,
-                                       reason="connection_unavailable"))
+                                       reason="connection unavailable"))
             raise RouterException("Server error", status_code=502,
                                   errno=902,
                                   log_exception=False)

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -164,13 +164,6 @@ class APNSRouter(object):
             else:
                 reason = "unknown"
             if isinstance(e, RouterException) and e.status_code in [404, 410]:
-                self.metrics.increment(
-                    "notification.bridge.connection.error",
-                    tags=make_tags(
-                        self._base_tags,
-                        application=rel_channel,
-                        reason="unregistered"
-                        ))
                 raise RouterException(
                     str(e),
                     status_code=e.status_code,
@@ -178,7 +171,7 @@ class APNSRouter(object):
                     response_body="User is no longer registered",
                     log_exception=False
                 )
-            self.metrics.increment("notification.bridge.connection.error",
+            self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(self._base_tags,
                                                   application=rel_channel,
                                                   reason=reason))

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -2480,7 +2480,7 @@ class TestAPNSBridgeIntegration(IntegrationBase):
     def test_send_410(self):
         self._add_router()
         mock_metrics = Mock()
-        self.ep.db.metrics=mock_metrics
+        self.ep.db.metrics = mock_metrics
         # get the senderid
         url = "{}/v1/{}/{}/registration".format(
             self.ep.conf.endpoint_url,

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -2477,8 +2477,10 @@ class TestAPNSBridgeIntegration(IntegrationBase):
         assert ca_data['body'] == base64url_encode(data)
 
     @inlineCallbacks
-    def test_aaa_send_410(self):
+    def test_send_410(self):
         self._add_router()
+        mock_metrics = Mock()
+        self.ep.db.metrics=mock_metrics
         # get the senderid
         url = "{}/v1/{}/{}/registration".format(
             self.ep.conf.endpoint_url,
@@ -2515,6 +2517,8 @@ class TestAPNSBridgeIntegration(IntegrationBase):
             body=data
         )
         assert response.code == 410
+        assert mock_metrics.increment.call_args[1]['tags'] == \
+            ['code:410', 'router:apns', 'vapid:True']
         self.assertRaises(
             ItemNotFound,
             self.ep.db.router.get_uaid,

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -265,7 +265,7 @@ class APNSRouterTestCase(unittest.TestCase):
             'User is no longer registered')
 
     @inlineCallbacks
-    def test_aaaa_fail_send(self):
+    def test_fail_send(self):
         def throw(*args, **kwargs):
             raise HTTP20Error("oops")
 
@@ -279,7 +279,7 @@ class APNSRouterTestCase(unittest.TestCase):
                                          'processing request'
         assert self.metrics.increment.called
         assert self.metrics.increment.call_args[0][0] == \
-            'notification.bridge.connection.error'
+            'notification.bridge.error'
         self.flushLoggedErrors()
 
     @inlineCallbacks
@@ -300,7 +300,7 @@ class APNSRouterTestCase(unittest.TestCase):
                                          'processing request'
         assert self.metrics.increment.called
         assert self.metrics.increment.call_args[0][0] == \
-            'notification.bridge.connection.error'
+            'notification.bridge.error'
         self.flushLoggedErrors()
 
     def test_too_many_connections(self):

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -335,13 +335,13 @@ class BaseWebHandler(BaseHandler):
         # reporting a not found and they're mobile.
         if exc.status_code in [404, 410] and router_type in [
                 'apns', 'fcm', 'adm']:
-            tags = self._base_tags.update({
+            self._base_tags.update({
                 "platform": router_type,
                 "reason": "unregistered",
             })
             self.metrics.increment(
                     "notification.bridge.error",
-                    tags=tags)
+                    tags=self._base_tags)
 
             self.db.router.drop_user(uaid)
         self._router_response(exc, router_type, vapid)

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -335,6 +335,14 @@ class BaseWebHandler(BaseHandler):
         # reporting a not found and they're mobile.
         if exc.status_code in [404, 410] and router_type in [
                 'apns', 'fcm', 'adm']:
+            tags = self._base_tags.update({
+                "platform": router_type,
+                "reason": "unregistered",
+            })
+            self.metrics.increment(
+                    "notification.bridge.error",
+                    tags=tags)
+
             self.db.router.drop_user(uaid)
         self._router_response(exc, router_type, vapid)
 


### PR DESCRIPTION
* normalized metric name and tags

Closes #1421

## Description
* made the APNS user disconnect metric more generic across all mobile platforms
* normalized some tag information

## Testing

Tests included. 

## Issue(s)

Closes #1421.
