### PR TITLE
feat: Add status code and errno to bridge.error metrics

### DIFF
--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -175,7 +175,10 @@ class APNSRouter(object):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(self._base_tags,
                                                   application=rel_channel,
-                                                  reason=reason))
+                                                  reason=reason,
+                                                  error=502,
+                                                  errno=0,
+                                                  ))
             raise RouterException(
                 str(e),
                 status_code=502,

--- a/autopush/router/fcm.py
+++ b/autopush/router/fcm.py
@@ -206,6 +206,8 @@ class FCMRouter(object):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(
                                        self._base_tags,
+                                       error=502,
+                                       errno=0,
                                        reason="connection_unavailable"))
             self.log.warn("Could not connect to FCM server: %s" % e)
             raise RouterException("Server error", status_code=502,
@@ -235,6 +237,8 @@ class FCMRouter(object):
                            old=old_id, new=new_id)
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(self._base_tags,
+                                                  error=502,
+                                                  errno=0,
                                                   reason="reregister"))
             return RouterResponse(status_code=503,
                                   response_body="Please try request again.",
@@ -242,6 +246,8 @@ class FCMRouter(object):
         if reply.get('failure'):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(self._base_tags,
+                                                  error=502,
+                                                  errno=0,
                                                   reason="failure"))
             reason = result.get('error', "Unreported")
             err = self.reasonTable.get(reason)

--- a/autopush/router/fcm_v1.py
+++ b/autopush/router/fcm_v1.py
@@ -124,7 +124,6 @@ class FCMv1Router(FCMRouter):
                     "Final composed message payload too long for recipient: "
                     "{} bytes. Please try a shorter message.".format(
                         payload_size,
-                        4096
                     ),
                     413, errno=104, log_exception=False)
         # registration_ids are the FCM instance tokens (specified during

--- a/autopush/router/fcm_v1.py
+++ b/autopush/router/fcm_v1.py
@@ -161,7 +161,10 @@ class FCMv1Router(FCMRouter):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(
                                        self._base_tags,
-                                       reason="timeout"))
+                                       reason="timeout",
+                                       error=502,
+                                       errno=903,
+                                       ))
             raise RouterException("Server error", status_code=502,
                                   errno=903,
                                   log_exception=False)
@@ -170,7 +173,10 @@ class FCMv1Router(FCMRouter):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(
                                        self._base_tags,
-                                       reason="connection_unavailable"))
+                                       reason="connection_unavailable",
+                                       error=502,
+                                       errno=902,
+                                       ))
             raise RouterException("Server error", status_code=502,
                                   errno=902,
                                   log_exception=False)
@@ -179,7 +185,9 @@ class FCMv1Router(FCMRouter):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(
                                        self._base_tags,
-                                       reason="recipient_gone"
+                                       reason="recipient_gone",
+                                       error=404,
+                                       errno=106,
                                    ))
             raise RouterException("FCM Recipient no longer available",
                                   status_code=404,
@@ -190,7 +198,9 @@ class FCMv1Router(FCMRouter):
             self.metrics.increment("notification.bridge.error",
                                    tags=make_tags(
                                        self._base_tags,
-                                       reason="server_error"))
+                                       reason="server_error",
+                                       error=502,
+                                       errno=0))
         return failure
 
     def _error(self, err, status, **kwargs):

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -1044,8 +1044,10 @@ class FCMv1RouterTestCase(unittest.TestCase):
             assert self.router.metrics.increment.call_args[0][0] == (
                 'notification.bridge.error')
             self.router.metrics.increment.call_args[1]['tags'].sort()
-            assert self.router.metrics.increment.call_args[1]['tags'] == [
-                'platform:fcmv1', 'reason:server_error']
+            assert 'platform:fcmv1' in \
+                self.router.metrics.increment.call_args[1]['tags']
+            assert 'reason:server_error' in \
+                self.router.metrics.increment.call_args[1]['tags']
             assert "INVALID_ARGUMENT" in str(fail.value)
             self._check_error_call(fail.value, 500)
         d.addBoth(check_results)
@@ -1075,8 +1077,10 @@ class FCMv1RouterTestCase(unittest.TestCase):
             assert self.router.metrics.increment.call_args[0][0] == (
                 'notification.bridge.error')
             self.router.metrics.increment.call_args[1]['tags'].sort()
-            assert 'reason:timeout' in self.router.metrics.increment.call_args[1]['tags']
-            assert 'platform:fcmv1' in self.router.metrics.increment.call_args[1]['tags']
+            assert 'reason:timeout' in \
+                self.router.metrics.increment.call_args[1]['tags']
+            assert 'platform:fcmv1' in \
+                self.router.metrics.increment.call_args[1]['tags']
 
         d.addBoth(check_results)
         return d

--- a/autopush/tests/test_router.py
+++ b/autopush/tests/test_router.py
@@ -1075,8 +1075,8 @@ class FCMv1RouterTestCase(unittest.TestCase):
             assert self.router.metrics.increment.call_args[0][0] == (
                 'notification.bridge.error')
             self.router.metrics.increment.call_args[1]['tags'].sort()
-            assert self.router.metrics.increment.call_args[1]['tags'] == [
-                'platform:fcmv1', 'reason:timeout']
+            assert 'reason:timeout' in self.router.metrics.increment.call_args[1]['tags']
+            assert 'platform:fcmv1' in self.router.metrics.increment.call_args[1]['tags']
 
         d.addBoth(check_results)
         return d

--- a/autopush/web/base.py
+++ b/autopush/web/base.py
@@ -341,7 +341,9 @@ class BaseWebHandler(BaseHandler):
             })
             self.metrics.increment(
                     "notification.bridge.error",
-                    tags=self._base_tags)
+                    tags=self._base_tags,
+                    error=exc.status_code,
+                    errno=0)
 
             self.db.router.drop_user(uaid)
         self._router_response(exc, router_type, vapid)


### PR DESCRIPTION
## Description

Adds add'l metric tags to autopush endpoint bridge.errors (pairs to https://github.com/mozilla-services/autopush-rs/pull/291)


## Issue(s)

Closes #1454
