### PR TITLE
bug: report details of an FCM "INVALID_ARGUMENT" error

### DIFF
--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -128,15 +128,16 @@ class APNSRouter(object):
             "ver": notification.version,
         }
         if notification.data:
+            payload["con"] = notification.headers.get(
+                "content-encoding", notification.headers.get("encoding"))
+            if payload["con"] != "aes128gcm":
+                if "encryption" in notification.headers:
+                    payload["enc"] = notification.headers["encryption"]
+                if "crypto_key" in notification.headers:
+                    payload["cryptokey"] = notification.headers["crypto_key"]
+                elif "encryption_key" in notification.headers:
+                    payload["enckey"] = notification.headers["encryption_key"]
             payload["body"] = notification.data
-            payload["con"] = notification.headers["encoding"]
-
-            if "encryption" in notification.headers:
-                payload["enc"] = notification.headers["encryption"]
-            if "crypto_key" in notification.headers:
-                payload["cryptokey"] = notification.headers["crypto_key"]
-            elif "encryption_key" in notification.headers:
-                payload["enckey"] = notification.headers["encryption_key"]
             payload['aps'] = router_data.get('aps', {
                 "mutable-content": 1,
                 "alert": {

--- a/autopush/router/fcmv1client.py
+++ b/autopush/router/fcmv1client.py
@@ -63,8 +63,11 @@ class Result(object):
                 err = data.get("error")
                 if err.get("status") == "NOT_FOUND":
                     raise FCMNotFoundError("FCM recipient no longer available")
-                raise RouterException("{}: {}".format(err.get("status"),
-                                                      err.get("message")))
+                raise RouterException(
+                    "{}: {} {}".format(
+                    err.get("status"),
+                    err.get("message"),
+                    err.get("details", "No Details")))
             if "name" in data:
                 self.success = 1
         except (TypeError, ValueError, KeyError, AttributeError):

--- a/autopush/router/fcmv1client.py
+++ b/autopush/router/fcmv1client.py
@@ -65,9 +65,9 @@ class Result(object):
                     raise FCMNotFoundError("FCM recipient no longer available")
                 raise RouterException(
                     "{}: {} {}".format(
-                    err.get("status"),
-                    err.get("message"),
-                    err.get("details", "No Details")))
+                        err.get("status"),
+                        err.get("message"),
+                        err.get("details", "No Details")))
             if "name" in data:
                 self.success = 1
         except (TypeError, ValueError, KeyError, AttributeError):

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -761,7 +761,7 @@ class FCMv1RouterTestCase(unittest.TestCase):
             hostname="localhost",
             statsd_host=None,
         )
-        self.fcm_config = {'max_data': 32,
+        self.fcm_config = {'max_data': 120,
                            'ttl': 60,
                            'version': 1,
                            'dryrun': False,
@@ -940,10 +940,12 @@ class FCMv1RouterTestCase(unittest.TestCase):
         bad_notif = WebPushNotification(
             uaid=uuid.UUID(dummy_uaid),
             channel_id=uuid.UUID(dummy_chid),
-            data="\x01abcdefghijklmnopqrstuvwxyz0123456789",
+            data="\x01" + "a" * 120,
             headers=self.headers,
             ttl=200
         )
+        # fix up headers since we're calling route directly.
+        bad_notif.cleanup_headers()
         self._set_content()
 
         with pytest.raises(RouterException) as ex:


### PR DESCRIPTION
Issue #1373

## Description

This is a really quick patch to try and capture the relevant details returned from FCM when it returns an INVALID_ARGUMENT error. I had thought it was related to the TTL, but we already trim it down to an appropriate max value. 

## Testing

Honestly, if I could figure out how to trigger this in dev, I'd be thrilled. As it is, to test this you'll need a valid FCM routing number, which means compiling an emulated FCM client app (the sample one works fine) which means updating Android Studio to 5, and fetching the latest updates, before altering the code paths and java code to match the FCM project you declared so that the downloaded google-services.json file tied to the sample app you declared in FCM match then use a combination of registration and send scripts to try to trigger an INVALID_ARGUMENT error that gets dumped out to sentry.

All for a patch to see what's going on, and not the real fix.

## Issue(s)

Issue #1373 
