### PR TITLE
feat: add apns error reason to the metric reporting

### DIFF
--- a/autopush/router/apns2.py
+++ b/autopush/router/apns2.py
@@ -154,7 +154,8 @@ class APNSClient(object):
                         status_code=response.status,
                         response_body="APNS could not process "
                                       "your message {}".format(reason),
-                        log_exception=False
+                        log_exception=False,
+                        reason=reason
                     )
                 break
             except (HTTP20Error, IOError):

--- a/autopush/router/apnsrouter.py
+++ b/autopush/router/apnsrouter.py
@@ -163,7 +163,7 @@ class APNSRouter(object):
             elif isinstance(e, (HTTP20Error, socket.error)):
                 reason = "http2_error"
             else:
-                reason = "unknown"
+                reason = e.extra.get("reason", "unknown")
             if isinstance(e, RouterException) and e.status_code in [404, 410]:
                 raise RouterException(
                     str(e),

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose
 enum34==1.1.6             # via cryptography, grpcio, h2
 firebase-admin==3.2.1
-futures==3.3.0            # via google-api-core, grpcio, s3transfer
+futures==3.1.1            # via google-api-core, grpcio, s3transfer
 gcm-client==0.1.4
 google-api-core[grpc]==1.16.0  # via firebase-admin, google-cloud-core, google-cloud-firestore
 google-api-python-client==1.7.11  # via firebase-admin


### PR DESCRIPTION
Closes #1457

## Description
Add the APNS error reason to the `notification.bridge.error` tags. This is a work around to expose the APNS error so that we can determine failure causes for APNS.

## Issue(s)

Closes #1457
