### PR TITLE
fix: Avoid installing dependencies as editable

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ service-identity
 simplejson
 treq
 twisted
--e git+https://github.com/mozilla-services/txstatsd.git@b744ccc6d5e299c5dd2de2568b0e61ed6e3e89aa#egg=txStatsD-master
+git+https://github.com/mozilla-services/txstatsd.git@b744ccc6d5e299c5dd2de2568b0e61ed6e3e89aa#egg=txstatsd
 typing
 ua-parser
 wsaccel ; platform_python_implementation == "CPython"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/mozilla-services/txstatsd.git@b744ccc6d5e299c5dd2de2568b0e61ed6e3e89aa#egg=txStatsD-master
+git+https://github.com/mozilla-services/txstatsd.git@b744ccc6d5e299c5dd2de2568b0e61ed6e3e89aa#egg=txstatsd
 apns==2.0.1
 attrs==19.3.0
 autobahn[twisted]==19.11.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ factory_boy==2.8.1
 flake8==3.7.6
 funcsigs==1.0.2
 mock>=1.0.1
--e git+https://github.com/bbangert/moto.git@3bdb75a961148ea5aa526f0e88d9e7835a30df3a#egg=moto
+git+https://github.com/bbangert/moto.git@3bdb75a961148ea5aa526f0e88d9e7835a30df3a#egg=moto
 nose
 pbr==1.10.0
 # locked for python2 eol


### PR DESCRIPTION
## Description

Editable dependencies may be installed in ./src, such as when running on CI without a virtual env. This breaks py.test because the dependency tests are also considered (which may have unknown dependencies). This issue was seen on autopush-rs when moving the tests to CircleCI.

Also, the txstatsd dependency was using an incorrect egg name, which caused a warning during install.

## Testing

CI passes

## Issue(s)

N/A
