### PR TITLE
bug: return 201 for all push subscription requests.

### DIFF
--- a/autopush/router/webpush.py
+++ b/autopush/router/webpush.py
@@ -167,10 +167,14 @@ class WebPushRouter(object):
                                notification.data_length,
                                tags=make_tags(destination='Stored'))
         location = "%s/m/%s" % (self.conf.endpoint_url, notification.location)
-        return RouterResponse(status_code=202, response_body="",
+        # RFC https://tools.ietf.org/html/rfc8030#section-5
+        # all responses should be 201, unless this is a push reciept request,
+        # which requires a 202 and a URL that can be checked later for UA
+        # acknowledgement. (We don't support that yet. See autopush-rs#244)
+        return RouterResponse(status_code=201, response_body="",
                               headers={"Location": location,
                                        "TTL": notification.ttl},
-                              logged_status=202)
+                              logged_status=201)
 
     #############################################################
     #                    Blocking Helper Functions

--- a/autopush/tests/test_integration.py
+++ b/autopush/tests/test_integration.py
@@ -229,7 +229,8 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
             headers["Topic"] = topic
         body = data or ""
         method = "POST"
-        status = status or (201 if self.ws and self.ws.connected else 202)
+        # 202 status reserved for yet to be implemented push w/ reciept.
+        status = status or 201
 
         log.debug("%s body: %s", method, body)
         http.request(method, url.path.encode("utf-8"), body, headers)
@@ -246,7 +247,7 @@ keyid="http://example.org/bob/keys/123";salt="XZwpw6o37R-6qoZjw6KwAw=="\
         if status == 201 and ttl is not None:
             ttl_header = resp.getheader("TTL")
             assert ttl_header == str(ttl)
-        if ttl != 0 and status == 202:
+        if ttl != 0 and status == 201:
             assert location is not None
             if channel in self.messages:
                 self.messages[channel].append(location)
@@ -535,7 +536,7 @@ class Test_Data(IntegrationBase):
                           'current_month': self.ep.db.current_msg_month})
         safe = db.Message.all_channels
         db.Message.all_channels = Mock(return_value=(True, client.channels))
-        yield client.send_notification(status=202)
+        yield client.send_notification(status=201)
         db.Message.all_channels = safe
         yield self.shut_down(client)
 
@@ -601,7 +602,7 @@ class Test_Data(IntegrationBase):
             return_value=False)
         yield client.send_notification(channel=chan,
                                        data=test["data"],
-                                       status=202)
+                                       status=201)
         db.Message.store_message = safe
         yield self.shut_down(client)
 

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -1490,7 +1490,8 @@ class WebPushRouterTestCase(unittest.TestCase):
 
         def verify_deliver(result):
             assert isinstance(result, RouterResponse)
-            assert result.status_code == 202
+            # https://tools.ietf.org/html/rfc8030#section-5
+            assert result.status_code == 201
             kwargs = self.message_mock.store_message.call_args[1]
             assert len(self.metrics.increment.mock_calls) == 3
             t_h = kwargs["notification"].headers
@@ -1585,7 +1586,7 @@ class WebPushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(status):
-            assert status.status_code == 202
+            assert status.status_code == 201
         d.addBoth(verify_deliver)
 
         return d
@@ -1621,7 +1622,7 @@ class WebPushRouterTestCase(unittest.TestCase):
         d = self.router.route_notification(self.notif, router_data)
 
         def verify_deliver(status):
-            assert status.status_code == 202
+            assert status.status_code == 201
         d.addBoth(verify_deliver)
 
         return d
@@ -1648,7 +1649,7 @@ class WebPushRouterTestCase(unittest.TestCase):
 
         def verify_deliver(result):
             assert isinstance(result, RouterResponse)
-            assert result.status_code == 202
+            assert result.status_code == 201
             kwargs = self.message_mock.store_message.call_args[1]
             assert len(self.metrics.increment.mock_calls) == 3
             t_h = kwargs["notification"].headers

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ configargparse==1.0
 configparser==4.0.2       # via datadog
 constantly==15.1.0        # via twisted
 contextlib2==0.6.0.post1  # via raven
-cryptography==2.8
+cryptography==3.2
 cyclone==1.2
 datadog==0.37.1
 decorator==4.4.1          # via datadog


### PR DESCRIPTION
## Description

This version ensures that we return a status code of 201 for all subscription updates. According to https://tools.ietf.org/html/rfc8030#section-5.1 only Push Subscriptions with Receipts should ever return 202, and those are currently not supported by Autopush.

This also includes an update flagged by dependabot.

## Testing

Tests included.  Verification can be done by sending a push message while the recipient device is "offline".

## Issue(s)

Closes #1443.
